### PR TITLE
Update to `latest` tag for images

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -35,4 +35,4 @@ jobs:
       - name: push
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push quay.io/open-cluster-management/config-policy-controller:edge
+          docker push quay.io/open-cluster-management/config-policy-controller:latest

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
 IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 REGISTRY ?= quay.io/open-cluster-management
-TAG ?= edge
+TAG ?= latest
 
 # Github host to use for checking the source tree;
 # Override this variable ue with your own value if you're working on forked repo.

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: config-policy-controller
       containers:
-        - image: quay.io/open-cluster-management/config-policy-controller:edge
+        - image: quay.io/open-cluster-management/config-policy-controller:latest
           name: config-policy-controller
           command:
           - config-policy-controller

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: config-policy-controller
-        image: quay.io/open-cluster-management/config-policy-controller:edge
+        image: quay.io/open-cluster-management/config-policy-controller:latest
         imagePullPolicy: Always
         name: config-policy-controller
       serviceAccountName: config-policy-controller


### PR DESCRIPTION
Originally `edge` was to distinguish from midstream, but this is no
longer necessary.
