### PR TITLE
Evaluate policies concurrently

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -178,7 +178,7 @@ func (r *ConfigurationPolicyReconciler) PeriodicallyExecConfigPolicies(freq uint
 		if float64(freq) > float64(elapsed) {
 			remainingSleep := float64(freq) - float64(elapsed)
 			sleepTime := time.Duration(remainingSleep) * time.Second
-			log.V(2).Info("Sleeping before reprocessing the configuration polices", "seconds", sleepTime)
+			log.V(2).Info("Sleeping before reprocessing the configuration policies", "seconds", sleepTime)
 			time.Sleep(sleepTime)
 		}
 

--- a/main.go
+++ b/main.go
@@ -69,7 +69,8 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	var clusterName, hubConfigPath, probeAddr string
-	var frequency, decryptionConcurrency uint
+	var frequency uint
+	var decryptionConcurrency uint8
 	var enableLease, enableLeaderElection, legacyLeaderElection bool
 
 	pflag.UintVar(&frequency, "update-frequency", 10,
@@ -85,7 +86,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	pflag.BoolVar(&legacyLeaderElection, "legacy-leader-elect", false,
 		"Use a legacy leader election method for controller manager instead of the lease API.")
-	pflag.UintVar(
+	pflag.Uint8Var(
 		&decryptionConcurrency,
 		"decryption-concurrency",
 		5,
@@ -195,7 +196,7 @@ func main() {
 
 	reconciler := controllers.ConfigurationPolicyReconciler{
 		Client:                mgr.GetClient(),
-		DecryptionConcurrency: uint8(decryptionConcurrency),
+		DecryptionConcurrency: decryptionConcurrency,
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.ControllerName),
 	}


### PR DESCRIPTION
This adds concurrency to evaluating configuration policies. This
defaults to two Go routines to provide a performance increase while not
overwhelming the Kubernetes API in resource constrained deployments.
Additionally, it means that the E2E tests will be testing the
concurrency on every test, which is desired.

The number of Go routines can be configured with the
`--evaluation-concurrency` flag.

Relates:
https://github.com/stolostron/backlog/issues/23546