### PR TITLE
Make config policies with no objects compliant

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1019,6 +1019,25 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 		return
 	}
 
+	if len(plc.Spec.ObjectTemplates) == 0 {
+		reason := "No object templates"
+		msg := fmt.Sprintf("%v contains no object templates to check, and thus has no violations",
+			plc.GetName())
+
+		statusUpdateNeeded := addConditionToStatus(&plc, 0, true, reason, msg)
+
+		if statusUpdateNeeded {
+			eventType := eventNormal
+
+			r.Recorder.Event(&plc, eventType, fmt.Sprintf(plcFmtStr, plc.GetName()),
+				convertPolicyStatusToString(&plc))
+		}
+
+		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, statusUpdateNeeded)
+
+		return
+	}
+
 	for indx, objectT := range plc.Spec.ObjectTemplates {
 		nonCompliantObjects := map[string]map[string]interface{}{}
 		compliantObjects := map[string]map[string]interface{}{}

--- a/test/resources/case30_multiline_templatization/case30_no_object.yaml
+++ b/test/resources/case30_multiline_templatization/case30_no_object.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case30-configpolicy-no-object
+spec:
+  remediationAction: inform
+  severity: low
+  object-templates-raw: |
+    {{ range (lookup "v1" "ConfigMap" "default" "doesnotexist").items }}
+      - complianceType: musthave
+        objectDefinition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: {{ .metadata.name }}
+            namespace: default
+          data:
+            extraData: exists!
+    {{ end }}


### PR DESCRIPTION
Config policies with no object templates (like from a range template with no matches) will have no status. This change makes policies with no object templates register as compliant, since they are not checking anything and cannot find violations.

ref: https://issues.redhat.com/browse/ACM-4021?filter=-1