### PR TITLE
Clean up when deployment is being deleted

### DIFF
--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	apiRes "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -530,8 +531,8 @@ func sortAndJoinKeys(m map[string]bool, sep string) string {
 	return strings.Join(keys, sep)
 }
 
-func configPlcHasFinalizer(plc policyv1.ConfigurationPolicy, finalizer string) bool {
-	for _, existingFinalizer := range plc.GetFinalizers() {
+func objHasFinalizer(obj metav1.Object, finalizer string) bool {
+	for _, existingFinalizer := range obj.GetFinalizers() {
 		if existingFinalizer == finalizer {
 			return true
 		}
@@ -540,18 +541,19 @@ func configPlcHasFinalizer(plc policyv1.ConfigurationPolicy, finalizer string) b
 	return false
 }
 
-func addConfigPlcFinalizer(plc policyv1.ConfigurationPolicy, finalizer string) []string {
-	if configPlcHasFinalizer(plc, finalizer) {
-		return plc.GetFinalizers()
+func addObjFinalizer(obj metav1.Object, finalizer string) []string {
+	if objHasFinalizer(obj, finalizer) {
+		return obj.GetFinalizers()
 	}
 
-	return append(plc.GetFinalizers(), finalizer)
+	return append(obj.GetFinalizers(), finalizer)
 }
 
-func removeConfigPlcFinalizer(plc policyv1.ConfigurationPolicy, finalizer string) []string {
+// nolint: unparam
+func removeObjFinalizer(obj metav1.Object, finalizer string) []string {
 	result := []string{}
 
-	for _, existingFinalizer := range plc.GetFinalizers() {
+	for _, existingFinalizer := range obj.GetFinalizers() {
 		if existingFinalizer != finalizer {
 			result = append(result, existingFinalizer)
 		}

--- a/pkg/common/operator-sdk-port.go
+++ b/pkg/common/operator-sdk-port.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type RunModeType string
@@ -22,6 +24,10 @@ const (
 	// which specifies the Namespace to watch.
 	// An empty value means the operator is running with cluster scope.
 	watchNamespaceEnvVar = "WATCH_NAMESPACE"
+
+	// OperatorNameEnvVar is the constant for env variable OPERATOR_NAME
+	// which is the name of the current operator
+	OperatorNameEnvVar = "OPERATOR_NAME"
 )
 
 // ErrNoNamespace indicates that a namespace could not be found for the current
@@ -62,4 +68,36 @@ func GetOperatorNamespace() (string, error) {
 	}
 
 	return strings.TrimSpace(string(nsBytes)), nil
+}
+
+// GetOperatorName returns the operator name
+func GetOperatorName() (string, error) {
+	operatorName, found := os.LookupEnv(OperatorNameEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", OperatorNameEnvVar)
+	}
+
+	if len(operatorName) == 0 {
+		return "", fmt.Errorf("%s must not be empty", OperatorNameEnvVar)
+	}
+
+	return operatorName, nil
+}
+
+// GetOperatorNamespacedName returns the name and namespace of the operator.
+func GetOperatorNamespacedName() (types.NamespacedName, error) {
+	key := types.NamespacedName{}
+	var err error
+
+	key.Namespace, err = GetOperatorNamespace()
+	if err != nil {
+		return key, err
+	}
+
+	key.Name, err = GetOperatorName()
+	if err != nil {
+		return key, err
+	}
+
+	return key, nil
 }


### PR DESCRIPTION
Previously, when the controller is removed, it could leave a mess behind in the form of ConfigurationPolicy objects with finalizers on them. That would also result in the CRD being stuck.

Now, the controller will put a finalizer on its own deployment when at least one ConfigurationPolicy has a finalizer. Also, while the deployment is being deleted, the finalizers on ConfigurationPolicies will be removed immediately, in the same way they would be when the CRD was being deleted.

Note: in this implementation, related objects will *never* be pruned when the controller is removed.

Since the controller deployment is in a different namespace than the ConfigutaionPolicies it watches, the controller's cache cannot be limited to a single namespace the way it was before. Instead, this uses additional cache selectors to limit watches on ConfigurationPolicies and Deployments to the relevant namespaces.

Refs:
 - https://issues.redhat.com/browse/ACM-2923

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>