### PR TITLE
Evaluate policies on every loop when evaluationInterval isn't set

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -116,11 +116,11 @@ type EvaluationInterval struct {
 
 var ErrIsNever = errors.New("the interval is set to never")
 
-// parseInterval converts the input string to a duration. The default value is 10s. ErrIsNever is returned when the
+// parseInterval converts the input string to a duration. The default value is 0s. ErrIsNever is returned when the
 // string is set to "never".
 func (e EvaluationInterval) parseInterval(interval string) (time.Duration, error) {
 	if interval == "" {
-		return 10 * time.Second, nil
+		return 0, nil
 	}
 
 	if interval == "never" {


### PR DESCRIPTION
This reverts back to the original behavior before evaluationInterval was added.

Before this commit, the default value was 10s, which was supposed to be the equivalent of every loop. In practice, this often ended up being every other loop when there were few policies.