### PR TITLE
Allow enforcing policies that define a status with missing required fields

### DIFF
--- a/test/e2e/case20_delete_objects_test.go
+++ b/test/e2e/case20_delete_objects_test.go
@@ -4,10 +4,12 @@
 package e2e
 
 import (
+	"context"
 	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"open-cluster-management.io/config-policy-controller/test/utils"
@@ -361,7 +363,11 @@ var _ = Describe("Test objects that should be deleted are actually being deleted
 		})
 		It("should hang on unfinished child object delete", func() {
 			// delete policy, should delete pod
-			deleteConfigPolicies([]string{case20ConfigPolicyNameFinalizer})
+			err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Delete(
+				context.TODO(), case20ConfigPolicyNameFinalizer, metav1.DeleteOptions{},
+			)
+			Expect(err).To(BeNil())
+
 			Consistently(func() interface{} {
 				pod := utils.GetWithTimeout(clientManagedDynamic, gvrPod,
 					case20PodWithFinalizer, "default", true, defaultTimeoutSeconds)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
 var (
@@ -189,5 +191,11 @@ func deleteConfigPolicies(policyNames []string) {
 		if !errors.IsNotFound(err) {
 			Expect(err).To(BeNil())
 		}
+	}
+
+	for _, policyName := range policyNames {
+		_ = utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, policyName, testNamespace, false, defaultTimeoutSeconds,
+		)
 	}
 }

--- a/test/resources/case23_invalid_field/policy-ignore-status-field.yaml
+++ b/test/resources/case23_invalid_field/policy-ignore-status-field.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case23-pod-missing-status-fields
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-case23-missing-status
+          namespace: default
+        spec:
+          containers:
+            - name: nginx
+              image: nginx:1.7.9
+              ports:
+                - containerPort: 80
+        status:
+          conditions:
+            - status: "True"


### PR DESCRIPTION
The status in the objectDefinition is ignored when in enforced mode. This allows a user to switch a policy between inform and enforce without having to remove the status check.

Note that the additional commit is to fix the case 20 test which was blocking the CI from passing.

Relates:
https://github.com/stolostron/backlog/issues/26155 https://bugzilla.redhat.com/show_bug.cgi?id=2132396