### PR TITLE
Bug: Policy compliance status is truncated

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2842,7 +2842,6 @@ func (r *ConfigurationPolicyReconciler) sendComplianceEvent(instance *policyv1.C
 		LastTimestamp:  metav1.NewTime(now),
 		Count:          1,
 		Type:           "Normal",
-		EventTime:      metav1.NewMicroTime(now),
 		Action:         "ComplianceStateUpdate",
 		Related: &corev1.ObjectReference{
 			Kind:       instance.Kind,
@@ -2882,12 +2881,6 @@ func convertPolicyStatusToString(plc *policyv1.ConfigurationPolicy) (results str
 				result += ", "
 			}
 		}
-	}
-
-	runeResult := []rune(result)
-
-	if len(runeResult) > 1024 {
-		result = string(append(runeResult[:1021], '.', '.', '.'))
 	}
 
 	return result

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -268,8 +268,7 @@ func TestConvertPolicyStatusToStringLongMsg(t *testing.T) {
 	}
 	statusMsg := convertPolicyStatusToString(&samplePolicy)
 
-	assert.Contains(t, statusMsg, "...")
-	assert.Len(t, []rune(statusMsg), 1024)
+	assert.Greater(t, len(statusMsg), 1024)
 }
 
 func TestMerge(t *testing.T) {

--- a/test/resources/case31_policy_history/long-message-config-policy.yaml
+++ b/test/resources/case31_policy_history/long-message-config-policy.yaml
@@ -1,0 +1,47 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: long-message-config-policy
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    blockOwnerDeletion: false
+    controller: true
+    kind: Policy
+    name: long-message-policy
+    uid: 08bae967-4262-498a-84e9-d1f0e321b41e
+spec:
+  pruneObjectBehavior: DeleteAll  
+  remediationAction: inform
+  namespaceSelector:
+    exclude:
+      - kube-*
+    include:            
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt1
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt2
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt3
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt4
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt5
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt6
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt7
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt8
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt9
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt10
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt11
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt12
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt13
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt14
+      - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt15
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case31-multi-namespace-inform-pod
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              imagePullPolicy: Never
+              name: nginx
+              ports:
+                - containerPort: 80

--- a/test/resources/case31_policy_history/long-message-policy.yaml
+++ b/test/resources/case31_policy_history/long-message-policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  resourceVersion: "306"
+  name: long-message-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: long-message-config-policy
+      spec:
+        namespaceselector:
+          exclude:
+          - kube-*
+          include:
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt1
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt2
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt3
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt4
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt5
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt6
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt7
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt8
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt9
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt10
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt11
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt12
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt13
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt14
+            - innovafertanimvsmvtatasdicereformascorporinnovafertanimvsmvt15
+        object-templates:
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: case31-multi-namespace-inform-pod
+              spec:
+                containers:
+                  - image: nginx:1.7.9
+                    imagePullPolicy: Never
+                    name: nginx
+                    ports:
+                      - containerPort: 80
+        remediationAction: inform
+        severity: low


### PR DESCRIPTION
Description of problem:
The status message for non compliant policy is truncated with "..." when the policy has multiple objectTemplates or a namespace. This leaves the user unable to determine why the policy is non compliant.

Expect result: message should include all information
Signed-off-by: Yi Rae Kim <yikim@redhat.com>