### PR TITLE
Fix behavior when the kube api might omit some more fields

### DIFF
--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -124,15 +124,21 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 		}
 
 		return false
-	default:
-		// NOTE: when type is string, int, bool
-		var oVal interface{}
-
+	default: // when mergedObj's type is string, int, bool, or nil
 		if oldObj == nil && mergedObj != nil {
+			// compare the zero value of mergedObj's type to mergedObj
 			ref := reflect.ValueOf(mergedObj)
-			oVal = reflect.Zero(ref.Type()).Interface()
+			zero := reflect.Zero(ref.Type()).Interface()
 
-			return fmt.Sprint(oVal) == fmt.Sprint(mergedObj)
+			return fmt.Sprint(zero) == fmt.Sprint(mergedObj)
+		}
+
+		if mergedObj == nil && oldObj != nil {
+			// compare the zero value of oldObj's type to oldObj
+			ref := reflect.ValueOf(oldObj)
+			zero := reflect.Zero(ref.Type()).Interface()
+
+			return fmt.Sprint(zero) == fmt.Sprint(oldObj)
 		}
 
 		if !reflect.DeepEqual(fmt.Sprint(mergedObj), fmt.Sprint(oldObj)) {

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -115,6 +115,10 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 		// this includes the case where oldObj is nil
 		return false
 	case []interface{}:
+		if len(mergedObj) == 0 && oldObj == nil {
+			return true
+		}
+
 		if oldObjList, ok := oldObj.([]interface{}); ok {
 			return checkListsMatch(mergedObj, oldObjList)
 		}

--- a/test/e2e/case15_event_format_test.go
+++ b/test/e2e/case15_event_format_test.go
@@ -36,21 +36,8 @@ const (
 
 var _ = Describe("Testing compliance event formatting", func() {
 	It("Records the right events for a policy that is always compliant", func() {
-		By("Creating parent policy " + case15AlwaysCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15AlwaysCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15AlwaysCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating compliant policy " + case15AlwaysCompliantName + " on " + testNamespace + " with parent " +
-			case15AlwaysCompliantParentName)
-		plcDef := utils.ParseYaml(case15AlwaysCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		createConfigPolicyWithParent(case15AlwaysCompliantParentYaml, case15AlwaysCompliantParentName,
+			case15AlwaysCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15AlwaysCompliantName, testNamespace, true, defaultTimeoutSeconds)
@@ -81,21 +68,8 @@ var _ = Describe("Testing compliance event formatting", func() {
 		Expect(nonCompParentEvents).To(BeEmpty())
 	})
 	It("Records the right events for a policy that is never compliant", func() {
-		By("Creating parent policy " + case15NeverCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15NeverCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15NeverCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating noncompliant policy " + case15NeverCompliantName + " on " + testNamespace + " with parent " +
-			case15NeverCompliantParentName)
-		plcDef := utils.ParseYaml(case15NeverCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		createConfigPolicyWithParent(case15NeverCompliantParentYaml, case15NeverCompliantParentName,
+			case15NeverCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15NeverCompliantName, testNamespace, true, defaultTimeoutSeconds)
@@ -126,21 +100,8 @@ var _ = Describe("Testing compliance event formatting", func() {
 		Expect(nonCompParentEvents).NotTo(BeEmpty())
 	})
 	It("Records events for a policy that becomes compliant", func() {
-		By("Creating parent policy " + case15BecomesCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15BecomesCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15BecomesCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating noncompliant policy " + case15BecomesCompliantName + " on " + testNamespace + " with parent " +
-			case15BecomesCompliantParentName)
-		plcDef := utils.ParseYaml(case15BecomesCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		createConfigPolicyWithParent(case15BecomesCompliantParentYaml, case15BecomesCompliantParentName,
+			case15BecomesCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15BecomesCompliantName, testNamespace, true, defaultTimeoutSeconds)
@@ -176,21 +137,8 @@ var _ = Describe("Testing compliance event formatting", func() {
 		Expect(compParentEvents).NotTo(BeEmpty())
 	})
 	It("Records events for a policy that becomes noncompliant", func() {
-		By("Creating parent policy " + case15BecomesNonCompliantParentName + " on " + testNamespace)
-		utils.Kubectl("apply", "-f", case15BecomesNonCompliantParentYaml, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic, gvrPolicy,
-			case15BecomesNonCompliantParentName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating compliant policy " + case15BecomesNonCompliantName + " on " + testNamespace + " with parent " +
-			case15BecomesNonCompliantParentName)
-		plcDef := utils.ParseYaml(case15BecomesNonCompliantYaml)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).
-			Create(context.TODO(), plcDef, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		createConfigPolicyWithParent(case15BecomesNonCompliantParentYaml, case15BecomesNonCompliantParentName,
+			case15BecomesNonCompliantYaml)
 
 		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
 			case15BecomesNonCompliantName, testNamespace, true, defaultTimeoutSeconds)

--- a/test/e2e/case17_evaluation_interval_test.go
+++ b/test/e2e/case17_evaluation_interval_test.go
@@ -29,26 +29,7 @@ const (
 
 var _ = Describe("Test evaluation interval", func() {
 	It("Verifies that status.lastEvaluated is properly set", func() {
-		By("Creating the parent policy " + case17ParentPolicyName + " on the managed cluster")
-		utils.Kubectl("apply", "-f", case17ParentPolicy, "-n", testNamespace)
-		parent := utils.GetWithTimeout(clientManagedDynamic,
-			gvrPolicy,
-			case17ParentPolicyName,
-			testNamespace,
-			true,
-			defaultTimeoutSeconds,
-		)
-		Expect(parent).NotTo(BeNil())
-
-		By("Creating " + case17PolicyName + " on the managed cluster")
-		plcDef := utils.ParseYaml(case17Policy)
-		ownerRefs := plcDef.GetOwnerReferences()
-		ownerRefs[0].UID = parent.GetUID()
-		plcDef.SetOwnerReferences(ownerRefs)
-		_, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Create(
-			context.TODO(), plcDef, v1.CreateOptions{},
-		)
-		Expect(err).To(BeNil())
+		createConfigPolicyWithParent(case17ParentPolicy, case17ParentPolicyName, case17Policy)
 
 		By("Getting status.lastEvaluated")
 		var managedPlc *unstructured.Unstructured

--- a/test/resources/case31_policy_history/event-config-policy-emptystruct.yaml
+++ b/test/resources/case31_policy_history/event-config-policy-emptystruct.yaml
@@ -1,0 +1,39 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: config-policy-event-emptystruct
+  labels:
+    policy.open-cluster-management.io/policy: test-policy-security
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: Policy
+    name: test-policy-security-emptystruct
+    uid: 08bae967-4262-498a-84e9-d1f0e321b41e
+spec:
+  pruneObjectBehavior: DeleteAll  
+  remediationAction: enforce
+  namespaceSelector:
+    exclude:
+      - kube-public
+    include:
+      - default
+      - kube-system
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        action: DidTheThing
+        apiVersion: events.k8s.io/v1
+        eventTime: 2023-04-27T14:37:36.721589Z
+        kind: Event
+        metadata:
+          name: configpol-test-event
+          namespace: kube-system
+        note: Successfully did something
+        reason: Success
+        regarding: null
+        related: null
+        reportingController: ConfigPolicyTester
+        reportingInstance: configpol-history-test
+        type: Normal

--- a/test/resources/case31_policy_history/event-policy-emptystruct.yaml
+++ b/test/resources/case31_policy_history/event-policy-emptystruct.yaml
@@ -1,0 +1,42 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: test-policy-security-emptystruct
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: config-policy-event-emptystruct
+        spec:
+          remediationAction: enforce
+          namespaceSelector:
+            exclude:
+              - kube-public
+            include:
+              - default
+              - kube-system
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                action: DidTheThing
+                apiVersion: events.k8s.io/v1
+                eventTime: 2023-04-27T14:37:36.721589Z
+                kind: Event
+                metadata:
+                  name: configpol-test-event
+                  namespace: kube-system
+                note: Successfully did something
+                reason: Success
+                regarding: null
+                related: null
+                reportingController: ConfigPolicyTester
+                reportingInstance: configpol-history-test
+                type: Normal

--- a/test/resources/case31_policy_history/rb-config-policy-emptyarray.yaml
+++ b/test/resources/case31_policy_history/rb-config-policy-emptyarray.yaml
@@ -1,0 +1,33 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: config-policy-rb-emptyarray
+  labels:
+    policy.open-cluster-management.io/policy: test-policy-security
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: Policy
+    name: test-policy-security-emptyarray
+    uid: 08bae967-4262-498a-84e9-d1f0e321b41e
+spec:
+  pruneObjectBehavior: DeleteAll  
+  remediationAction: enforce
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:
+      - default
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+          name: case31-empty-binding
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: Role
+          name: case31-imaginary-role
+        subjects: []

--- a/test/resources/case31_policy_history/rb-policy-emptyarray.yaml
+++ b/test/resources/case31_policy_history/rb-policy-emptyarray.yaml
@@ -1,0 +1,36 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: test-policy-security-emptyarray
+  annotations:
+    policy.open-cluster.management.io/standards: NIST-CSF
+    policy.open-cluster.management.io/categories: PR.PT Protective Technology
+    policy.open-cluster.management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: config-policy-rb-emptyarray
+        spec:
+          remediationAction: enforce
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: RoleBinding
+                metadata:
+                  name: case31-empty-binding
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: Role
+                  name: case31-imaginary-role
+                subjects: []


### PR DESCRIPTION
These are two more situations where the kube api server may omit "empty" values in some of the default kubernetes objects.

https://issues.redhat.com/browse/ACM-5132