### PR TITLE
Update go-template-utils to v3.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.1
-	github.com/stolostron/go-template-utils/v3 v3.0.0
+	github.com/stolostron/go-template-utils/v3 v3.0.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.9
 	k8s.io/apimachinery v0.23.9

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/go-log-utils v0.1.1 h1:T48GyfuGpn2+6817FQVec1CyxGf0ibuVhoBiz9SeCec=
 github.com/stolostron/go-log-utils v0.1.1/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
-github.com/stolostron/go-template-utils/v3 v3.0.0 h1:SxXFxDkHD8GpkkOL3iJXcPwkRdkUZwdwytuFFR8WJHs=
-github.com/stolostron/go-template-utils/v3 v3.0.0/go.mod h1:gtsdI4h90CDp3wQWqaRyhlZg0tPSD0bmVtXpw37BugQ=
+github.com/stolostron/go-template-utils/v3 v3.0.1 h1:E+BcQZubHmHWepXjqcSXUNPmzXoWzCLF3pO26w4NNVQ=
+github.com/stolostron/go-template-utils/v3 v3.0.1/go.mod h1:k9qoQ/OH/jOQI5ovfC11QJ6ApWsa3E5rmbkfUAEUF3g=
 github.com/stolostron/kubernetes-dependency-watches v0.0.0-20221007134235-7551d84cf688 h1:Q/0MspxKFkqBN59keMsJI2hGqGGpTSxdNEvrxTOBlRg=
 github.com/stolostron/kubernetes-dependency-watches v0.0.0-20221007134235-7551d84cf688/go.mod h1:jGnjY4g8N1PaBqt35EjqNRjymjG0DWqki/2JOLMN1Pg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Relates:
https://issues.redhat.com/browse/ACM-1936