### PR TITLE
Log policy NonCompliance

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2826,11 +2826,14 @@ func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 			eventType = eventWarning
 		}
 
+		eventMessage := fmt.Sprintf("%s%s", policy.Status.ComplianceState, msg)
+		log.Info("Policy status message", "policy", policy.GetName(), "status", eventMessage)
+
 		r.Recorder.Event(
 			policy,
 			eventType,
 			"Policy updated",
-			fmt.Sprintf("Policy status is %s%s", policy.Status.ComplianceState, msg),
+			fmt.Sprintf("Policy status is %s", eventMessage),
 		)
 	}
 


### PR DESCRIPTION
Consistently log the policy noncompliance and compliance as updates are made.  The goal is to allow tools that scrape logs to be able to obtain the violation message and the details on when compliance changes happen.

Refs:
 - https://issues.redhat.com/browse/ACM-5568