### PR TITLE
Event on object update

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -107,7 +107,7 @@ var compareObjSecondsCounter = prometheus.NewCounterVec(
 		Help: "The total seconds taken while comparing policy objects. Use this alongside " +
 			"compare_objects_evaluation_total.",
 	},
-	[]string{"config_policy_name", "object"},
+	[]string{"config_policy_name", "namespace", "object"},
 )
 
 var compareObjEvalCounter = prometheus.NewCounterVec(
@@ -116,7 +116,7 @@ var compareObjEvalCounter = prometheus.NewCounterVec(
 		Help: "The total number of times the comparison algorithm is run on an object. " +
 			"Use this alongside compare_objects_seconds_total.",
 	},
-	[]string{"config_policy_name", "object"},
+	[]string{"config_policy_name", "namespace", "object"},
 )
 
 func init() {
@@ -1598,10 +1598,12 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 		seconds := float64(duration) / float64(time.Second)
 		compareObjSecondsCounter.WithLabelValues(
 			obj.policy.Name,
+			obj.namespace,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Add(seconds)
 		compareObjEvalCounter.WithLabelValues(
 			obj.policy.Name,
+			obj.namespace,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Inc()
 

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -73,6 +73,62 @@ var (
 	reasonCleanupError       = "Error cleaning up child objects"
 )
 
+<<<<<<< HEAD
+=======
+var evalLoopHistogram = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Name:    "config_policies_evaluation_duration_seconds",
+		Help:    "The seconds that it takes to evaluate all configuration policies on the cluster",
+		Buckets: []float64{1, 3, 9, 10.5, 15, 30, 60, 90, 120, 180, 300, 450, 600},
+	},
+)
+
+var policyEvalSecondsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "config_policy_evaluation_seconds_total",
+		Help: "The total seconds taken while evaluating the configuration policy. Use this alongside " +
+			"config_policy_evaluation_total.",
+	},
+	[]string{"name"},
+)
+
+var policyEvalCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "config_policy_evaluation_total",
+		Help: "The total number of evaluations of the configuration policy. Use this alongside " +
+			"config_policy_evaluation_seconds_total.",
+	},
+	[]string{"name"},
+)
+
+var compareObjSecondsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "compare_objects_seconds_total",
+		Help: "The total seconds taken while comparing policy objects. Use this alongside " +
+			"compare_objects_evaluation_total.",
+	},
+	[]string{"config_policy_name", "object"},
+)
+
+var compareObjEvalCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "compare_objects_evaluation_total",
+		Help: "The total number of times the comparison algorithm is run on an object. " +
+			"Use this alongside compare_objects_seconds_total.",
+	},
+	[]string{"config_policy_name", "object"},
+)
+
+func init() {
+	// Register custom metrics with the global Prometheus registry
+	metrics.Registry.MustRegister(evalLoopHistogram)
+	metrics.Registry.MustRegister(policyEvalSecondsCounter)
+	metrics.Registry.MustRegister(policyEvalCounter)
+	metrics.Registry.MustRegister(compareObjSecondsCounter)
+	metrics.Registry.MustRegister(compareObjEvalCounter)
+}
+
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 // SetupWithManager sets up the controller with the Manager.
 func (r *ConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -134,6 +190,7 @@ func (r *ConfigurationPolicyReconciler) Reconcile(ctx context.Context, request c
 		// If the metric was not deleted, that means the policy was never evaluated so it can be ignored.
 		_ = policyEvalSecondsCounter.DeleteLabelValues(request.Name)
 		_ = policyEvalCounter.DeleteLabelValues(request.Name)
+<<<<<<< HEAD
 		_ = plcTempsProcessSecondsCounter.DeleteLabelValues(request.Name)
 		_ = plcTempsProcessCounter.DeleteLabelValues(request.Name)
 		_ = compareObjEvalCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
@@ -142,6 +199,10 @@ func (r *ConfigurationPolicyReconciler) Reconcile(ctx context.Context, request c
 			prometheus.Labels{"policy": fmt.Sprintf("%s/%s", request.Namespace, request.Name)})
 		_ = policyUserErrorsCounter.DeletePartialMatch(prometheus.Labels{"template": request.Name})
 		_ = policySystemErrorsCounter.DeletePartialMatch(prometheus.Labels{"template": request.Name})
+=======
+		_ = compareObjEvalCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
+		_ = compareObjSecondsCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 	}
 
 	return reconcile.Result{}, nil
@@ -1514,6 +1575,7 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 
 		before := time.Now().UTC()
 
+<<<<<<< HEAD
 		throwSpecViolation, msg, pErr := r.checkAndUpdateResource(obj, compType, mdCompType, remediation)
 
 		duration := time.Now().UTC().Sub(before)
@@ -1526,6 +1588,20 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 		compareObjEvalCounter.WithLabelValues(
 			obj.policy.Name,
 			obj.namespace,
+			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
+		).Inc()
+=======
+		throwSpecViolation, msg, pErr := r.checkAndUpdateResource(obj, compType, mdCompType, remediation, dclient)
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
+
+		duration := time.Now().UTC().Sub(before)
+		seconds := float64(duration) / float64(time.Second)
+		compareObjSecondsCounter.WithLabelValues(
+			obj.policy.Name,
+			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
+		).Add(seconds)
+		compareObjEvalCounter.WithLabelValues(
+			obj.policy.Name,
 			fmt.Sprintf("%s.%s", obj.gvr.Resource, obj.name),
 		).Inc()
 

--- a/go.mod
+++ b/go.mod
@@ -76,16 +76,25 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
+<<<<<<< HEAD
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+=======
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+<<<<<<< HEAD
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+=======
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -770,9 +770,14 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+<<<<<<< HEAD
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+=======
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+>>>>>>> 19f845c (add metrics to time the compare algorithm)
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/test/e2e/case27_showupdateinstatus_test.go
+++ b/test/e2e/case27_showupdateinstatus_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+const (
+	case27ConfigPolicyName string = "policy-pod-create"
+	case27CreateYaml       string = "../resources/case27_showupdateinstatus/case27-create-pod-policy.yaml"
+	case27UpdateYaml       string = "../resources/case27_showupdateinstatus/case27-update-pod-policy.yaml"
+)
+
+var _ = Describe("Test cluster version obj template handling", func() {
+	Describe("enforce patch on unnamespaced resource clusterversion "+testNamespace, func() {
+		It("should be created properly on the managed cluster", func() {
+			By("Creating " + case27ConfigPolicyName + " on managed")
+			utils.Kubectl("apply", "-f", case27CreateYaml, "-n", testNamespace)
+			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+			Expect(plc).NotTo(BeNil())
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetStatusMessage(managedPlc)
+			}, 120, 1).Should(Equal(
+				"pods [nginx-pod-e2e] in namespace default found as specified, therefore this Object template is compliant"))
+		})
+		It("should be updated properly on the managed cluster", func() {
+			By("Creating " + case27ConfigPolicyName + " on managed")
+			utils.Kubectl("apply", "-f", case27UpdateYaml, "-n", testNamespace)
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetStatusMessage(managedPlc)
+			}, 30, 0.5).Should(Equal(
+				"pods [nginx-pod-e2e] in namespace default was updated successfully"))
+		})
+		It("Cleans up", func() {
+			deleteConfigPolicies([]string{case27ConfigPolicyName})
+			utils.Kubectl("delete", "pod", "nginx-pod-e2e")
+		})
+	})
+})

--- a/test/resources/case27_showupdateinstatus/case27-create-pod-policy.yaml
+++ b/test/resources/case27_showupdateinstatus/case27-create-pod-policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-create
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80

--- a/test/resources/case27_showupdateinstatus/case27-update-pod-policy.yaml
+++ b/test/resources/case27_showupdateinstatus/case27-update-pod-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-create
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e
+          labels:
+            test: test
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80


### PR DESCRIPTION
Fires an event when an object is updated by the config policy controller, rather than just when one is created or deleted.

refs:
- https://issues.redhat.com/browse/ACM-2021?filter=-1