### PR TITLE
Initialize klog explicitly

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ func init() {
 }
 
 func main() {
+	klog.InitFlags(nil)
+
 	zflags := zaputil.FlagConfig{
 		LevelName:   "log-level",
 		EncoderName: "log-encoder",


### PR DESCRIPTION
Updating go-template-utils causes the klog flags to not be initialized implicitly.

Signed-off-by: mprahl <mprahl@users.noreply.github.com>