### PR TITLE
Send compliance state events synchronously

### DIFF
--- a/main.go
+++ b/main.go
@@ -239,12 +239,15 @@ func main() {
 		)
 	}
 
+	instanceName, _ := os.Hostname() // on an error, instanceName will be empty, which is ok
+
 	reconciler := controllers.ConfigurationPolicyReconciler{
 		Client:                mgr.GetClient(),
 		DecryptionConcurrency: decryptionConcurrency,
 		EvaluationConcurrency: evaluationConcurrency,
 		Scheme:                mgr.GetScheme(),
 		Recorder:              mgr.GetEventRecorderFor(controllers.ControllerName),
+		InstanceName:          instanceName,
 		TargetK8sClient:       targetK8sClient,
 		TargetK8sConfig:       targetK8sConfig,
 	}


### PR DESCRIPTION
Instead of using the controller-runtime event recorder for compliance events attached to the parent policy, this will create them manually, and should help ensure they are always created. Previously, the event and the configuration policy status would be updated more independently, and it could lead to situations where they disagreed on whether it was compliant or not. Now, the status is not updated unless the event was successfully created, and if either operation can't be made, they will be retried on the next loop.

This also adds some additional information that is not included in events from the controller-runtime recorder.

Refs:
 - https://github.com/stolostron/backlog/issues/26066

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>