### PR TITLE
fix make test-dependencies by only perform 'mv' if kubebuilder doesn't exist already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test:
 
 test-dependencies:
 	curl -L https://go.kubebuilder.io/dl/$(KBVERSION)/$(GOOS)/$(GOARCH) | tar -xz -C /tmp/
-	sudo mv /tmp/kubebuilder_$(KBVERSION)_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
+	sudo mv -n /tmp/kubebuilder_$(KBVERSION)_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
 
 ############################################################
 # build section


### PR DESCRIPTION
Addresses https://github.com/open-cluster-management-io/community/issues/58

Signed-off-by: Mike Ng <ming@redhat.com>

