### PR TITLE
add additional kind tests for policy obj pruning

### DIFF
--- a/test/resources/case20_delete_objects/case20_change_enforce.yaml
+++ b/test/resources/case20_delete_objects/case20_change_enforce.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-change-remediation
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  pruneObjectBehavior: DeleteAll
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e20
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80

--- a/test/resources/case20_delete_objects/case20_change_inform.yaml
+++ b/test/resources/case20_delete_objects/case20_change_inform.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-change-remediation
+spec:
+  remediationAction: inform
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  pruneObjectBehavior: DeleteAll
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e20
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Adds extra kind tests for policy object pruning, I don't have an issue for this but it relates to https://github.com/stolostron/backlog/issues/22967