### PR TITLE
Refactor object template status generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ install-resources:
 
 .PHONY: e2e-test
 e2e-test: e2e-dependencies
-	$(GINKGO) -v --fail-fast $(E2E_TEST_ARGS) test/e2e
+	$(GINKGO) -v --timeout=2h --fail-fast $(E2E_TEST_ARGS) test/e2e
 
 .PHONY: e2e-test-coverage
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode && !running-in-cluster' --output-dir=.

--- a/test/e2e/case13_templatization_test.go
+++ b/test/e2e/case13_templatization_test.go
@@ -224,7 +224,8 @@ var _ = Describe("Test templatization", func() {
 
 				return utils.GetStatusMessage(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal(
-				"pods [testvalue] in namespace default found as specified, therefore this Object template is compliant",
+				"pods [testvalue] found as specified, therefore, this object template is compliant in " +
+					"namespace default",
 			))
 			utils.Kubectl("delete", "configurationpolicy", case13LookupSecret, "-n", testNamespace)
 			utils.Kubectl("delete", "configurationpolicy", case13LookupClusterClaim, "-n", testNamespace)

--- a/test/e2e/case15_event_format_test.go
+++ b/test/e2e/case15_event_format_test.go
@@ -51,10 +51,10 @@ var _ = Describe("Testing compliance event formatting", func() {
 
 		By("Checking events on the configurationpolicy")
 		compPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
-			case15AlwaysCompliantName, "", "Policy status is: Compliant", defaultTimeoutSeconds)
+			case15AlwaysCompliantName, "", "Policy status is Compliant", defaultTimeoutSeconds)
 		Expect(compPlcEvents).NotTo(BeEmpty())
 		nonCompPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
-			case15AlwaysCompliantName, "", "Policy status is: NonCompliant", defaultTimeoutSeconds)
+			case15AlwaysCompliantName, "", "Policy status is NonCompliant", defaultTimeoutSeconds)
 		Expect(nonCompPlcEvents).To(BeEmpty())
 
 		By("Checking events on the parent policy")
@@ -83,10 +83,10 @@ var _ = Describe("Testing compliance event formatting", func() {
 
 		By("Checking events on the configurationpolicy")
 		compPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
-			case15NeverCompliantName, "", "Policy status is: Compliant", defaultTimeoutSeconds)
+			case15NeverCompliantName, "", "Policy status is Compliant", defaultTimeoutSeconds)
 		Expect(compPlcEvents).To(BeEmpty())
 		nonCompPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
-			case15NeverCompliantName, "", "Policy status is: NonCompliant", defaultTimeoutSeconds)
+			case15NeverCompliantName, "", "Policy status is NonCompliant", defaultTimeoutSeconds)
 		Expect(nonCompPlcEvents).NotTo(BeEmpty())
 
 		By("Checking events on the parent policy")
@@ -125,15 +125,15 @@ var _ = Describe("Testing compliance event formatting", func() {
 
 		By("Checking for compliant events on the configurationpolicy and the parent policy")
 		compPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
-			case15BecomesCompliantName, "", "Policy status is: Compliant", defaultTimeoutSeconds)
+			case15BecomesCompliantName, "", "Policy status is Compliant", defaultTimeoutSeconds)
 		Expect(compPlcEvents).NotTo(BeEmpty())
 		compParentEventsPreCreation := utils.GetMatchingEvents(clientManaged, testNamespace,
 			case15BecomesCompliantParentName, "policy: "+testNamespace+"/"+case15BecomesCompliantName,
-			"^NonCompliant;.*No instances of.*found as specified", defaultTimeoutSeconds)
+			"^NonCompliant;.*not found in namespace default$", defaultTimeoutSeconds)
 		Expect(compParentEventsPreCreation).NotTo(BeEmpty())
 		compParentEvents := utils.GetMatchingEvents(clientManaged, testNamespace, case15BecomesCompliantParentName,
 			"policy: "+testNamespace+"/"+case15BecomesCompliantName,
-			"^Compliant;.*and was created successfully$", defaultTimeoutSeconds)
+			"^Compliant;.*and was created successfully in namespace default$", defaultTimeoutSeconds)
 		Expect(compParentEvents).NotTo(BeEmpty())
 	})
 	It("Records events for a policy that becomes noncompliant", func() {
@@ -161,7 +161,7 @@ var _ = Describe("Testing compliance event formatting", func() {
 
 		By("Checking for noncompliant events on the configurationpolicy and the parent policy")
 		nonCompPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
-			case15BecomesNonCompliantName, "", "Policy status is: NonCompliant", defaultTimeoutSeconds)
+			case15BecomesNonCompliantName, "", "Policy status is NonCompliant", defaultTimeoutSeconds)
 		Expect(nonCompPlcEvents).NotTo(BeEmpty())
 		nonCompParentEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
 			case15BecomesNonCompliantParentName, "policy: "+testNamespace+"/"+case15BecomesNonCompliantName,

--- a/test/e2e/case17_evaluation_interval_test.go
+++ b/test/e2e/case17_evaluation_interval_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Test evaluation interval", func() {
 			testNamespace,
 			case17PolicyName,
 			"",
-			"Policy status is: NonCompliant",
+			"Policy status is NonCompliant",
 			defaultTimeoutSeconds,
 		)
 		Expect(events).To(HaveLen(1))

--- a/test/e2e/case19_ns_selector_test.go
+++ b/test/e2e/case19_ns_selector_test.go
@@ -48,21 +48,17 @@ var _ = Describe("Test object namespace selection", Ordered, func() {
 		"LabelSelector and exclude": {
 			"{\"exclude\":[\"*-[3-4]-e2e\"],\"matchLabels\":{}," +
 				"\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"Exists\"}]}",
-			"configmaps not found: [configmap-selector-e2e] in namespace case19-2-e2e missing; " +
-				"[configmap-selector-e2e] in namespace case19-5-e2e missing",
+			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-5-e2e",
 		},
 		"empty LabelSelector and include/exclude": {
 			"{\"include\":[\"case19-[2-5]-e2e\"],\"exclude\":[\"*-[3-4]-e2e\"]," +
 				"\"matchLabels\":{},\"matchExpressions\":[]}",
-			"configmaps not found: [configmap-selector-e2e] in namespace case19-2-e2e missing; " +
-				"[configmap-selector-e2e] in namespace case19-5-e2e missing",
+			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-5-e2e",
 		},
 		"LabelSelector": {
 			"{\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"Exists\"}]}",
-			"configmaps not found: [configmap-selector-e2e] in namespace case19-2-e2e missing; " +
-				"[configmap-selector-e2e] in namespace case19-3-e2e missing; " +
-				"[configmap-selector-e2e] in namespace case19-4-e2e missing; " +
-				"[configmap-selector-e2e] in namespace case19-5-e2e missing",
+			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-3-e2e, " +
+				"case19-4-e2e, case19-5-e2e",
 		},
 		"Malformed filepath in include": {
 			"{\"include\":[\"*-[a-z-*\"]}",
@@ -135,8 +131,10 @@ var _ = Describe("Test object namespace selection", Ordered, func() {
 				case19PolicyName, testNamespace, true, defaultTimeoutSeconds)
 
 			return utils.GetStatusMessage(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(ContainSubstring(
-			"[configmap-selector-e2e] in namespace case19-6-e2e missing"))
+		}, defaultTimeoutSeconds, 1).Should(Equal(
+			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-3-e2e, case19-4-e2e, " +
+				"case19-5-e2e, case19-6-e2e",
+		))
 	})
 
 	AfterAll(func() {

--- a/test/e2e/case27_showupdateinstatus_test.go
+++ b/test/e2e/case27_showupdateinstatus_test.go
@@ -29,8 +29,9 @@ var _ = Describe("Verify status update after updating object", Ordered, func() {
 
 			return utils.GetStatusMessage(managedPlc)
 		}, 120, 1).Should(Equal(
-			"configmaps [case27-map] in namespace default found as specified, " +
-				"therefore this Object template is compliant"))
+			"configmaps [case27-map] found as specified, therefore, this object template is compliant in " +
+				"namespace default",
+		))
 	})
 	It("configmap and status should be updated properly on the managed cluster", func() {
 		By("Updating " + case27ConfigPolicyName + " on managed")
@@ -40,8 +41,7 @@ var _ = Describe("Verify status update after updating object", Ordered, func() {
 				case27ConfigPolicyName, testNamespace, true, defaultTimeoutSeconds)
 
 			return utils.GetStatusMessage(managedPlc)
-		}, 30, 0.5).Should(Equal(
-			"configmaps [case27-map] in namespace default was updated successfully"))
+		}, 30, 0.5).Should(Equal("configmaps [case27-map] was updated successfully in namespace default"))
 	})
 
 	AfterAll(func() {

--- a/test/e2e/case4_clusterversion_test.go
+++ b/test/e2e/case4_clusterversion_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Test cluster version obj template handling", func() {
 
 				return utils.GetStatusMessage(managedPlc)
 			}, 120, 1).Should(Equal(
-				"clusterversions [version] found as specified, therefore this Object template is compliant"))
+				"clusterversions [version] found as specified, therefore, this object template is compliant"))
 		})
 		It("Cleans up", func() {
 			policies := []string{

--- a/test/e2e/case5_multi_test.go
+++ b/test/e2e/case5_multi_test.go
@@ -141,41 +141,30 @@ var _ = Describe("Test multiple obj template handling", func() {
 				case5KindNameMissPlcName, 0, defaultTimeoutSeconds, kindNameErrMsg)
 
 			By("Name missing")
-			nameErrMsg := "No instances of `pods` found as specified in namespaces: n1, n2, n3"
+			nameErrMsg := "pods not found in namespaces: n1, n2, n3"
 			utils.DoConfigPolicyMessageTest(clientManagedDynamic, gvrConfigPolicy, testNamespace,
 				case5NameMissPlcName, 0, defaultTimeoutSeconds, nameErrMsg)
 		})
 		It("Should show merged Noncompliant messages when it is multiple namespaces and inform", func() {
-			expectedMsg := "pods not found: [case5-multi-namespace-inform-pod] " +
-				"in namespace n1 missing; [case5-multi-namespace-inform-pod] " +
-				"in namespace n2 missing; [case5-multi-namespace-inform-pod] " +
-				"in namespace n3 missing"
+			expectedMsg := "pods [case5-multi-namespace-inform-pod] not found in namespaces: n1, n2, n3"
 			utils.Kubectl("apply", "-f", case5InformYaml)
 			utils.DoConfigPolicyMessageTest(clientManagedDynamic, gvrConfigPolicy, testNamespace,
 				case5MultiNSInformConfigPolicyName, 0, defaultTimeoutSeconds, expectedMsg)
 		})
 		It("Should show merged messages when it is multiple namespaces", func() {
-			expectedMsg := "Pod [case5-multi-namespace-enforce-pod] in namespace n1 found; " +
-				"[case5-multi-namespace-enforce-pod] in namespace n2 found; " +
-				"[case5-multi-namespace-enforce-pod] in namespace n3 found " +
-				"as specified, therefore this Object template is compliant"
+			expectedMsg := "pods [case5-multi-namespace-enforce-pod] found as specified, therefore, this object " +
+				"template is compliant in namespaces: n1, n2, n3"
 			utils.Kubectl("apply", "-f", case5EnforceYaml)
 			utils.DoConfigPolicyMessageTest(clientManagedDynamic, gvrConfigPolicy, testNamespace,
 				case5MultiNSConfigPolicyName, 0, defaultTimeoutSeconds, expectedMsg)
 		})
 		It("Should show 3 merged messages when it is multiple namespaces and multiple obj-template", func() {
-			firstMsg := "Pod [case5-multi-obj-temp-pod-11] in namespace n1 found; " +
-				"[case5-multi-obj-temp-pod-11] in namespace n2 found; " +
-				"[case5-multi-obj-temp-pod-11] in namespace n3 found " +
-				"as specified, therefore this Object template is compliant"
-			secondMsg := "Pod [case5-multi-obj-temp-pod-22] in namespace n1 found; " +
-				"[case5-multi-obj-temp-pod-22] in namespace n2 found; " +
-				"[case5-multi-obj-temp-pod-22] in namespace n3 found " +
-				"as specified, therefore this Object template is compliant"
-			thirdMsg := "Pod [case5-multi-obj-temp-pod-33] in namespace n1 found; " +
-				"[case5-multi-obj-temp-pod-33] in namespace n2 found; " +
-				"[case5-multi-obj-temp-pod-33] in namespace n3 found " +
-				"as specified, therefore this Object template is compliant"
+			firstMsg := "pods [case5-multi-obj-temp-pod-11] found as specified, therefore, this object template is " +
+				"compliant in namespaces: n1, n2, n3"
+			secondMsg := "pods [case5-multi-obj-temp-pod-22] found as specified, therefore, this object template is " +
+				"compliant in namespaces: n1, n2, n3"
+			thirdMsg := "pods [case5-multi-obj-temp-pod-33] found as specified, therefore, this object template is " +
+				"compliant in namespaces: n1, n2, n3"
 			utils.Kubectl("apply", "-f", case5MultiObjTmpYaml)
 			utils.DoConfigPolicyMessageTest(clientManagedDynamic, gvrConfigPolicy, testNamespace,
 				case5MultiObjNSConfigPolicyName, 0, defaultTimeoutSeconds, firstMsg)

--- a/test/e2e/case8_status_check_test.go
+++ b/test/e2e/case8_status_check_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case8ConfigPolicyNamePod,
 				case8ConfigPolicyNameCheck,


### PR DESCRIPTION
The code is ready for review but I will need to update some E2E tests.

This refactoring takes away the responsibility of individual methods of updating the status and instead they return one or more status events. The handleObjectTemplates method then generates status events using the entire context of results from the object-template to be able to consolidate messages and include different messages per namespace.

Relates:
https://issues.redhat.com/browse/ACM-5175