### PR TITLE
Trigger uninstalls through a new annotation

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -87,16 +87,21 @@ jobs:
         export GOPATH=$(go env GOPATH)
         KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
 
+    - name: Verify Deployment Configuration
+      run: |
+        make build-images
+        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
+
+    - name: E2E tests that require the controller running in a cluster
+      run: |
+        export GOPATH=$(go env GOPATH)
+        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-running-in-cluster
+
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         make test-coverage
         make coverage-verify
-
-    - name: Verify Deployment Configuration
-      run: |
-        make build-images
-        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
 
     - name: Debug
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -334,14 +334,18 @@ e2e-test: e2e-dependencies
 	$(GINKGO) -v --fail-fast --slow-spec-threshold=10s $(E2E_TEST_ARGS) test/e2e
 
 .PHONY: e2e-test-coverage
-e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode' --output-dir=.
+e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode && !running-in-cluster' --output-dir=.
 e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
 .PHONY: e2e-test-hosted-mode-coverage
-e2e-test-hosted-mode-coverage: E2E_TEST_ARGS = --json-report=report_e2e_hosted_mode.json --label-filter="hosted-mode" --output-dir=.
+e2e-test-hosted-mode-coverage: E2E_TEST_ARGS = --json-report=report_e2e_hosted_mode.json --label-filter="hosted-mode && !running-in-cluster" --output-dir=.
 e2e-test-hosted-mode-coverage: COVERAGE_E2E_OUT = coverage_e2e_hosted_mode.out
 e2e-test-hosted-mode-coverage: export TARGET_KUBECONFIG_PATH = $(PWD)/kubeconfig_managed2
 e2e-test-hosted-mode-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
+
+.PHONY: e2e-test-running-in-cluster
+e2e-test-running-in-cluster: E2E_TEST_ARGS = --label-filter="running-in-cluster" --covermode=atomic --coverprofile=coverage_e2e_uninstall.out --coverpkg=open-cluster-management.io/config-policy-controller/pkg/triggeruninstall
+e2e-test-running-in-cluster: e2e-test
 
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ COPY --from=builder ${REPO_PATH}/build/_output/bin/${COMPONENT} ${OPERATOR}
 COPY --from=builder ${REPO_PATH}/build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ENTRYPOINT ["/usr/local/bin/entrypoint", "controller"]
 
 RUN microdnf update && \
     microdnf clean all

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -549,7 +549,6 @@ func addObjFinalizer(obj metav1.Object, finalizer string) []string {
 	return append(obj.GetFinalizers(), finalizer)
 }
 
-// nolint: unparam
 func removeObjFinalizer(obj metav1.Object, finalizer string) []string {
 	result := []string{}
 

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
           command:
           - config-policy-controller
           args:
+            - "controller"
             - "--enable-lease=true"
             - "--log-level=2"
             - "--v=0"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       containers:
       - args:
+        - controller
         - --enable-lease=true
         - --log-level=2
         - --v=0

--- a/main_test.go
+++ b/main_test.go
@@ -15,8 +15,11 @@ import (
 // TestRunMain wraps the main() function in order to build a test binary and collection coverage for
 // E2E/Integration tests. Controller CLI flags are also passed in here.
 func TestRunMain(t *testing.T) {
+	args := append([]string{os.Args[1], "controller"}, os.Args[2:]...)
 	os.Args = append(
-		os.Args, "--leader-elect=false", fmt.Sprintf("--target-kubeconfig-path=%s", os.Getenv("TARGET_KUBECONFIG_PATH")),
+		args,
+		"--leader-elect=false",
+		fmt.Sprintf("--target-kubeconfig-path=%s", os.Getenv("TARGET_KUBECONFIG_PATH")),
 	)
 
 	main()

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+const UninstallingAnnotation string = "policy.open-cluster-management.io/uninstalling"
+
 // CreateRecorder return recorder
 func CreateRecorder(kubeClient kubernetes.Interface, componentName string) (record.EventRecorder, error) {
 	eventsScheme := runtime.NewScheme()

--- a/pkg/triggeruninstall/triggeruninstall.go
+++ b/pkg/triggeruninstall/triggeruninstall.go
@@ -1,0 +1,112 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package triggeruninstall
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+
+	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
+	"open-cluster-management.io/config-policy-controller/pkg/common"
+)
+
+// TriggerUninstall will add an annotation to the controller's Deployment indicating that the controller needs to
+// prepare to be uninstalled. This function will run until all ConfigurationPolicy objects have no finalizers.
+func TriggerUninstall(
+	ctx context.Context, config *rest.Config, deploymentName, deploymentNamespace, policyNamespace string,
+) error {
+	client := kubernetes.NewForConfigOrDie(config)
+	dynamicClient := dynamic.NewForConfigOrDie(config)
+
+	for {
+		klog.Info("Setting the Deployment uninstall annotation")
+		var err error
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled before the uninstallation preparation was complete")
+		default:
+		}
+
+		deploymentRsrc := client.AppsV1().Deployments(deploymentNamespace)
+
+		deployment, err := deploymentRsrc.Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		annotations := deployment.GetAnnotations()
+		annotations[common.UninstallingAnnotation] = "true"
+		deployment.SetAnnotations(annotations)
+
+		_, err = deploymentRsrc.Update(ctx, deployment, metav1.UpdateOptions{})
+		if err != nil {
+			if k8serrors.IsServerTimeout(err) || k8serrors.IsTimeout(err) || k8serrors.IsConflict(err) {
+				klog.Infof("Retrying setting the Deployment uninstall annotation due to error: %s", err)
+
+				continue
+			}
+
+			return err
+		}
+
+		break
+	}
+
+	configPolicyGVR := schema.GroupVersionResource{
+		Group:    policyv1.GroupVersion.Group,
+		Version:  policyv1.GroupVersion.Version,
+		Resource: "configurationpolicies",
+	}
+
+	for {
+		klog.Info("Checking if the uninstall preparation is complete")
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled before the uninstallation preparation was complete")
+		default:
+		}
+
+		configPolicies, err := dynamicClient.Resource(configPolicyGVR).Namespace(policyNamespace).List(
+			ctx, metav1.ListOptions{},
+		)
+		if err != nil {
+			if k8serrors.IsServerTimeout(err) || k8serrors.IsTimeout(err) {
+				klog.Infof("Retrying listing the ConfigurationPolicy objects due to error: %s", err)
+
+				continue
+			}
+
+			return err
+		}
+
+		cleanedUp := true
+
+		for _, configPolicy := range configPolicies.Items {
+			if len(configPolicy.GetFinalizers()) != 0 {
+				cleanedUp = false
+
+				break
+			}
+		}
+
+		if cleanedUp {
+			break
+		}
+
+		klog.Info("The uninstall preparation is not complete. Sleeping two seconds before checking again.")
+		time.Sleep(2 * time.Second)
+	}
+
+	return nil
+}

--- a/test/e2e/case29_trigger_uninstall_test.go
+++ b/test/e2e/case29_trigger_uninstall_test.go
@@ -1,0 +1,121 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"open-cluster-management.io/config-policy-controller/pkg/common"
+	"open-cluster-management.io/config-policy-controller/pkg/triggeruninstall"
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+// This test only works when the controller is running in the cluster.
+var _ = Describe("Clean up during uninstalls", Label("running-in-cluster"), Ordered, func() {
+	const (
+		configMapName        string = "case29-trigger-uninstall"
+		deploymentName       string = "config-policy-controller"
+		deploymentNamespace  string = "open-cluster-management-agent-addon"
+		policyName           string = "case29-trigger-uninstall"
+		policy2Name          string = "case29-trigger-uninstall2"
+		policyYAMLPath       string = "../resources/case29_trigger_uninstall/policy.yaml"
+		policy2YAMLPath      string = "../resources/case29_trigger_uninstall/policy2.yaml"
+		pruneObjectFinalizer string = "policy.open-cluster-management.io/delete-related-objects"
+	)
+
+	It("verifies that finalizers are removed when being uninstalled", func() {
+		By("Creating two configuration policies with pruneObjectBehavior")
+		utils.Kubectl("apply", "-f", policyYAMLPath, "-n", testNamespace)
+		utils.Kubectl("apply", "-f", policy2YAMLPath, "-n", testNamespace)
+
+		By("Verifying that the configuration policies are compliant and have finalizers")
+		Eventually(func(g Gomega) {
+			policy := utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, policyName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			g.Expect(utils.GetComplianceState(policy)).To(Equal("Compliant"))
+
+			g.Expect(policy.GetFinalizers()).To(ContainElement(pruneObjectFinalizer))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			policy2 := utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, policy2Name, testNamespace, true, defaultTimeoutSeconds,
+			)
+			g.Expect(utils.GetComplianceState(policy2)).To(Equal("Compliant"))
+
+			g.Expect(policy2.GetFinalizers()).To(ContainElement(pruneObjectFinalizer))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		By("Triggering an uninstall")
+		config, err := LoadConfig("", kubeconfigManaged, "")
+		Expect(err).To(BeNil())
+
+		ctx, ctxCancel := context.WithDeadline(
+			context.Background(),
+			// Cancel the context after the default timeout seconds to avoid the test running forever if it doesn't
+			// exit cleanly before then.
+			time.Now().Add(time.Duration(defaultTimeoutSeconds)*time.Second),
+		)
+		defer ctxCancel()
+
+		err = triggeruninstall.TriggerUninstall(ctx, config, deploymentName, deploymentNamespace, testNamespace)
+		Expect(err).To(BeNil())
+
+		By("Verifying that the uninstall annotation was set on the Deployment")
+		deployment, err := clientManaged.AppsV1().Deployments(deploymentNamespace).Get(
+			context.TODO(), deploymentName, metav1.GetOptions{},
+		)
+		Expect(err).To(BeNil())
+		Expect(deployment.GetAnnotations()).To(HaveKeyWithValue(common.UninstallingAnnotation, "true"))
+
+		By("Verifying that the ConfiguratioPolicy finalizers have been removed")
+		policy := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, policyName, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(policy.GetFinalizers()).To(HaveLen(0))
+
+		policy2 := utils.GetWithTimeout(
+			clientManagedDynamic, gvrConfigPolicy, policy2Name, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(policy2.GetFinalizers()).To(HaveLen(0))
+	})
+
+	AfterAll(func() {
+		deleteConfigPolicies([]string{policyName, policy2Name})
+
+		err := clientManaged.CoreV1().ConfigMaps("default").Delete(
+			context.TODO(), configMapName, metav1.DeleteOptions{},
+		)
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).To(BeNil())
+		}
+
+		// Use an eventually in case there are update conflicts and there needs to be a retry
+		Eventually(func(g Gomega) {
+			deployment, err := clientManaged.AppsV1().Deployments(deploymentNamespace).Get(
+				context.TODO(), deploymentName, metav1.GetOptions{},
+			)
+			g.Expect(err).To(BeNil())
+
+			annotations := deployment.GetAnnotations()
+			if _, ok := annotations[common.UninstallingAnnotation]; !ok {
+				return
+			}
+
+			delete(annotations, common.UninstallingAnnotation)
+			deployment.SetAnnotations(annotations)
+
+			_, err = clientManaged.AppsV1().Deployments(deploymentNamespace).Update(
+				context.TODO(), deployment, metav1.UpdateOptions{},
+			)
+			g.Expect(err).To(BeNil())
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+	})
+})

--- a/test/resources/case29_trigger_uninstall/policy.yaml
+++ b/test/resources/case29_trigger_uninstall/policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case29-trigger-uninstall
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case29-trigger-uninstall
+          namespace: default
+        data:
+          city: Raleigh

--- a/test/resources/case29_trigger_uninstall/policy2.yaml
+++ b/test/resources/case29_trigger_uninstall/policy2.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case29-trigger-uninstall2
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case29-trigger-uninstall
+          namespace: default
+        data:
+          state: NC


### PR DESCRIPTION
Previous to this, a finalizer on the Deployment was added so that if the Deployment was deleted, it would handle immediate clean up. This doesn't handle the common case where the config-policy-controller ManagedClusterAddOn is deleted, which causes the ManifestWork to be deleted, which triggers all Configuration Policy controller deployment artifacts, including the service account.

A new approach is taken so that a new annotation of policy.open-cluster-management.io/uninstalling=true is set on the Deployment to indicate that the Configuration Policy controller should remove all finalizers because it's getting deleted.

The Policy Addon controller will be updated so that when the config-policy-controller ManagedClusterAddOn object is deleted, a finalizer will prevent it and a Pod will run on the managed cluster with the new `trigger-uninstall` subcommand. This sets the uninstalling annotation on the Deployment and then waits until all ConfigurationPolicy finalizers have been removed. Once the command ends, the Pod exits, and the ManagedClusterAddOn object's finalizer is removed and the uninstall proceeds.

Relates:
https://issues.redhat.com/browse/ACM-3233
https://issues.redhat.com/browse/ACM-2923