### PR TITLE
potential role merge issue fix

### DIFF
--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -2,8 +2,8 @@
 // Copyright Contributors to the Open Cluster Management project
 
 // Package v1 contains API Schema definitions for the policy v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=policy.open-cluster-management.io
+// +kubebuilder:object:generate=true
+// +groupName=policy.open-cluster-management.io
 package v1
 
 import (

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -137,7 +137,7 @@ type cachedEncryptionKey struct {
 	previousKey []byte
 }
 
-//nolint: structcheck
+// nolint: structcheck
 type discoveryInfo struct {
 	apiResourceList        []*metav1.APIResourceList
 	apiGroups              []*restmapper.APIGroupResources
@@ -414,7 +414,8 @@ type objectTemplateDetails struct {
 // getObjectTemplateDetails retrieves values from the object templates and returns an array of
 // objects containing the retrieved values.
 // It also gathers namespaces for this policy if necessary:
-//   If a namespaceSelector is present AND objects are namespaced without a namespace specified
+//
+//	If a namespaceSelector is present AND objects are namespaced without a namespace specified
 func (r *ConfigurationPolicyReconciler) getObjectTemplateDetails(
 	plc policyv1.ConfigurationPolicy,
 ) ([]objectTemplateDetails, []string, bool, error) {

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2079,7 +2079,8 @@ func mergeArrays(newArr []interface{}, old []interface{}, ctype string, mergeSub
 // compareLists is a wrapper function that creates a merged list for musthave
 // and returns the template list for mustonlyhave
 func compareLists(newList []interface{}, oldList []interface{}, ctype string,
-	mergeSubLists bool) (updatedList []interface{}, err error) {
+	mergeSubLists bool,
+) (updatedList []interface{}, err error) {
 	if ctype != "mustonlyhave" {
 		return mergeArrays(newList, oldList, ctype, mergeSubLists), nil
 	}

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2077,7 +2077,8 @@ func mergeArrays(newArr []interface{}, old []interface{}, ctype string, mergeSub
 
 // compareLists is a wrapper function that creates a merged list for musthave
 // and returns the template list for mustonlyhave
-func compareLists(newList []interface{}, oldList []interface{}, ctype string, mergeSubLists bool) (updatedList []interface{}, err error) {
+func compareLists(newList []interface{}, oldList []interface{}, ctype string,
+	mergeSubLists bool) (updatedList []interface{}, err error) {
 	if ctype != "mustonlyhave" {
 		return mergeArrays(newList, oldList, ctype, mergeSubLists), nil
 	}

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1958,9 +1958,9 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string, mergeS
 			// object to do a proper compare
 			if mergeSubLists {
 				return mergeArrays(templateVal, existingVal, ctype, mergeSubLists)
-			} else {
-				return templateVal
 			}
+
+			return templateVal
 		}
 	case nil:
 		// if template value is nil, pull data from existing, since the template does not care about it

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2188,6 +2188,13 @@ func handleSingleKey(
 	// sort objects before checking equality to ensure they're in the same order
 	if !equalObjWithSort(mergedValue, existingValue) {
 		updateNeeded = true
+		fmt.Println(mergedValue)
+		fmt.Println(existingValue)
+		fmt.Println("MISMATCH FOUND!")
+	} else {
+		fmt.Println(mergedValue)
+		fmt.Println(existingValue)
+		fmt.Println("MATCH FOUND!!!!! :)")
 	}
 
 	return "", updateNeeded, mergedValue, false

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -100,7 +100,11 @@ var compareObjSecondsCounter = prometheus.NewCounterVec(
 		Help: "The total seconds taken while comparing policy objects. Use this alongside " +
 			"compare_objects_evaluation_total.",
 	},
+<<<<<<< HEAD
 	[]string{"config_policy_name", "namespace", "object"},
+=======
+	[]string{"config_policy_name", "object"},
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 )
 
 var compareObjEvalCounter = prometheus.NewCounterVec(
@@ -109,7 +113,11 @@ var compareObjEvalCounter = prometheus.NewCounterVec(
 		Help: "The total number of times the comparison algorithm is run on an object. " +
 			"Use this alongside compare_objects_seconds_total.",
 	},
+<<<<<<< HEAD
 	[]string{"config_policy_name", "namespace", "object"},
+=======
+	[]string{"config_policy_name", "object"},
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 )
 
 func init() {
@@ -1425,12 +1433,10 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 		seconds := float64(duration) / float64(time.Second)
 		compareObjSecondsCounter.WithLabelValues(
 			obj.policy.Name,
-			obj.namespace,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Add(seconds)
 		compareObjEvalCounter.WithLabelValues(
 			obj.policy.Name,
-			obj.namespace,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Inc()
 

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -100,7 +100,7 @@ var compareObjSecondsCounter = prometheus.NewCounterVec(
 		Help: "The total seconds taken while comparing policy objects. Use this alongside " +
 			"compare_objects_evaluation_total.",
 	},
-	[]string{"config_policy_name", "object"},
+	[]string{"config_policy_name", "namespace", "object"},
 )
 
 var compareObjEvalCounter = prometheus.NewCounterVec(
@@ -109,7 +109,7 @@ var compareObjEvalCounter = prometheus.NewCounterVec(
 		Help: "The total number of times the comparison algorithm is run on an object. " +
 			"Use this alongside compare_objects_seconds_total.",
 	},
-	[]string{"config_policy_name", "object"},
+	[]string{"config_policy_name", "namespace", "object"},
 )
 
 func init() {

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -100,11 +100,7 @@ var compareObjSecondsCounter = prometheus.NewCounterVec(
 		Help: "The total seconds taken while comparing policy objects. Use this alongside " +
 			"compare_objects_evaluation_total.",
 	},
-<<<<<<< HEAD
-	[]string{"config_policy_name", "namespace", "object"},
-=======
 	[]string{"config_policy_name", "object"},
->>>>>>> 19f845c (add metrics to time the compare algorithm)
 )
 
 var compareObjEvalCounter = prometheus.NewCounterVec(
@@ -113,11 +109,7 @@ var compareObjEvalCounter = prometheus.NewCounterVec(
 		Help: "The total number of times the comparison algorithm is run on an object. " +
 			"Use this alongside compare_objects_seconds_total.",
 	},
-<<<<<<< HEAD
-	[]string{"config_policy_name", "namespace", "object"},
-=======
 	[]string{"config_policy_name", "object"},
->>>>>>> 19f845c (add metrics to time the compare algorithm)
 )
 
 func init() {
@@ -1433,10 +1425,12 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 		seconds := float64(duration) / float64(time.Second)
 		compareObjSecondsCounter.WithLabelValues(
 			obj.policy.Name,
+			obj.namespace,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Add(seconds)
 		compareObjEvalCounter.WithLabelValues(
 			obj.policy.Name,
+			obj.namespace,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Inc()
 

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -89,7 +89,7 @@ func TestCompareSpecs(t *testing.T) {
 		},
 	}
 
-	merged, err := compareSpecs(spec1, spec2, "mustonlyhave")
+	merged, err := compareSpecs(spec1, spec2, "mustonlyhave", true)
 	if err != nil {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
@@ -121,7 +121,7 @@ func TestCompareSpecs(t *testing.T) {
 		},
 	}
 
-	merged, err = compareSpecs(spec1, spec2, "musthave")
+	merged, err = compareSpecs(spec1, spec2, "musthave", true)
 	if err != nil {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
@@ -171,7 +171,7 @@ func TestCompareLists(t *testing.T) {
 		},
 	}
 
-	merged, err := compareLists(rules2, rules1, "musthave")
+	merged, err := compareLists(rules2, rules1, "musthave", true)
 	if err != nil {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
@@ -203,7 +203,7 @@ func TestCompareLists(t *testing.T) {
 
 	assert.Equal(t, reflect.DeepEqual(fmt.Sprint(merged), fmt.Sprint(mergedExpected)), true)
 
-	merged, err = compareLists(rules2, rules1, "mustonlyhave")
+	merged, err = compareLists(rules2, rules1, "mustonlyhave", true)
 	if err != nil {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
@@ -264,10 +264,10 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
-	merged1 := mergeArrays(newList, oldList, "musthave")
+	merged1 := mergeArrays(newList, oldList, "musthave", true)
 	assert.Equal(t, checkListsMatch(oldList, merged1), true)
 
-	merged2 := mergeArrays(newList, oldList, "mustonlyhave")
+	merged2 := mergeArrays(newList, oldList, "mustonlyhave", true)
 	assert.Equal(t, checkListsMatch(newList, merged2), true)
 
 	newList2 := []interface{}{
@@ -295,7 +295,7 @@ func TestMerge(t *testing.T) {
 			"d": "dog",
 		},
 	}
-	merged3 := mergeArrays(newList2, oldList2, "musthave")
+	merged3 := mergeArrays(newList2, oldList2, "musthave", true)
 
 	assert.Equal(t, checkListsMatch(checkList2, merged3), true)
 
@@ -307,7 +307,7 @@ func TestMerge(t *testing.T) {
 			"c": "candy",
 		},
 	}
-	merged4 := mergeArrays(newList3, oldList2, "musthave")
+	merged4 := mergeArrays(newList3, oldList2, "musthave", true)
 
 	assert.Equal(t, checkListsMatch(checkList2, merged4), true)
 }

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -314,7 +314,6 @@ func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 			}
 		}
 	}
-
 	return true
 }
 

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -314,6 +314,7 @@ func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 			}
 		}
 	}
+
 	return true
 }
 


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/26055

The first fix (for developer-a in the BZ) is changing the sort method we use when comparing lists. Previously we sorted lists at the top level first and then sorted any lower-level lists second, but that could cause problems if the sorting of the lower-level lists affected the top-level sort. This PR adds a recursive sort function that will sort the lowest level lists in an object first, which should eliminate this issue. In the future, it might make sense to use this sort function elsewhere in the code if it can make some parts of the code cleaner.

The second fix (for developer-original in the BZ) is adding a new `mergeSubLIsts` bool to the functions in the merge logic. The idea with this variable is that the merge functions are set to attempt to merge any lists into one when the compliance type is set to `musthave`, which can cause issues with a field like `role.rules`, for which we want to treat each sub-list as a complete entity and do not want to merge the lists of apiGroups, resources, or verbs between rules. So we set `mergeSubLists` to false when the key being processed is `rules`, and the merge function will only merge the rules list in the template with the existing rules list, rather than trying to merge the fields inside each rule as well.

The second fix needs some more testing to ensure it doesn't break anything, and it is likely that changing the merge in the controller to use strategic merge would produce cleaner code, but this solution should result in less code being changed. If we decide to use this fix, I'd still like to open an issue to investigate replacing the majority of the merge logic in the controller with strategic merge in 2.7 or a later release - it would make the code easier to maintain and debug than the current implementation.