### PR TITLE
Fire event on object update

### DIFF
--- a/test/e2e/case27_showupdateinstatus_test.go
+++ b/test/e2e/case27_showupdateinstatus_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+const (
+	case27ConfigPolicyName string = "policy-cfgmap-create"
+	case27CreateYaml       string = "../resources/case27_showupdateinstatus/case27-create-cfgmap-policy.yaml"
+	case27UpdateYaml       string = "../resources/case27_showupdateinstatus/case27-update-cfgmap-policy.yaml"
+)
+
+var _ = Describe("Verify status update after updating object", Ordered, func() {
+	It("configmap should be created properly on the managed cluster", func() {
+		By("Creating " + case27ConfigPolicyName + " on managed")
+		utils.Kubectl("apply", "-f", case27CreateYaml, "-n", testNamespace)
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+			case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, 120, 1).Should(Equal(
+			"configmaps [case27-map] in namespace default found as specified, " +
+				"therefore this Object template is compliant"))
+	})
+	It("configmap and status should be updated properly on the managed cluster", func() {
+		By("Updating " + case27ConfigPolicyName + " on managed")
+		utils.Kubectl("apply", "-f", case27UpdateYaml, "-n", testNamespace)
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, 30, 0.5).Should(Equal(
+			"configmaps [case27-map] in namespace default was updated successfully"))
+	})
+
+	AfterAll(func() {
+		deleteConfigPolicies([]string{case27ConfigPolicyName})
+		utils.Kubectl("delete", "configmap", "case27-map")
+	})
+})

--- a/test/resources/case27_showupdateinstatus/case27-create-cfgmap-policy.yaml
+++ b/test/resources/case27_showupdateinstatus/case27-create-cfgmap-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-cfgmap-create
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case27-map
+        data:
+          fieldToUpdate: "1"

--- a/test/resources/case27_showupdateinstatus/case27-update-cfgmap-policy.yaml
+++ b/test/resources/case27_showupdateinstatus/case27-update-cfgmap-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-cfgmap-create
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case27-map
+        data:
+          fieldToUpdate: "2"


### PR DESCRIPTION
Fires an event when an object is updated by the config policy controller, rather than just when one is created or deleted. Also changes events sent by successful enforce actions to compliant and adds a noncompliant "object not found" event before the enforce event.

refs:
- https://issues.redhat.com/browse/ACM-2021?filter=-1

Signed-off-by: Will Kutler <wkutler@redhat.com>