### PR TITLE
Bug: Objects are pruned on templating errors

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -698,7 +698,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 				fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
 		}
 
-		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, statusChanged)
+		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, statusChanged, true)
 
 		parent := ""
 		if len(plc.OwnerReferences) > 0 {
@@ -793,7 +793,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 				}
 
 				// don't change related objects while deletion is in progress
-				r.checkRelatedAndUpdate(plc, oldRelated, oldRelated, parentStatusUpdateNeeded)
+				r.checkRelatedAndUpdate(plc, oldRelated, oldRelated, parentStatusUpdateNeeded, true)
 			}
 
 			return
@@ -810,6 +810,8 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 		}
 	}
 
+	// When it is hub or managed template parse error, deleteDetachedObjs should be false
+	// Then it doesn't remove resources
 	addTemplateErrorViolation := func(reason, msg string) {
 		log.Info("Setting the policy to noncompliant due to a templating error", "error", msg)
 
@@ -829,7 +831,8 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 			)
 		}
 
-		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, parentStatusUpdateNeeded)
+		// deleteDetachedObjs should be false
+		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, parentStatusUpdateNeeded, false)
 	}
 
 	// initialize apiresources for template processing before starting objectTemplate processing
@@ -1054,7 +1057,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 
 	if err != nil {
 		if parentStatusUpdateNeeded {
-			r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, parentStatusUpdateNeeded)
+			r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, parentStatusUpdateNeeded, false)
 		}
 
 		return
@@ -1074,7 +1077,7 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 				convertPolicyStatusToString(&plc))
 		}
 
-		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, statusUpdateNeeded)
+		r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, statusUpdateNeeded, true)
 
 		return
 	}
@@ -1187,14 +1190,17 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 		}
 	}
 
-	r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, parentStatusUpdateNeeded)
+	r.checkRelatedAndUpdate(plc, relatedObjects, oldRelated, parentStatusUpdateNeeded, true)
 }
 
 // checkRelatedAndUpdate checks the related objects field and triggers an update on the ConfigurationPolicy
 func (r *ConfigurationPolicyReconciler) checkRelatedAndUpdate(
-	plc policyv1.ConfigurationPolicy, related, oldRelated []policyv1.RelatedObject, sendEvent bool,
+	plc policyv1.ConfigurationPolicy,
+	related, oldRelated []policyv1.RelatedObject,
+	sendEvent bool,
+	deleteDetachedObjs bool,
 ) {
-	r.sortRelatedObjectsAndUpdate(&plc, related, oldRelated, r.EnableMetrics)
+	r.sortRelatedObjectsAndUpdate(&plc, related, oldRelated, r.EnableMetrics, deleteDetachedObjs)
 	// An update always occurs to account for the lastEvaluated status field
 	r.addForUpdate(&plc, sendEvent)
 }
@@ -1203,6 +1209,7 @@ func (r *ConfigurationPolicyReconciler) checkRelatedAndUpdate(
 func (r *ConfigurationPolicyReconciler) sortRelatedObjectsAndUpdate(
 	plc *policyv1.ConfigurationPolicy, related, oldRelated []policyv1.RelatedObject,
 	collectMetrics bool,
+	deleteDetachedObjs bool,
 ) {
 	sort.SliceStable(related, func(i, j int) bool {
 		if related[i].Object.Kind != related[j].Object.Kind {
@@ -1273,7 +1280,11 @@ func (r *ConfigurationPolicyReconciler) sortRelatedObjectsAndUpdate(
 	}
 
 	if !gocmp.Equal(related, oldRelated) {
-		r.deleteDetachedObj(*plc, related, oldRelated)
+		// When it is hub or managed template parse error, it should not remove previous objects
+		if deleteDetachedObjs {
+			r.deleteDetachedObj(*plc, related, oldRelated)
+		}
+
 		plc.Status.RelatedObjects = related
 	}
 }

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -414,14 +414,14 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 
 	empty := []policyv1.RelatedObject{}
 
-	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
+	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false, true)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 
 	// append another object named bar but also with namespace bar
 	relatedList = append(relatedList, addRelatedObjects(true, rsrc,
 		"ConfigurationPolicy", "bar", true, []string{name}, "reason", nil)...)
 
-	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
+	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false, true)
 	assert.True(t, relatedList[0].Object.Metadata.Namespace == "bar")
 
 	// clear related objects and test sorting with no namespace
@@ -432,7 +432,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 	relatedList = append(relatedList, addRelatedObjects(true, rsrc, "ConfigurationPolicy", "",
 		false, []string{name}, "reason", nil)...)
 
-	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
+	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false, true)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 }
 

--- a/test/resources/case13_templatization/case13_prune_template_error.yaml
+++ b/test/resources/case13_templatization/case13_prune_template_error.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case13-prune-template-error
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case13-prune-template-error-configmap
+          namespace: default
+        data:
+          test: '{{ print "doraemong" }}'
+


### PR DESCRIPTION
Description:
Deploying a enforced ConfigurationPolicy with a valid template and then updating the template to be invalid caused the created object to be pruned. (I did it with hub templates, but I'd suspect managed cluster templates would have a similar behavior.)

 

expected:  Not perform any deletion while in this error state.

Ref: https://issues.redhat.com/browse/ACM-5301
Signed-off-by: Yi Rae Kim <yikim@redhat.com>