### PR TITLE
Fix hosted mode uninstalls

### DIFF
--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -29,6 +29,9 @@ linters:
   enable-all: true
   disable:
     - bodyclose
+    # Disable contextcheck since we don't want to pass the context passed to PeriodicallyExecConfigPolicies to functions
+    # called within it or else cleanup won't occur
+    - contextcheck
     - cyclop
     - depguard
     - dupl


### PR DESCRIPTION
When a hosted cluster is removed from OCM, it triggers the hosted cluster instance of the config-policy-controller to be uninstalled on the hosting cluster.

If any ConfigurationPolicy uses pruneObjectBehavior, they will have finalizers set on them. During an uninstall, the finalizers are immediately removed on the next evaluation of the ConfigurationPolicy with pruneObjectBehavior set so that the uninstall can proceed immediately.

The issue is if the ConfigurationPolicy sets evaluationInterval to a long value, the finalizer won't be removed until the next evaluation time, which could be hours.

This is not an issue when it's not deployed in hosted mode because the CRD is also deleted at the same time, which causes the ConfigurationPolicy to have a deletionTimestamp which then causes immediate evaluation for the finalizer to be removed.

Without the second commit, as soon as a SIGINT signal was received, mgr.Start would exit and cause the main function to finish before PeriodicallyExecConfigPolicies could finish the removal of finalizers when the config-policy-controller is being uninstalled.

Relates:
https://issues.redhat.com/browse/ACM-3233

Signed-off-by: mprahl <mprahl@users.noreply.github.com>