### PR TITLE
Send compliance events on the hosting cluster

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2520,10 +2520,7 @@ func (r *ConfigurationPolicyReconciler) sendComplianceEvent(instance *policyv1.C
 		event.Type = "Warning"
 	}
 
-	eventClient := r.TargetK8sClient.CoreV1().Events(instance.Namespace)
-	_, err := eventClient.Create(context.TODO(), event, metav1.CreateOptions{})
-
-	return err
+	return r.Create(context.TODO(), event)
 }
 
 // convertPolicyStatusToString to be able to pass the status as event

--- a/test/resources/case21_alternative_kubeconfig/parent-policy.yaml
+++ b/test/resources/case21_alternative_kubeconfig/parent-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: parent-create-ns
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: create-ns
+        spec:
+          remediationAction: enforce
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: e2e-test-ns

--- a/test/resources/case21_alternative_kubeconfig/policy.yaml
+++ b/test/resources/case21_alternative_kubeconfig/policy.yaml
@@ -2,6 +2,11 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: create-ns
+  ownerReferences:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: parent-create-ns
+      uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
 spec:
   remediationAction: enforce
   object-templates:


### PR DESCRIPTION
If the controller was configured with a target cluster that was not the same as the cluster the controller was in, then the compliance events were being created on the wrong cluster. Now they are correctly created on the cluster hosting the controller, which is where the policy framework will be looking for them.

Refs:
 - https://issues.redhat.com/browse/ACM-2249

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>