### PR TITLE
Fix: update UID when recreating an object

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -917,14 +917,17 @@ func sortRelatedObjectsAndUpdate(
 
 	update := false
 
-	// don't set creation info if it has already been set
 	for i, newEntry := range related {
 		for _, oldEntry := range oldRelated {
-			if oldEntry.Object.Kind == newEntry.Object.Kind &&
-				oldEntry.Object.Metadata.Name == newEntry.Object.Metadata.Name &&
-				oldEntry.Object.Metadata.Namespace == newEntry.Object.Metadata.Namespace &&
-				oldEntry.Properties != nil {
-				related[i].Properties = oldEntry.Properties
+			// Get matching objects
+			if gocmp.Equal(newEntry.Object, oldEntry.Object) {
+				if oldEntry.Properties != nil &&
+					newEntry.Properties != nil &&
+					newEntry.Properties.CreatedByPolicy != nil &&
+					!(*newEntry.Properties.CreatedByPolicy) {
+					// Use the old properties if they existed and this is not a newly created resource
+					related[i].Properties = oldEntry.Properties
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When an object was re-created by the policy after being deleted, the
UID in the object's properties was not updated. Then, the logic for
DeleteIfCreated pruning would see the UID as stale and not remove the
object, even though it *was* created by the policy.

Refs:
 - https://github.com/stolostron/backlog/issues/24677

Co-authored-by: Will Kutler <wkutler@redhat.com>
Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>