### PR TITLE
Fix order of events on create or delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ create-ns:
 # Run against the current locally configured Kubernetes cluster
 .PHONY: run
 run:
-	WATCH_NAMESPACE=$(WATCH_NAMESPACE) go run ./main.go --leader-elect=false
+	WATCH_NAMESPACE=$(WATCH_NAMESPACE) go run ./main.go controller --leader-elect=false
 
 ############################################################
 # clean section

--- a/test/e2e/case15_event_format_test.go
+++ b/test/e2e/case15_event_format_test.go
@@ -166,8 +166,13 @@ var _ = Describe("Testing compliance event formatting", func() {
 		compPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
 			case15BecomesCompliantName, "", "Policy status is: Compliant", defaultTimeoutSeconds)
 		Expect(compPlcEvents).NotTo(BeEmpty())
+		compParentEventsPreCreation := utils.GetMatchingEvents(clientManaged, testNamespace,
+			case15BecomesCompliantParentName, "policy: "+testNamespace+"/"+case15BecomesCompliantName,
+			"^NonCompliant;.*No instances of.*found as specified", defaultTimeoutSeconds)
+		Expect(compParentEventsPreCreation).NotTo(BeEmpty())
 		compParentEvents := utils.GetMatchingEvents(clientManaged, testNamespace, case15BecomesCompliantParentName,
-			"policy: "+testNamespace+"/"+case15BecomesCompliantName, "^Compliant;", defaultTimeoutSeconds)
+			"policy: "+testNamespace+"/"+case15BecomesCompliantName,
+			"^Compliant;.*and was created successfully$", defaultTimeoutSeconds)
 		Expect(compParentEvents).NotTo(BeEmpty())
 	})
 	It("Records events for a policy that becomes noncompliant", func() {


### PR DESCRIPTION
fixes the issue that is causing https://github.com/stolostron/governance-policy-framework-addon/pull/43 to fail

also adds the `controller` argument to `make run` - the command does not work without it