### PR TITLE
fix logic in sortRelatedObjectsAndUpdate

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -932,6 +932,23 @@ func sortRelatedObjectsAndUpdate(
 		}
 	}
 
+	// add RelatedObject into newRelated which is in oldRelated but not in newRelated
+	for _, oldEntry := range oldRelated {
+		ifAppend := true
+
+		if oldEntry.Properties != nil && (*oldEntry.Properties.CreatedByPolicy) {
+			for _, newEntry := range related {
+				if gocmp.Equal(newEntry.Object, oldEntry.Object) {
+					ifAppend = false
+				}
+			}
+
+			if ifAppend {
+				related = append(related, oldEntry)
+			}
+		}
+	}
+
 	if len(oldRelated) == len(related) {
 		for i, entry := range oldRelated {
 			if !gocmp.Equal(entry, related[i]) {


### PR DESCRIPTION
Signed-off-by: Chunxi Luo chuluo@redhat.com

https://github.com/stolostron/backlog/issues/24572

So I found more issues than the original bug, it is not only related to namespace change, but also happens under the same namespace.  

For example, test case A):

1) Create an enforcement policy `create-pod` with enabling pruneObjectBehavior option to create a pod `policy-pod-1` in the specific namespace ( ie `auto-test-1`)

2) The pod `policy-pod-1` is created in the namespaces `auto-test-1`, check `create-pod` YAML and  find `policy-pod-1` under `relatedObjects`

3) edit the policy `create-pod` to change the pod name to `policy-pod-2` but still target the same namespace `auto-test-1`

4) The pod `policy-pod-2` is also created in the namespace `auto-test-1`, then check the pods in the namespaces `auto-test-1`, both pods `policy-pod-1` and `policy-pod-2` exist. 

5) check `create-pod` YAML and only find `policy-pod-2` under `relatedObjects`, `policy-pod-1` disappeared in `relatedObjects`.

6) Delete the policy `create-pod`, the second pod `policy-pod-2` is deleted, but the first pod `policy-pod-1` still be existed in the same namespace `auto-test-1`.

Test case B is described in the original issue:
1) Create an enforcement policy with enabling pruneObjectBehavior option to create a pod in the specific namespace ( ie auto-test-1, auto-test-2)

2) The pod is created in these two namespaces, then edit the policy to change the object namespace as the default namespace

3) The pod is created in the default namespace, then check the pod in the above two namespaces, this pod still be existed.

4) Delete the policy, this pod is deleted from the default namespace, but two previous pod still be existed in `auto-test-1`, `auto-test-2` namespace.

Both Test Cases A) and B) are due to the same reason that in `sortRelatedObjectsAndUpdate`, when the oldEntry is different and not in the new related, we don't append it to the new related.


