### PR TITLE
Add metric to monitor common related objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,8 @@ deploy: generate-operator-yaml
 
 .PHONY: create-ns
 create-ns:
-	@kubectl create namespace $(CONTROLLER_NAMESPACE) || true
-	@kubectl create namespace $(WATCH_NAMESPACE) || true
+	-@kubectl create namespace $(CONTROLLER_NAMESPACE)
+	-@kubectl create namespace $(WATCH_NAMESPACE)
 
 # Run against the current locally configured Kubernetes cluster
 .PHONY: run
@@ -239,7 +239,7 @@ kind-bootstrap-cluster-dev: kind-create-cluster install-crds install-resources
 .PHONY: kind-deploy-controller
 kind-deploy-controller: generate-operator-yaml
 	@echo Installing $(IMG)
-	kubectl create ns $(KIND_NAMESPACE) || true
+	-kubectl create ns $(KIND_NAMESPACE)
 	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE)
 	kubectl patch deployment $(IMG) -n $(KIND_NAMESPACE) -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"$(IMG)\",\"env\":[{\"name\":\"WATCH_NAMESPACE\",\"value\":\"$(WATCH_NAMESPACE)\"}]}]}}}}"
 

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/kubectl/pkg/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
@@ -67,59 +66,6 @@ var (
 	reasonWantNotFoundDNE    = "Resource not found as expected"
 	reasonCleanupError       = "Error cleaning up child objects"
 )
-
-var evalLoopHistogram = prometheus.NewHistogram(
-	prometheus.HistogramOpts{
-		Name:    "config_policies_evaluation_duration_seconds",
-		Help:    "The seconds that it takes to evaluate all configuration policies on the cluster",
-		Buckets: []float64{1, 3, 9, 10.5, 15, 30, 60, 90, 120, 180, 300, 450, 600},
-	},
-)
-
-var policyEvalSecondsCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "config_policy_evaluation_seconds_total",
-		Help: "The total seconds taken while evaluating the configuration policy. Use this alongside " +
-			"config_policy_evaluation_total.",
-	},
-	[]string{"name"},
-)
-
-var policyEvalCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "config_policy_evaluation_total",
-		Help: "The total number of evaluations of the configuration policy. Use this alongside " +
-			"config_policy_evaluation_seconds_total.",
-	},
-	[]string{"name"},
-)
-
-var compareObjSecondsCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "compare_objects_seconds_total",
-		Help: "The total seconds taken while comparing policy objects. Use this alongside " +
-			"compare_objects_evaluation_total.",
-	},
-	[]string{"config_policy_name", "namespace", "object"},
-)
-
-var compareObjEvalCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "compare_objects_evaluation_total",
-		Help: "The total number of times the comparison algorithm is run on an object. " +
-			"Use this alongside compare_objects_seconds_total.",
-	},
-	[]string{"config_policy_name", "namespace", "object"},
-)
-
-func init() {
-	// Register custom metrics with the global Prometheus registry
-	metrics.Registry.MustRegister(evalLoopHistogram)
-	metrics.Registry.MustRegister(policyEvalSecondsCounter)
-	metrics.Registry.MustRegister(policyEvalCounter)
-	metrics.Registry.MustRegister(compareObjSecondsCounter)
-	metrics.Registry.MustRegister(compareObjEvalCounter)
-}
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1005,6 +1005,8 @@ func sortRelatedObjectsAndUpdate(
 					!(*newEntry.Properties.CreatedByPolicy) {
 					// Use the old properties if they existed and this is not a newly created resource
 					related[i].Properties = oldEntry.Properties
+
+					break
 				}
 			}
 		}

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -412,14 +412,14 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 
 	empty := []policyv1.RelatedObject{}
 
-	sortRelatedObjectsAndUpdate(policy, relatedList, empty)
+	sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 
 	// append another object named bar but also with namespace bar
 	relatedList = append(relatedList, addRelatedObjects(true, rsrc, "ConfigurationPolicy", "bar",
 		true, []string{name}, "reason", nil)...)
 
-	sortRelatedObjectsAndUpdate(policy, relatedList, empty)
+	sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
 	assert.True(t, relatedList[0].Object.Metadata.Namespace == "bar")
 
 	// clear related objects and test sorting with no namespace
@@ -430,7 +430,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 	relatedList = append(relatedList, addRelatedObjects(true, rsrc, "ConfigurationPolicy", "",
 		false, []string{name}, "reason", nil)...)
 
-	sortRelatedObjectsAndUpdate(policy, relatedList, empty)
+	sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 }
 

--- a/controllers/metric.go
+++ b/controllers/metric.go
@@ -1,0 +1,60 @@
+package controllers
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	evalLoopHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "config_policies_evaluation_duration_seconds",
+			Help:    "The seconds that it takes to evaluate all configuration policies on the cluster",
+			Buckets: []float64{1, 3, 9, 10.5, 15, 30, 60, 90, 120, 180, 300, 450, 600},
+		},
+	)
+	policyEvalSecondsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "config_policy_evaluation_seconds_total",
+			Help: "The total seconds taken while evaluating the configuration policy. Use this alongside " +
+				"config_policy_evaluation_total.",
+		},
+		[]string{"name"},
+	)
+	policyEvalCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "config_policy_evaluation_total",
+			Help: "The total number of evaluations of the configuration policy. Use this alongside " +
+				"config_policy_evaluation_seconds_total.",
+		},
+		[]string{"name"},
+	)
+	compareObjSecondsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "compare_objects_seconds_total",
+			Help: "The total seconds taken while comparing policy objects. Use this alongside " +
+				"compare_objects_evaluation_total.",
+		},
+		[]string{"config_policy_name", "namespace", "object"},
+	)
+	compareObjEvalCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "compare_objects_evaluation_total",
+			Help: "The total number of times the comparison algorithm is run on an object. " +
+				"Use this alongside compare_objects_seconds_total.",
+		},
+		[]string{"config_policy_name", "namespace", "object"},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global Prometheus registry
+	metrics.Registry.MustRegister(evalLoopHistogram)
+	metrics.Registry.MustRegister(policyEvalSecondsCounter)
+	metrics.Registry.MustRegister(policyEvalCounter)
+	metrics.Registry.MustRegister(compareObjSecondsCounter)
+	metrics.Registry.MustRegister(compareObjEvalCounter)
+	metrics.Registry.MustRegister(policyRelatedObjectGauge)
+}

--- a/controllers/metric.go
+++ b/controllers/metric.go
@@ -2,9 +2,12 @@ package controllers
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 )
 
 var (
@@ -47,6 +50,20 @@ var (
 		},
 		[]string{"config_policy_name", "namespace", "object"},
 	)
+	// The policyRelatedObjectMap collects a map of related objects to policies
+	// in order to populate the gauge:
+	//   <kind.version/namespace/name>: []<policy-namespace/policy-name>
+	policyRelatedObjectMap   sync.Map
+	policyRelatedObjectGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "common_related_objects",
+			Help: "A gauge vector of related objects managed by multiple policies.",
+		},
+		[]string{
+			"relatedObject",
+			"policy",
+		},
+	)
 )
 
 func init() {
@@ -57,4 +74,43 @@ func init() {
 	metrics.Registry.MustRegister(compareObjSecondsCounter)
 	metrics.Registry.MustRegister(compareObjEvalCounter)
 	metrics.Registry.MustRegister(policyRelatedObjectGauge)
+}
+
+// updateRelatedObjectMetric iterates through the collected related object map, deletes any metrics
+// that aren't duplications, and sets a metric for any related object that is handled by multiple
+// policies to the number of policies that currently handles it.
+func updateRelatedObjectMetric() {
+	log.V(3).Info("Updating common_related_objects metric ...")
+
+	policyRelatedObjectMap.Range(func(key any, value any) bool {
+		relatedObj := key.(string)
+		policies := value.([]string)
+
+		for _, policy := range policies {
+			if len(policies) == 1 {
+				policyRelatedObjectGauge.DeleteLabelValues(relatedObj, policy)
+
+				continue
+			}
+
+			gaugeInstance, err := policyRelatedObjectGauge.GetMetricWithLabelValues(relatedObj, policy)
+			if err != nil {
+				log.V(3).Error(err, "Failed to retrieve related object gauge")
+
+				continue
+			}
+
+			gaugeInstance.Set(float64(len(policies)))
+		}
+
+		return true
+	})
+}
+
+// getObjectString returns a string formatted as:
+// <kind>.<version>/<namespace>/<name>
+func getObjectString(obj policyv1.RelatedObject) string {
+	return fmt.Sprintf("%s.%s/%s/%s",
+		obj.Object.Kind, obj.Object.APIVersion,
+		obj.Object.Metadata.Namespace, obj.Object.Metadata.Name)
 }

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 	var clusterName, hubConfigPath, targetKubeConfig, metricsAddr, probeAddr string
 	var frequency uint
 	var decryptionConcurrency, evaluationConcurrency uint8
-	var enableLease, enableLeaderElection, legacyLeaderElection bool
+	var enableLease, enableLeaderElection, legacyLeaderElection, enableMetrics bool
 
 	pflag.UintVar(&frequency, "update-frequency", 10,
 		"The status update frequency (in seconds) of a mutation policy")
@@ -109,6 +109,7 @@ func main() {
 		2,
 		"The max number of concurrent configuration policy evaluations",
 	)
+	pflag.BoolVar(&enableMetrics, "enable-metrics", true, "Disable custom metrics collection")
 
 	pflag.Parse()
 
@@ -252,6 +253,7 @@ func main() {
 		InstanceName:          instanceName,
 		TargetK8sClient:       targetK8sClient,
 		TargetK8sConfig:       targetK8sConfig,
+		EnableMetrics:         enableMetrics,
 	}
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		log.Error(err, "Unable to create controller", "controller", "ConfigurationPolicy")

--- a/test/e2e/case25_related_object_metric_test.go
+++ b/test/e2e/case25_related_object_metric_test.go
@@ -1,0 +1,78 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+var _ = Describe("Test related object metrics", Ordered, func() {
+	const (
+		policy1Name   = "case25-test-policy-1"
+		policy2Name   = "case25-test-policy-2"
+		relatedObject = "case25-configmap"
+		policyYaml    = "../resources/case25_related_object_metric/case25-test-policy.yaml"
+	)
+	It("should create policies and related objects", func() {
+		By("Creating " + policyYaml)
+		utils.Kubectl("apply",
+			"-f", policyYaml,
+			"-n", testNamespace)
+		By("Verifying the policies were created")
+		plc1 := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, policy1Name, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(plc1).NotTo(BeNil())
+		plc2 := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, policy2Name, testNamespace, true, defaultTimeoutSeconds,
+		)
+		By("Verifying the related object was created")
+		Expect(plc2).NotTo(BeNil())
+		obj := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigMap, relatedObject, "default", true, defaultTimeoutSeconds,
+		)
+		Expect(obj).NotTo(BeNil())
+	})
+
+	It("should correctly report common related objects", func() {
+		By("Checking metric endpoint for relate object gauge for policy " + policy1Name)
+		Eventually(func() interface{} {
+			return utils.GetMetrics(
+				"common_related_objects", fmt.Sprintf(`policy=\"%s/%s\"`, testNamespace, policy1Name))
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"2"}))
+		By("Checking metric endpoint for relate object gauge for policy " + policy2Name)
+		Eventually(func() interface{} {
+			return utils.GetMetrics(
+				"common_related_objects", fmt.Sprintf(`policy=\"%s/%s\"`, testNamespace, policy2Name))
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{"2"}))
+	})
+
+	cleanup := func() {
+		// Delete the policies and ignore any errors (in case it was deleted previously)
+		cmd := exec.Command("kubectl", "delete",
+			"-f", policyYaml,
+			"-n", testNamespace)
+		_, _ = cmd.CombinedOutput()
+		opt := metav1.ListOptions{}
+		utils.ListWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, opt, 0, false, defaultTimeoutSeconds)
+		utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigMap, relatedObject, "default", false, defaultTimeoutSeconds)
+	}
+
+	It("should clean up", cleanup)
+
+	It("should have no common related object metrics after clean up", func() {
+		By("Checking metric endpoint for related object gauges")
+		Eventually(func() interface{} {
+			return utils.GetMetrics("common_related_objects")
+		}, defaultTimeoutSeconds, 1).Should(Equal([]string{}))
+	})
+
+	AfterAll(cleanup)
+})

--- a/test/resources/case25_related_object_metric/case25-test-policy.yaml
+++ b/test/resources/case25_related_object_metric/case25-test-policy.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case25-test-policy-1
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case25-configmap
+          namespace: default
+        data:
+          name: testvalue
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case25-test-policy-2
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  namespaceSelector:
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case25-configmap
+        data:
+          name: testvalue


### PR DESCRIPTION
This adds a `common_related_objects` metric, which is a Gauge Vector sliced by the related object and the policy. Each policy and related object pair has a gauge set to the total number of instances of that related object. For example, if two policies point to a related object, there would be two gauges for each policy/related object pair, each set to `2`. Gauges set to `1` are ignored/cleaned up.

ref:
- https://github.com/stolostron/backlog/issues/25357