### PR TITLE
Clear compliancyDetails on template error

### DIFF
--- a/test/resources/case30_multiline_templatization/case30_configmaps.yaml
+++ b/test/resources/case30_multiline_templatization/case30_configmaps.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: 30config1
+  labels:
+    testcase: "30"
 data:
   name: testvalue1
 ---
@@ -9,5 +11,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: 30config2
+  labels:
+    testcase: "30"
 data:
   name: testvalue2

--- a/test/resources/case30_multiline_templatization/case30_policy.yaml
+++ b/test/resources/case30_multiline_templatization/case30_policy.yaml
@@ -6,7 +6,7 @@ spec:
   remediationAction: enforce
   severity: low
   object-templates-raw: |
-    {{ range (lookup "v1" "ConfigMap" "default" "").items }}
+    {{ range (lookup "v1" "ConfigMap" "default" "" "testcase=30").items }}
       - complianceType: musthave
         objectDefinition:
           apiVersion: v1

--- a/test/resources/case30_multiline_templatization/case30_unterminated.yaml
+++ b/test/resources/case30_multiline_templatization/case30_unterminated.yaml
@@ -1,22 +1,21 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-create-unterminated
+  name: case30-configpolicy
 spec:
   remediationAction: enforce
   namespaceSelector:
     exclude: ["kube-*"]
     include: ["default"]
-  object-templates-raw: |
-    - complianceType: musthave
-      objectDefinition:
-        apiVersion: v1
-        kind: Pod
-        metadata:
-          name: '{{'
-        spec:
-          containers:
-            - image: nginx:1.7.9
-              name: nginx
-              ports:
-                - containerPort: 80
+  object-templates-raw:  |
+    {{ range (lookup "v1" "ConfigMap" "default" "" "testcase=30").items }}
+      - complianceType: musthave
+        objectDefinition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{'
+            namespace: default
+          data:
+            extraData: exists!
+    {{ end }}


### PR DESCRIPTION
Also adjusts the CompliancyDetails array for the number of object-templates.

ref: https://issues.redhat.com/browse/ACM-5512