### PR TITLE
Pull in the new template utils with copy template functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.1
-	github.com/stolostron/go-template-utils/v3 v3.0.2
+	github.com/stolostron/go-template-utils/v3 v3.1.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.9
 	k8s.io/apiextensions-apiserver v0.23.5

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/go-log-utils v0.1.1 h1:T48GyfuGpn2+6817FQVec1CyxGf0ibuVhoBiz9SeCec=
 github.com/stolostron/go-log-utils v0.1.1/go.mod h1:2Uc5mbuLvSFpoXFFEKRTEFOlR7nqGVMu9mbU+FIttTI=
-github.com/stolostron/go-template-utils/v3 v3.0.2 h1:0wUbfcvG5pYoEa0p4qj3oBpz9k6WPyE5S5IaYIBWbbg=
-github.com/stolostron/go-template-utils/v3 v3.0.2/go.mod h1:k9qoQ/OH/jOQI5ovfC11QJ6ApWsa3E5rmbkfUAEUF3g=
+github.com/stolostron/go-template-utils/v3 v3.1.0 h1:wizzuURDnI2fewOx/AxHLpKx06FXUGjkUnMjdcgat3o=
+github.com/stolostron/go-template-utils/v3 v3.1.0/go.mod h1:k9qoQ/OH/jOQI5ovfC11QJ6ApWsa3E5rmbkfUAEUF3g=
 github.com/stolostron/kubernetes-dependency-watches v0.0.0-20221007134235-7551d84cf688 h1:Q/0MspxKFkqBN59keMsJI2hGqGGpTSxdNEvrxTOBlRg=
 github.com/stolostron/kubernetes-dependency-watches v0.0.0-20221007134235-7551d84cf688/go.mod h1:jGnjY4g8N1PaBqt35EjqNRjymjG0DWqki/2JOLMN1Pg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/test/resources/case13_templatization/case13_copy_referenced_configmap.yaml
+++ b/test/resources/case13_templatization/case13_copy_referenced_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: tmplt-policy-secret-duplicate
+  name: policy-copy-referenced-configmap
 spec:
   remediationAction: enforce
   namespaceSelector:
@@ -11,8 +11,8 @@ spec:
     - complianceType: musthave
       objectDefinition:
         apiVersion: v1
-        kind: Secret
+        kind: ConfigMap
         metadata:
-          name: e2esecret2
-        type: Opaque
-        data: '{{ copySecretData "default" "e2esecret" }}'
+          name: configmap-copy-configmap-object-repl
+          namespace: default
+        data: '{{ copyConfigMapData "default" "configmap-copy-configmap-object" }}'

--- a/test/resources/case13_templatization/case13_fromsecret.yaml
+++ b/test/resources/case13_templatization/case13_fromsecret.yaml
@@ -15,4 +15,6 @@ spec:
         metadata:
           name: e2esecret2
         type: Opaque
-        data: '{{ copySecretData "default" "e2esecret" }}'
+        data:
+          USER_NAME: YWRtaW4=
+          PASSWORD: '{{ fromSecret "default" "e2esecret" "PASSWORD" }}'


### PR DESCRIPTION
Adding support for the new go template functions:
- copyConfigMapData
- copySecretData These copy the data section of ConfigMap or Secret resources so individual keys don't have to be specified

Refs:
 - https://issues.redhat.com/browse/ACM-2611