### PR TITLE
Update named objects in arrays instead of appending

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1892,11 +1892,14 @@ func mergeArrays(newArr []interface{}, old []interface{}, ctype string) (result 
 
 	// create a set with a key for each unique item in the list
 	oldItemSet := map[string]map[string]interface{}{}
+
 	for _, val2 := range old {
-		if entry, ok := oldItemSet[fmt.Sprint(val2)]; ok {
-			oldItemSet[fmt.Sprint(val2)]["count"] = entry["count"].(int) + 1
+		key := fmt.Sprint(val2)
+
+		if entry, ok := oldItemSet[key]; ok {
+			oldItemSet[key]["count"] = entry["count"].(int) + 1
 		} else {
-			oldItemSet[fmt.Sprint(val2)] = map[string]interface{}{
+			oldItemSet[key] = map[string]interface{}{
 				"count": 1,
 				"value": val2,
 			}

--- a/test/e2e/case22_pod_update_image_test.go
+++ b/test/e2e/case22_pod_update_image_test.go
@@ -1,0 +1,74 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+var _ = Describe("Test that an array can be updated when using named objects", Ordered, func() {
+	const (
+		podName    = "pod-case22"
+		policyName = "case22-pod-create"
+		policyYAML = "../resources/case22_pod_update_image/policy.yaml"
+	)
+
+	It("Verifies an image on a pod container can be updated (RHBZ#2117728)", func() {
+		By("Creating the " + podName + " pod")
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "nginx",
+						// The policy is going to apply 1.7.8
+						Image: "nginx:1.7.9",
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := clientManaged.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+
+		By("Creating the " + policyName + " policy")
+		utils.Kubectl("apply", "-f", policyYAML, "-n", testNamespace)
+
+		By("Verifying that the " + policyName + " policy is compliant")
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, policyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Verifying the pod's image was updated")
+		pod, err = clientManaged.CoreV1().Pods("default").Get(context.TODO(), podName, metav1.GetOptions{})
+		Expect(err).To(BeNil())
+		Expect(pod.Spec.Containers).To(HaveLen(1))
+		Expect(pod.Spec.Containers[0].Image).To(Equal("nginx:1.7.8"))
+	})
+
+	AfterAll(func() {
+		deleteConfigPolicies([]string{policyName})
+		err := clientManaged.CoreV1().Pods("default").Delete(context.TODO(), podName, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+	})
+})

--- a/test/resources/case22_pod_update_image/policy.yaml
+++ b/test/resources/case22_pod_update_image/policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case22-pod-create
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: pod-case22
+          namespace: default
+        spec:
+          containers:
+            - image: nginx:1.7.8
+              name: nginx
+              ports:
+                - containerPort: 80


### PR DESCRIPTION
In the case of a Deployment object's container array, if a policy
updates the image of a container, the container should be updated.

Before this commit, a new container with the same name would be
erroneously appended to the containers array and cause the Kubernetes
API update request to fail and make the policy non-compliant.

This assumption is safe due to the Kubernetes API conventions:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#lists-of-named-subobjects-preferred-over-maps

The first commit in the PR is a micro performance improvement.

Relates:
https://github.com/stolostron/backlog/issues/25061
https://bugzilla.redhat.com/show_bug.cgi?id=2117728