### PR TITLE
Use the controller ServiceAccount for tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -67,10 +67,14 @@ jobs:
       run: |
         make kind-bootstrap-cluster-dev
 
+    - name: Ensure Service Account kubeconfig
+      run: |
+        KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
+
     - name: E2E Tests
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-test-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
     - name: Create K8s KinD Cluster to simulate hosted mode - ${{ matrix.kind }}
       env:
@@ -81,7 +85,7 @@ jobs:
     - name: E2E tests that simulate hosted mode
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-test-hosted-mode-coverage
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
 
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' }}
@@ -92,7 +96,7 @@ jobs:
     - name: Verify Deployment Configuration
       run: |
         make build-images
-        make kind-deploy-controller-dev
+        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
 
     - name: Debug
       if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,7 @@ test/crds/test-policy.yaml
 !vbh/.build-harness-vendorized
 !vbh/build-harness
 !vbh/build-harness-extensions 
-kubeconfig_managed
-kubeconfig_managed2
+kubeconfig_managed*
 kind_kubeconfig.yaml
 report.json
 report_*.json

--- a/deploy/manager/kustomization.yaml
+++ b/deploy/manager/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - ./manager.yaml
+- ./service-account.yaml
 - ../rbac/

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -33,21 +33,3 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "config-policy-controller"
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: config-policy-controller
-subjects:
-- kind: ServiceAccount
-  name: config-policy-controller
-  namespace: open-cluster-management-agent-addon
-roleRef:
-  kind: ClusterRole
-  name: config-policy-controller
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: config-policy-controller

--- a/deploy/manager/service-account.yaml
+++ b/deploy/manager/service-account.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: config-policy-controller
+subjects:
+- kind: ServiceAccount
+  name: config-policy-controller
+  namespace: open-cluster-management-agent-addon
+roleRef:
+  kind: ClusterRole
+  name: config-policy-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: config-policy-controller

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -56,8 +56,8 @@ func TestE2e(t *testing.T) {
 func init() {
 	klog.SetOutput(GinkgoWriter)
 	klog.InitFlags(nil)
-	flag.StringVar(&kubeconfigManaged, "kubeconfig_managed", "../../kubeconfig_managed",
-		"Location of the kubeconfig to use; defaults to KUBECONFIG if not set")
+	flag.StringVar(&kubeconfigManaged, "kubeconfig_managed", "../../kubeconfig_managed_e2e",
+		"Location of the kubeconfig to use; defaults to current kubeconfig if set to an empty string")
 }
 
 var _ = BeforeSuite(func() {

--- a/test/resources/e2e_controller_secret.yaml
+++ b/test/resources/e2e_controller_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: config-policy-controller
+  annotations:
+    kubernetes.io/service-account.name: config-policy-controller


### PR DESCRIPTION
Previously the tests ran the controller binary locally using the default kubeadmin kubeconfig. This generates a new kubeconfig using the controller ServiceAccount for the local binary to use.

ref: https://issues.redhat.com/browse/ACM-2439
Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>