### PR TITLE
:memo: Parallelize the Config Policy controller E2E tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -27,89 +27,90 @@ jobs:
         # The "minimum" tag is set in the Makefile
         # KinD tags: https://hub.docker.com/r/kindest/node/tags
         kind:
-          - 'minimum'
-          - 'latest'
+          - "minimum"
+          - "latest"
     name: KinD tests
     steps:
-    - name: Checkout Config Policy Controller
-      uses: actions/checkout@v3
-      with:
-        path: config-policy-controller
-        fetch-depth: 0 # Fetch all history for all tags and branches
+      - name: Checkout Config Policy Controller
+        uses: actions/checkout@v3
+        with:
+          path: config-policy-controller
+          fetch-depth: 0 # Fetch all history for all tags and branches
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      id: go
-      with:
-        go-version-file: config-policy-controller/go.mod
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        id: go
+        with:
+          go-version-file: config-policy-controller/go.mod
 
-    - name: Verify modules
-      run: |
-        go mod verify
+      - name: Verify modules
+        run: |
+          go mod verify
 
-    - name: Verify format
-      run: |
-        make fmt
-        git diff --exit-code
-        make lint
+      - name: Verify format
+        run: |
+          make fmt
+          git diff --exit-code
+          make lint
 
-    - name: Verify deploy/operator.yaml
-      run: |
-        make generate-operator-yaml
-        git diff --exit-code
+      - name: Verify deploy/operator.yaml
+        run: |
+          make generate-operator-yaml
+          git diff --exit-code
 
-    - name: Unit and Integration Tests
-      run: |
-        make test
+      - name: Unit and Integration Tests
+        run: |
+          make test
 
-    - name: Create K8s KinD Cluster - ${{ matrix.kind }}
-      env:
-        KIND_VERSION: ${{ matrix.kind }}
-      run: |
-        make kind-bootstrap-cluster-dev
+      - name: Create K8s KinD Cluster - ${{ matrix.kind }}
+        env:
+          KIND_VERSION: ${{ matrix.kind }}
+        run: |
+          make kind-bootstrap-cluster-dev
 
-    - name: Ensure Service Account kubeconfig
-      run: |
-        KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
+      - name: Ensure Service Account kubeconfig
+        run: |
+          KUBECONFIG=${PWD}/kubeconfig_managed make kind-ensure-sa
 
-    - name: E2E Tests
-      run: |
-        export GOPATH=$(go env GOPATH)
-        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
+      - name: E2E Tests
+        run: |
+          kubectl get pod -A
+          export GOPATH=$(go env GOPATH)
+          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
-    - name: Create K8s KinD Cluster to simulate hosted mode - ${{ matrix.kind }}
-      env:
-        KIND_VERSION: ${{ matrix.kind }}
-      run: |
-        make kind-additional-cluster
+      - name: Create K8s KinD Cluster to simulate hosted mode - ${{ matrix.kind }}
+        env:
+          KIND_VERSION: ${{ matrix.kind }}
+        run: |
+          make kind-additional-cluster
 
-    - name: E2E tests that simulate hosted mode
-      run: |
-        export GOPATH=$(go env GOPATH)
-        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
+      - name: E2E tests that simulate hosted mode
+        run: |
+          export GOPATH=$(go env GOPATH)
+          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
 
-    - name: Verify Deployment Configuration
-      run: |
-        make build-images
-        KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
+      - name: Verify Deployment Configuration
+        run: |
+          make build-images
+          KUBECONFIG=${PWD}/kubeconfig_managed_e2e make kind-deploy-controller-dev
 
-    - name: E2E tests that require the controller running in a cluster
-      run: |
-        export GOPATH=$(go env GOPATH)
-        KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-running-in-cluster
+      - name: E2E tests that require the controller running in a cluster
+        run: |
+          export GOPATH=$(go env GOPATH)
+          KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-running-in-cluster
 
-    - name: Test Coverage Verification
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        make test-coverage
-        make coverage-verify
+      - name: Test Coverage Verification
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          make test-coverage
+          make coverage-verify
 
-    - name: Debug
-      if: ${{ failure() }}
-      run: |
-        make e2e-debug
+      - name: Debug
+        if: ${{ failure() }}
+        run: |
+          make e2e-debug
 
-    - name: Clean up cluster
-      if: ${{ always() }}
-      run: |
-        make kind-delete-cluster
+      - name: Clean up cluster
+        if: ${{ always() }}
+        run: |
+          make kind-delete-cluster

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ install-resources:
 
 .PHONY: e2e-test
 e2e-test: e2e-dependencies
-	$(GINKGO) -v --timeout=2h --fail-fast $(E2E_TEST_ARGS) test/e2e
+	$(GINKGO) -v -p -procs=20 --fail-fast $(E2E_TEST_ARGS) test/e2e
 
 .PHONY: e2e-test-coverage
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode && !running-in-cluster' --output-dir=.

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/go-cmp v0.5.9
-	github.com/onsi/ginkgo/v2 v2.9.4
-	github.com/onsi/gomega v1.27.6
+	github.com/onsi/ginkgo/v2 v2.9.7
+	github.com/onsi/gomega v1.27.8
 	github.com/prometheus/client_golang v1.15.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
@@ -80,14 +80,14 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
-	golang.org/x/net v0.9.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
-	golang.org/x/tools v0.8.0 // indirect
+	golang.org/x/tools v0.9.1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,10 +156,10 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
-github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
-github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
-github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/onsi/ginkgo/v2 v2.9.7 h1:06xGQy5www2oN160RtEZoTvnP2sPhEfePYmCDc2szss=
+github.com/onsi/ginkgo/v2 v2.9.7/go.mod h1:cxrmXWykAwTwhQsJOPfdIDiJ+l2RYq7U8hFU+M/1uw0=
+github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
+github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -256,8 +256,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
-golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=
@@ -303,8 +303,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
-golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
-golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
+golang.org/x/tools v0.9.1 h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=
+golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/test/e2e/case10_kind_field_test.go
+++ b/test/e2e/case10_kind_field_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 var _ = Describe("Test pod obj template handling", func() {
-	Describe("Create a pod policy on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a pod policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should create a policy properly on the managed cluster", func() {
 			By("Creating " + case10ConfigPolicyNamePod + " on managed")
 			utils.Kubectl("apply", "-f", case10PolicyYamlPod, "-n", testNamespace)
@@ -60,7 +60,7 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case10ConfigPolicyNamePod,
 				case10ConfigPolicyNameCheck,

--- a/test/e2e/case11_apiserver_config_test.go
+++ b/test/e2e/case11_apiserver_config_test.go
@@ -24,8 +24,8 @@ const (
 	tlsProfileInformYaml             string = "../resources/case11_apiserver_config/tls_profile_inform.yaml"
 )
 
-var _ = Describe("Test APIServer Config policy", func() {
-	Describe("Test etcd encryption and tls profile", func() {
+var _ = Describe("Test APIServer Config policy", Serial, func() {
+	Describe("Test etcd encryption and tls profile", Ordered, func() {
 		It("should be noncompliant for no encryption", func() {
 			By("Creating " + etcdEncryptionInformYaml + " on managed")
 			utils.Kubectl("apply", "-f", etcdEncryptionInformYaml, "-n", testNamespace)
@@ -122,7 +122,7 @@ var _ = Describe("Test APIServer Config policy", func() {
 				return utils.GetComplianceState(informPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				etcdEncryptionEnforceName,
 				etcdEncryptionInformName,

--- a/test/e2e/case12_list_compare_test.go
+++ b/test/e2e/case12_list_compare_test.go
@@ -15,6 +15,7 @@ import (
 const (
 	case12ConfigPolicyNameInform  string = "policy-pod-mh-listinform"
 	case12ConfigPolicyNameEnforce string = "policy-pod-create-listinspec"
+	case12PodName                 string = "nginx-pod-e2e-12"
 	case12InformYaml              string = "../resources/case12_list_compare/case12_pod_inform.yaml"
 	case12EnforceYaml             string = "../resources/case12_list_compare/case12_pod_create.yaml"
 )
@@ -77,7 +78,7 @@ const (
 )
 
 var _ = Describe("Test list handling for musthave", func() {
-	Describe("Create a policy with a nested list on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a policy with a nested list on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case12ConfigPolicyNameEnforce + " and " + case12ConfigPolicyNameInform + " on managed")
 			utils.Kubectl("apply", "-f", case12EnforceYaml, "-n", testNamespace)
@@ -101,16 +102,18 @@ var _ = Describe("Test list handling for musthave", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case12ConfigPolicyNameInform,
 				case12ConfigPolicyNameEnforce,
 			}
 
 			deleteConfigPolicies(policies)
+
+			utils.Kubectl("delete", "pod", case12PodName, "-n", "default", "--ignore-not-found")
 		})
 	})
-	Describe("Create a policy with a list field on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a policy with a list field on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case12ConfigPolicyNameRoleEnforce + " and " +
 				case12ConfigPolicyNameRoleInform + " on managed")
@@ -135,7 +138,7 @@ var _ = Describe("Test list handling for musthave", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case12ConfigPolicyNameRoleInform,
 				case12ConfigPolicyNameRoleEnforce,
@@ -144,7 +147,7 @@ var _ = Describe("Test list handling for musthave", func() {
 			deleteConfigPolicies(policies)
 		})
 	})
-	Describe("Create and patch a role on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create and patch a role on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case12RoleToPatch + " and " + case12RolePatchEnforce + " on managed")
 			utils.Kubectl("apply", "-f", case12RoleToPatchYaml, "-n", testNamespace)
@@ -178,7 +181,7 @@ var _ = Describe("Test list handling for musthave", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case12RoleToPatch,
 				case12RolePatchEnforce,
@@ -188,7 +191,7 @@ var _ = Describe("Test list handling for musthave", func() {
 			deleteConfigPolicies(policies)
 		})
 	})
-	Describe("Create and patch an oauth object on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create and patch an oauth object on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case12OauthCreate + " and " + case12OauthPatch + " on managed")
 			utils.Kubectl("apply", "-f", case12OauthCreateYaml, "-n", testNamespace)
@@ -295,7 +298,7 @@ var _ = Describe("Test list handling for musthave", func() {
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
 
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case12OauthCreate,
 				case12OauthPatch,
@@ -311,7 +314,7 @@ var _ = Describe("Test list handling for musthave", func() {
 			deleteConfigPolicies(policies)
 		})
 	})
-	Describe("Create a deployment object with env vars on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a deployment object with env vars on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should only add the list item with prefix and suffix whitespace once", func() {
 			By("Creating " + case12WhitespaceListCreate + " and " + case12WhitespaceListInform + " on managed")
 			utils.Kubectl("apply", "-f", case12WhitespaceListCreateYaml, "-n", testNamespace)
@@ -347,7 +350,7 @@ var _ = Describe("Test list handling for musthave", func() {
 			Expect(envvars).To(HaveLen(1))
 		})
 
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case12WhitespaceListCreate,
 				case12WhitespaceListInform,

--- a/test/e2e/case16_policy_template_decryption_test.go
+++ b/test/e2e/case16_policy_template_decryption_test.go
@@ -27,134 +27,136 @@ const (
 	case16SecretDiffKey          = "../resources/case16_policy_template_decryption/secret-diff-key.yaml"
 )
 
-var _ = Describe("Test policy template decryption", func() {
-	It("deletes the namespace "+case16CreatedNamespace, func() {
-		utils.Kubectl("delete", "namespace", case16CreatedNamespace, "--ignore-not-found")
+var _ = Describe("Test policy template decryption", Ordered, func() {
+	Describe("Test policy template decryption with new key", Ordered, func() {
+		It("deletes the namespace "+case16CreatedNamespace, func() {
+			utils.Kubectl("delete", "namespace", case16CreatedNamespace, "--ignore-not-found")
+		})
+
+		It("creates the policy-encryption-key secret in "+testNamespace, func() {
+			utils.Kubectl("apply", "-f", case16Secret, "-n", testNamespace)
+		})
+
+		It("creates the policy "+case16PolicyName+" in "+testNamespace, func() {
+			utils.Kubectl("apply", "-f", case16Policy, "-n", testNamespace)
+		})
+
+		It("verifies the policy "+case16PolicyName+" in "+testNamespace, func() {
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(
+					clientManagedDynamic, gvrConfigPolicy, case16PolicyName, testNamespace, true, defaultTimeoutSeconds,
+				)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		})
+
+		It("simulates a key rotation", func() {
+			utils.Kubectl("apply", "-f", case16SecretDiffKey, "-n", testNamespace)
+		})
+
+		It("Creates the policy "+case16PolicyDiffKeyName+" in "+testNamespace+" that uses the new key", func() {
+			utils.Kubectl("apply", "-f", case16PolicyDiffKey, "-n", testNamespace)
+		})
+
+		It("verifies the policy "+case16PolicyDiffKeyName+" in "+testNamespace, func() {
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(
+					clientManagedDynamic,
+					gvrConfigPolicy,
+					case16PolicyDiffKeyName,
+					testNamespace,
+					true,
+					defaultTimeoutSeconds,
+				)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		})
+
+		It("verifies that the policy "+case16PolicyName+" in "+testNamespace+" is still compliant", func() {
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(
+					clientManagedDynamic,
+					gvrConfigPolicy,
+					case16PolicyName,
+					testNamespace,
+					true,
+					defaultTimeoutSeconds,
+				)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		})
+
+		AfterAll(func() {
+			utils.Kubectl("delete", "-f", case16Policy, "-n", testNamespace)
+			utils.Kubectl("delete", "-f", case16PolicyDiffKey, "-n", testNamespace)
+			utils.Kubectl("delete", "-f", case16Secret, "-n", testNamespace)
+			utils.Kubectl("delete", "namespace", case16CreatedNamespace, "--ignore-not-found")
+			utils.Kubectl("delete", "namespace", case16SecondCreatedNamespace, "--ignore-not-found")
+		})
 	})
 
-	It("creates the policy-encryption-key secret in "+testNamespace, func() {
-		utils.Kubectl("apply", "-f", case16Secret, "-n", testNamespace)
+	Describe("Test policy template decryption with an invalid AES key", Ordered, func() {
+		It("creates the invalid policy-encryption-key secret in "+testNamespace, func() {
+			utils.Kubectl("apply", "-f", case16SecretInvalid, "-n", testNamespace)
+		})
+
+		It("creates the policy "+case16PolicyInvalidKeyName+" in "+testNamespace, func() {
+			utils.Kubectl("apply", "-f", case16PolicyInvalidKey, "-n", testNamespace)
+		})
+
+		It("verifies the policy "+case16PolicyInvalidKeyName+" in "+testNamespace+" is noncompliant", func() {
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(
+					clientManagedDynamic,
+					gvrConfigPolicy,
+					case16PolicyInvalidKeyName,
+					testNamespace,
+					true,
+					defaultTimeoutSeconds,
+				)
+
+				return utils.GetStatusMessage(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal(`The "policy-encryption-key" Secret contains an invalid AES key`))
+		})
+
+		AfterAll(func() {
+			utils.Kubectl("delete", "-f", case16PolicyInvalidKey, "-n", testNamespace)
+			utils.Kubectl("delete", "-f", case16Secret, "-n", testNamespace)
+		})
 	})
 
-	It("creates the policy "+case16PolicyName+" in "+testNamespace, func() {
-		utils.Kubectl("apply", "-f", case16Policy, "-n", testNamespace)
-	})
+	Describe("Test policy template decryption with an invalid initialization vector", Ordered, func() {
+		It("creates the policy-encryption-key secret in "+testNamespace, func() {
+			utils.Kubectl("apply", "-f", case16Secret, "-n", testNamespace)
+		})
 
-	It("verifies the policy "+case16PolicyName+" in "+testNamespace, func() {
-		Eventually(func() interface{} {
-			managedPlc := utils.GetWithTimeout(
-				clientManagedDynamic, gvrConfigPolicy, case16PolicyName, testNamespace, true, defaultTimeoutSeconds,
-			)
+		It("creates the policy "+case16PolicyInvalidIVName+" in "+testNamespace, func() {
+			utils.Kubectl("apply", "-f", case16PolicyInvalidIV, "-n", testNamespace)
+		})
 
-			return utils.GetComplianceState(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
-	})
+		It("verifies the policy "+case16PolicyInvalidIVName+" in "+testNamespace+" is noncompliant", func() {
+			expected := `The "policy.open-cluster-management.io/encryption-iv" annotation value is not a valid ` +
+				"initialization vector"
+			Eventually(func() interface{} {
+				managedPlc := utils.GetWithTimeout(
+					clientManagedDynamic,
+					gvrConfigPolicy,
+					case16PolicyInvalidIVName,
+					testNamespace,
+					true,
+					defaultTimeoutSeconds,
+				)
 
-	It("simulates a key rotation", func() {
-		utils.Kubectl("apply", "-f", case16SecretDiffKey, "-n", testNamespace)
-	})
+				return utils.GetStatusMessage(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal(expected))
+		})
 
-	It("Creates the policy "+case16PolicyDiffKeyName+" in "+testNamespace+" that uses the new key", func() {
-		utils.Kubectl("apply", "-f", case16PolicyDiffKey, "-n", testNamespace)
-	})
-
-	It("verifies the policy "+case16PolicyDiffKeyName+" in "+testNamespace, func() {
-		Eventually(func() interface{} {
-			managedPlc := utils.GetWithTimeout(
-				clientManagedDynamic,
-				gvrConfigPolicy,
-				case16PolicyDiffKeyName,
-				testNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-
-			return utils.GetComplianceState(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
-	})
-
-	It("verifies that the policy "+case16PolicyName+" in "+testNamespace+" is still compliant", func() {
-		Eventually(func() interface{} {
-			managedPlc := utils.GetWithTimeout(
-				clientManagedDynamic,
-				gvrConfigPolicy,
-				case16PolicyName,
-				testNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-
-			return utils.GetComplianceState(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
-	})
-
-	It("cleans up", func() {
-		utils.Kubectl("delete", "-f", case16Policy, "-n", testNamespace)
-		utils.Kubectl("delete", "-f", case16PolicyDiffKey, "-n", testNamespace)
-		utils.Kubectl("delete", "-f", case16Secret, "-n", testNamespace)
-		utils.Kubectl("delete", "namespace", case16CreatedNamespace, "--ignore-not-found")
-		utils.Kubectl("delete", "namespace", case16SecondCreatedNamespace, "--ignore-not-found")
-	})
-})
-
-var _ = Describe("Test policy template decryption with an invalid AES key", func() {
-	It("creates the invalid policy-encryption-key secret in "+testNamespace, func() {
-		utils.Kubectl("apply", "-f", case16SecretInvalid, "-n", testNamespace)
-	})
-
-	It("creates the policy "+case16PolicyInvalidKeyName+" in "+testNamespace, func() {
-		utils.Kubectl("apply", "-f", case16PolicyInvalidKey, "-n", testNamespace)
-	})
-
-	It("verifies the policy "+case16PolicyInvalidKeyName+" in "+testNamespace+" is noncompliant", func() {
-		Eventually(func() interface{} {
-			managedPlc := utils.GetWithTimeout(
-				clientManagedDynamic,
-				gvrConfigPolicy,
-				case16PolicyInvalidKeyName,
-				testNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-
-			return utils.GetStatusMessage(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal(`The "policy-encryption-key" Secret contains an invalid AES key`))
-	})
-
-	It("cleans up", func() {
-		utils.Kubectl("delete", "-f", case16PolicyInvalidKey, "-n", testNamespace)
-		utils.Kubectl("delete", "-f", case16Secret, "-n", testNamespace)
-	})
-})
-
-var _ = Describe("Test policy template decryption with an invalid initialization vector", func() {
-	It("creates the policy-encryption-key secret in "+testNamespace, func() {
-		utils.Kubectl("apply", "-f", case16Secret, "-n", testNamespace)
-	})
-
-	It("creates the policy "+case16PolicyInvalidIVName+" in "+testNamespace, func() {
-		utils.Kubectl("apply", "-f", case16PolicyInvalidIV, "-n", testNamespace)
-	})
-
-	It("verifies the policy "+case16PolicyInvalidIVName+" in "+testNamespace+" is noncompliant", func() {
-		expected := `The "policy.open-cluster-management.io/encryption-iv" annotation value is not a valid ` +
-			"initialization vector"
-		Eventually(func() interface{} {
-			managedPlc := utils.GetWithTimeout(
-				clientManagedDynamic,
-				gvrConfigPolicy,
-				case16PolicyInvalidIVName,
-				testNamespace,
-				true,
-				defaultTimeoutSeconds,
-			)
-
-			return utils.GetStatusMessage(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal(expected))
-	})
-
-	It("cleans up", func() {
-		utils.Kubectl("delete", "-f", case16PolicyInvalidIV, "-n", testNamespace)
-		utils.Kubectl("delete", "-f", case16Secret, "-n", testNamespace)
+		AfterAll(func() {
+			utils.Kubectl("delete", "-f", case16PolicyInvalidIV, "-n", testNamespace)
+			utils.Kubectl("delete", "-f", case16Secret, "-n", testNamespace)
+		})
 	})
 })

--- a/test/e2e/case17_evaluation_interval_test.go
+++ b/test/e2e/case17_evaluation_interval_test.go
@@ -27,7 +27,7 @@ const (
 	case17CreatedNamespaceName = "case17-test-never"
 )
 
-var _ = Describe("Test evaluation interval", func() {
+var _ = Describe("Test evaluation interval", Ordered, func() {
 	It("Verifies that status.lastEvaluated is properly set", func() {
 		createConfigPolicyWithParent(case17ParentPolicy, case17ParentPolicyName, case17Policy)
 
@@ -140,7 +140,7 @@ var _ = Describe("Test evaluation interval", func() {
 		Expect(lastEvalRefreshed).To(Equal(lastEvaluated))
 	})
 
-	It("Cleans up", func() {
+	AfterAll(func() {
 		utils.Kubectl("delete", "-f", case17ParentPolicy, "-n", testNamespace)
 		utils.Kubectl("delete", "-f", case17Policy, "-n", testNamespace, "--ignore-not-found")
 		utils.Kubectl("delete", "-f", case17PolicyNever, "-n", testNamespace)

--- a/test/e2e/case1_pod_handling_test.go
+++ b/test/e2e/case1_pod_handling_test.go
@@ -26,8 +26,8 @@ const (
 	case1PolicyYamlMultipleCheckMH    string = "../resources/case1_pod_handling/case1_pod_check_multiple_mh.yaml"
 )
 
-var _ = Describe("Test pod obj template handling", func() {
-	Describe("Create a policy on managed cluster in ns:"+testNamespace, func() {
+var _ = Describe("Test pod obj template handling", Ordered, func() {
+	Describe("Create a policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case1PolicyYamlInform + " on managed")
 			utils.Kubectl("apply", "-f", case1PolicyYamlInform, "-n", testNamespace)
@@ -145,7 +145,7 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case1ConfigPolicyNameInform,
 				case1ConfigPolicyNameEnforce,
@@ -159,6 +159,11 @@ var _ = Describe("Test pod obj template handling", func() {
 				"policy-pod-emptycontainerlist",
 			}
 			deleteConfigPolicies(policies)
+
+			By("Delete pods")
+			pods := []string{case1PodName, case1PodName + "-empty", case1PodName + "-multi"}
+			namespaces := []string{testNamespace, "default"}
+			deletePods(pods, namespaces)
 		})
 	})
 })

--- a/test/e2e/case23_invalid_field_test.go
+++ b/test/e2e/case23_invalid_field_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Test an objectDefinition with an invalid field", Ordered, func
 		Consistently(func() interface{} {
 			compPlcEvents := utils.GetMatchingEvents(clientManaged, testNamespace,
 				policyName,
-				"",
+				"Policy updated",
 				msg,
 				defaultTimeoutSeconds)
 

--- a/test/e2e/case28_evauluation_metric_test.go
+++ b/test/e2e/case28_evauluation_metric_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
@@ -15,6 +14,7 @@ import (
 var _ = Describe("Test config policy evaluation metrics", Ordered, func() {
 	const (
 		policyName = "policy-cfgmap-watch"
+		configMap  = "case28-ConfigMap"
 		policyYaml = "../resources/case28_evaluation_metric/case28_policy.yaml"
 	)
 
@@ -99,9 +99,11 @@ var _ = Describe("Test config policy evaluation metrics", Ordered, func() {
 			"-f", policyYaml,
 			"-n", testNamespace)
 		_, _ = cmd.CombinedOutput()
-		opt := metav1.ListOptions{}
-		utils.ListWithTimeout(
-			clientManagedDynamic, gvrConfigPolicy, opt, 0, false, defaultTimeoutSeconds)
+
+		By("Check configmap removed")
+		utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+			configMap, "default", false, defaultTimeoutSeconds)
+
 		Eventually(func() interface{} {
 			return utils.GetMetrics(
 				"config_policy_evaluation_total", fmt.Sprintf(`name=\"%s\"`, policyName))

--- a/test/e2e/case2_role_handling_test.go
+++ b/test/e2e/case2_role_handling_test.go
@@ -21,8 +21,8 @@ const (
 	case2PolicyCheckCompliant    string = "../resources/case2_role_handling/case2_role_check-c.yaml"
 )
 
-var _ = Describe("Test role obj template handling", func() {
-	Describe("Create a policy on managed cluster in ns:"+testNamespace, func() {
+var _ = Describe("Test role obj template handling", Ordered, func() {
+	Describe("Create a policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case2PolicyYamlInform + " on managed")
 			utils.Kubectl("apply", "-f", case2PolicyYamlInform, "-n", testNamespace)
@@ -90,7 +90,8 @@ var _ = Describe("Test role obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
+			By("clean up case2")
 			policies := []string{
 				case2ConfigPolicyNameInform,
 				case2ConfigPolicyNameEnforce,
@@ -99,6 +100,7 @@ var _ = Describe("Test role obj template handling", func() {
 				"policy-role-check-moh",
 			}
 			deleteConfigPolicies(policies)
+			utils.Kubectl("delete", "role", "pod-reader-e2e", "-n", "default", "--ignore-not-found")
 		})
 	})
 })

--- a/test/e2e/case30_multiline_templatization_test.go
+++ b/test/e2e/case30_multiline_templatization_test.go
@@ -21,6 +21,8 @@ const (
 	case30RangePolicyYaml      string = "../resources/case30_multiline_templatization/case30_policy.yaml"
 	case30NoTemplatePolicyYaml string = "../resources/case30_multiline_templatization/case30_policy_notemplate.yaml"
 	case30ConfigMapsYaml       string = "../resources/case30_multiline_templatization/case30_configmaps.yaml"
+	case30ConfigmapName1       string = "30config1"
+	case30ConfigmapName2       string = "30config2"
 )
 
 const (
@@ -108,6 +110,10 @@ var _ = Describe("Test multiline templatization", Ordered, func() {
 		AfterAll(func() {
 			deleteConfigPolicies([]string{case30RangePolicyName, case30NoTemplatePolicyName})
 			utils.Kubectl("delete", "-f", case30ConfigMapsYaml)
+			utils.Kubectl("delete", "configmap", case30ConfigmapName1,
+				"-n", "default", "--ignore-not-found")
+			utils.Kubectl("delete", "configmap", case30ConfigmapName2,
+				"-n", "default", "--ignore-not-found")
 		})
 	})
 	Describe("Test invalid multiline templates", func() {

--- a/test/e2e/case31_policy_history_test.go
+++ b/test/e2e/case31_policy_history_test.go
@@ -14,7 +14,7 @@ import (
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
-var _ = Describe("Test policy history messages when KubeAPI omits values in the returned object", Ordered, func() {
+var _ = Describe("Test policy history messages when KubeAPI omits values in the returned object", func() {
 	doHistoryTest := func(policyName, configPolicyName string) {
 		By("Waiting until the policy is initially compliant")
 		Eventually(func() interface{} {
@@ -153,7 +153,7 @@ var _ = Describe("Test policy history messages when KubeAPI omits values in the 
 			ExpectWithOffset(1, configlPlc).To(BeNil())
 		})
 	})
-	Describe("policy message should not be truncated", func() {
+	Describe("policy message should not be truncated", Ordered, func() {
 		const (
 			case31LMPolicy           = "../resources/case31_policy_history/long-message-policy.yaml"
 			case31LMConfigPolicy     = "../resources/case31_policy_history/long-message-config-policy.yaml"
@@ -208,9 +208,11 @@ var _ = Describe("Test policy history messages when KubeAPI omits values in the 
 			)
 			Expect(configlPlc).To(BeNil())
 			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31LMPolicyName, "-n", "managed")
+				"--field-selector=involvedObject.name="+case31LMPolicyName,
+				"-n", "managed", "--ignore-not-found")
 			utils.Kubectl("delete", "event",
-				"--field-selector=involvedObject.name="+case31LMConfigPolicy, "-n", "managed")
+				"--field-selector=involvedObject.name="+case31LMConfigPolicy,
+				"-n", "managed", "--ignore-not-found")
 			for i := range [15]int{} {
 				utils.Kubectl("delete", "ns", namespacePrefix+strconv.Itoa(i+1),
 					"--ignore-not-found", "--force", "--grace-period=0")

--- a/test/e2e/case3_imgvuln_test.go
+++ b/test/e2e/case3_imgvuln_test.go
@@ -22,7 +22,7 @@ const (
 )
 
 var _ = Describe("Test img vulnerability obj template handling", func() {
-	Describe("Create a clusterserviceversion on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a clusterserviceversion on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case3ConfigPolicyNameCSV + " on managed")
 			utils.Kubectl("apply", "-f", case3PolicyYamlCSV, "-n", testNamespace)

--- a/test/e2e/case4_clusterversion_test.go
+++ b/test/e2e/case4_clusterversion_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 var _ = Describe("Test cluster version obj template handling", func() {
-	Describe("enforce patch on unnamespaced resource clusterversion "+testNamespace, func() {
+	Describe("enforce patch on unnamespaced resource clusterversion "+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case4ConfigPolicyName + " on managed")
 			utils.Kubectl("apply", "-f", case4PolicyYaml, "-n", testNamespace)
@@ -47,6 +47,7 @@ var _ = Describe("Test cluster version obj template handling", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+			utils.Kubectl("delete", "configurationpolicy", case4ConfigPolicyNamePatch, "-n", testNamespace)
 		})
 		It("should be generate status properly for cluster-level resources", func() {
 			By("Creating " + case4ConfigPolicyNameInform + " on managed")
@@ -60,8 +61,10 @@ var _ = Describe("Test cluster version obj template handling", func() {
 
 				return utils.GetStatusMessage(managedPlc)
 			}, 120, 1).Should(Equal("clusterversions [version] found as specified"))
+
+			utils.Kubectl("delete", "configurationpolicy", case4ConfigPolicyNameInform, "-n", testNamespace)
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case4ConfigPolicyName,
 				case4ConfigPolicyNameInform,

--- a/test/e2e/case5_multi_test.go
+++ b/test/e2e/case5_multi_test.go
@@ -14,15 +14,15 @@ const (
 	case5ConfigPolicyNameInform  string = "policy-pod-multi-mh"
 	case5ConfigPolicyNameEnforce string = "policy-pod-multi-create"
 	case5ConfigPolicyNameCombo   string = "policy-pod-multi-combo"
-	case5PodName1                string = "nginx-pod-1"
-	case5PodName2                string = "nginx-pod-1"
+	case5PodName1                string = "case5-nginx-pod-1"
+	case5PodName2                string = "case5-nginx-pod-2"
 	case5InformYaml              string = "../resources/case5_multi/case5_multi_mh.yaml"
 	case5EnforceYaml             string = "../resources/case5_multi/case5_multi_enforce.yaml"
 	case5ComboYaml               string = "../resources/case5_multi/case5_multi_combo.yaml"
 )
 
 var _ = Describe("Test multiple obj template handling", func() {
-	Describe("Create a policy on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case5ConfigPolicyNameInform + " and " + case5ConfigPolicyNameCombo + " on managed")
 			utils.Kubectl("apply", "-f", case5InformYaml, "-n", testNamespace)
@@ -77,7 +77,7 @@ var _ = Describe("Test multiple obj template handling", func() {
 				case5PodName2, "default", true, defaultTimeoutSeconds)
 			Expect(pod2).NotTo(BeNil())
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case5ConfigPolicyNameInform,
 				case5ConfigPolicyNameEnforce,
@@ -85,6 +85,11 @@ var _ = Describe("Test multiple obj template handling", func() {
 			}
 
 			deleteConfigPolicies(policies)
+
+			By("Delete pods")
+			pods := []string{case5PodName1, case5PodName2}
+			namespaces := []string{"default"}
+			deletePods(pods, namespaces)
 		})
 	})
 

--- a/test/e2e/case6_no_ns_test.go
+++ b/test/e2e/case6_no_ns_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	case6ConfigPolicyNameNS    string = "policy-ns"
-	case6ConfigPolicyNameRole  string = "role-policy-no-ns"
-	case6ConfigPolicyNameCombo string = "policy-combo-no-ns"
-	case6NSName1               string = "e2etest"
-	case6NSName2               string = "e2etest2"
+	case6ConfigPolicyNameNS    string = "case6-policy-ns"
+	case6ConfigPolicyNameRole  string = "case6-role-policy-no-ns"
+	case6ConfigPolicyNameCombo string = "case6-policy-combo-no-ns"
+	case6ComboRole             string = "case6-role-policy-e2e2"
+	case6NSName1               string = "case6-e2etest"
+	case6NSName2               string = "case6-e2etest2"
 	case6NSYaml                string = "../resources/case6_no_ns/case6_create_ns.yaml"
 	case6RoleYaml              string = "../resources/case6_no_ns/case6_create_role.yaml"
 	case6ComboYaml             string = "../resources/case6_no_ns/case6_combo.yaml"
@@ -35,6 +36,13 @@ var _ = Describe("Test multiple obj template handling", func() {
 
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+			By("Clean up")
+			policies := []string{
+				case6ConfigPolicyNameRole,
+			}
+
+			deleteConfigPolicies(policies)
 		})
 		It("should create pods on managed cluster", func() {
 			By("creating cluster level objects")
@@ -64,15 +72,18 @@ var _ = Describe("Test multiple obj template handling", func() {
 			ns2 := utils.GetClusterLevelWithTimeout(clientManagedDynamic, gvrNS,
 				case6NSName2, true, defaultTimeoutSeconds)
 			Expect(ns2).NotTo(BeNil())
-		})
-		It("Cleans up", func() {
+
+			By("Clean up")
 			policies := []string{
 				case6ConfigPolicyNameNS,
-				case6ConfigPolicyNameRole,
 				case6ConfigPolicyNameCombo,
 			}
 
 			deleteConfigPolicies(policies)
+
+			utils.Kubectl("delete", "ns", case6NSName1, "--ignore-not-found")
+			utils.Kubectl("delete", "ns", case6NSName2, "--ignore-not-found")
+			utils.Kubectl("delete", "role", case6ComboRole, "-n", "default", "--ignore-not-found")
 		})
 	})
 })

--- a/test/e2e/case7_no_spec_test.go
+++ b/test/e2e/case7_no_spec_test.go
@@ -88,7 +88,7 @@ func matchToExpected(managedPlc *unstructured.Unstructured) (result bool) {
 }
 
 var _ = Describe("Test cluster version obj template handling", func() {
-	Describe("create scc policy in namespace "+testNamespace, func() {
+	Describe("create scc policy in namespace "+testNamespace, Ordered, func() {
 		It("should be created properly on the managed cluster", func() {
 			By("Creating " + case7ConfigPolicyName + " on managed")
 			utils.Kubectl("apply", "-f", case7PolicyYaml, "-n", testNamespace)
@@ -179,7 +179,7 @@ var _ = Describe("Test cluster version obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case7ConfigPolicyName,
 				case7ConfigPolicyNameNull,

--- a/test/e2e/case9_md_check_test.go
+++ b/test/e2e/case9_md_check_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 var _ = Describe("Test pod obj template handling", func() {
-	Describe("Create a pod policy on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a pod policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should create a policy properly on the managed cluster", func() {
 			By("Creating " + case9ConfigPolicyNamePod + " on managed")
 			utils.Kubectl("apply", "-f", case9PolicyYamlPod, "-n", testNamespace)
@@ -141,7 +141,7 @@ var _ = Describe("Test pod obj template handling", func() {
 				return utils.GetComplianceState(managedPlc)
 			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case9ConfigPolicyNamePod,
 				case9ConfigPolicyNameAnno,
@@ -156,7 +156,7 @@ var _ = Describe("Test pod obj template handling", func() {
 			deleteConfigPolicies(policies)
 		})
 	})
-	Describe("Create a namespace policy on managed cluster in ns:"+testNamespace, func() {
+	Describe("Create a namespace policy on managed cluster in ns:"+testNamespace, Ordered, func() {
 		It("should create a namespace with multiple annotations on the managed cluster", func() {
 			By("Creating " + case9MultiAnnoNSCreate + " on managed")
 			utils.Kubectl("apply", "-f", case9PolicyYamlMultiAnnoNSCreate, "-n", testNamespace)
@@ -199,11 +199,7 @@ var _ = Describe("Test pod obj template handling", func() {
 			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
 			utils.Kubectl("delete", "configurationpolicy", case9CheckNSMustonlyhave, "-n", testNamespace)
 		})
-		It("should clean up the created namespace", func() {
-			By("Deleting the namespace from " + case9MultiAnnoNSCreate)
-			utils.Kubectl("delete", "ns", "case9-test-multi-annotation")
-		})
-		It("Cleans up", func() {
+		AfterAll(func() {
 			policies := []string{
 				case9MultiAnnoNSCreate,
 				case9CheckNSMusthave,
@@ -211,6 +207,9 @@ var _ = Describe("Test pod obj template handling", func() {
 			}
 
 			deleteConfigPolicies(policies)
+
+			By("Deleting the namespace from " + case9MultiAnnoNSCreate)
+			utils.Kubectl("delete", "ns", "case9-test-multi-annotation")
 		})
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -104,7 +104,6 @@ var _ = BeforeSuite(func() {
 	defaultImageRegistry = "quay.io/open-cluster-management"
 	testNamespace = "managed"
 	defaultTimeoutSeconds = 60
-
 	By("Create watch namespace if needed")
 	namespaces := clientManaged.CoreV1().Namespaces()
 	if _, err := namespaces.Get(

--- a/test/resources/case13_templatization/case13_clusterclaim.yaml
+++ b/test/resources/case13_templatization/case13_clusterclaim.yaml
@@ -3,4 +3,4 @@ kind: ClusterClaim
 metadata:
   name: testclaim.open-cluster-management.io
 spec:
-  value: testvalue
+  value: c13-pod

--- a/test/resources/case13_templatization/case13_configmap.yaml
+++ b/test/resources/case13_templatization/case13_configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: e2e13config
 data:
-  name: testvalue
+  name: c13-pod

--- a/test/resources/case13_templatization/case13_pod_name_verify.yaml
+++ b/test/resources/case13_templatization/case13_pod_name_verify.yaml
@@ -13,7 +13,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: testvalue
+          name: c13-pod
         spec:
           containers:
             - image: nginx:1.7.9

--- a/test/resources/case20_delete_objects/case20_change_config_policy_not_prune.yaml
+++ b/test/resources/case20_delete_objects/case20_change_config_policy_not_prune.yaml
@@ -1,25 +1,22 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-edit-c20
+  name: case20-2-name-changed
+  namespace: managed
 spec:
   remediationAction: enforce
-  namespaceSelector:
-    exclude: ["kube-*"]
-    include: ["default"]
-  pruneObjectBehavior: DeleteIfCreated
   object-templates:
     - complianceType: musthave
       objectDefinition:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-e2e20
-          labels:
-            test: e2e
+          name: case20-2-name-changed-pod
+          namespace: default
         spec:
           containers:
-            - image: nginx:1.7.9
-              name: nginx
+            - name: nginx
+              imagePullPolicy: Never
+              image: nginx:1.7.9
               ports:
                 - containerPort: 80

--- a/test/resources/case20_delete_objects/case20_change_enforce.yaml
+++ b/test/resources/case20_delete_objects/case20_change_enforce.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-change-remediation
+  name: policy-pod-change-remediation-c20
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case20_delete_objects/case20_change_inform.yaml
+++ b/test/resources/case20_delete_objects/case20_change_inform.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-change-remediation
+  name: policy-pod-change-remediation-c20
 spec:
   remediationAction: inform
   namespaceSelector:

--- a/test/resources/case20_delete_objects/case20_create_pod.yaml
+++ b/test/resources/case20_delete_objects/case20_create_pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-create
+  name: policy-pod-create-c20
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case20_delete_objects/case20_createpod_finalizer.yaml
+++ b/test/resources/case20_delete_objects/case20_createpod_finalizer.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-create-withfinalizer
+  name: policy-pod-create-withfinalizer-c20
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case20_delete_objects/case20_enforce_noncreated_pod.yaml
+++ b/test/resources/case20_delete_objects/case20_enforce_noncreated_pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-already-created
+  name: policy-pod-already-created-c20
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case20_delete_objects/case20_inform_pod.yaml
+++ b/test/resources/case20_delete_objects/case20_inform_pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-inform
+  name: policy-pod-inform-c20
 spec:
   remediationAction: inform
   namespaceSelector:

--- a/test/resources/case20_delete_objects/case20_musthave_pod_deleteall.yaml
+++ b/test/resources/case20_delete_objects/case20_musthave_pod_deleteall.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-mhpda
+  name: policy-pod-mhpda-c20
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case5_multi/case5_multi_combo.yaml
+++ b/test/resources/case5_multi/case5_multi_combo.yaml
@@ -14,7 +14,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-1
+          name: case5-nginx-pod-1
         spec:
           containers:
             - image: nginx:1.7.9
@@ -26,7 +26,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-2
+          name: case5-nginx-pod-2
         spec:
           containers:
             - image: nginx:1.7.9

--- a/test/resources/case5_multi/case5_multi_enforce.yaml
+++ b/test/resources/case5_multi/case5_multi_enforce.yaml
@@ -14,7 +14,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-1
+          name: case5-nginx-pod-1
         spec:
           containers:
             - image: nginx:1.7.9
@@ -26,7 +26,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-2
+          name: case5-nginx-pod-2
         spec:
           containers:
             - image: nginx:1.7.9

--- a/test/resources/case5_multi/case5_multi_mh.yaml
+++ b/test/resources/case5_multi/case5_multi_mh.yaml
@@ -14,7 +14,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-1
+          name: case5-nginx-pod-1
         spec:
           containers:
             - image: nginx:1.7.9
@@ -26,7 +26,7 @@ spec:
         apiVersion: v1
         kind: Pod
         metadata:
-          name: nginx-pod-2
+          name: case5-nginx-pod-2
         spec:
           containers:
             - image: nginx:1.7.9

--- a/test/resources/case6_no_ns/case6_combo.yaml
+++ b/test/resources/case6_no_ns/case6_combo.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-combo-no-ns
+  name: case6-policy-combo-no-ns
 spec:
   remediationAction: enforce
   object-templates:
@@ -10,13 +10,13 @@ spec:
         kind: Namespace
         apiVersion: v1
         metadata:
-          name: e2etest2
+          name: case6-e2etest2
     - complianceType: musthave
       objectDefinition:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
-          name: role-policy-e2e2
+          name: case6-role-policy-e2e2
         rules:
           - apiGroups: ["extensions", "apps"]
             resources: ["deployments"]

--- a/test/resources/case6_no_ns/case6_create_ns.yaml
+++ b/test/resources/case6_no_ns/case6_create_ns.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-ns
+  name: case6-policy-ns
 spec:
   remediationAction: enforce
   object-templates:
@@ -10,4 +10,4 @@ spec:
         kind: Namespace # must have namespace 'e2etest'
         apiVersion: v1
         metadata:
-          name: e2etest
+          name: case6-e2etest

--- a/test/resources/case6_no_ns/case6_create_role.yaml
+++ b/test/resources/case6_no_ns/case6_create_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: role-policy-no-ns
+  name: case6-role-policy-no-ns
 spec:
   remediationAction: enforce
   object-templates:
@@ -10,7 +10,7 @@ spec:
         apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
-          name: role-policy-e2e
+          name: case6-role-policy-e2e
         rules:
           - apiGroups: ["extensions", "apps"]
             resources: ["deployments"]

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -121,36 +121,6 @@ func GetWithTimeout(
 	return nil
 }
 
-// ListWithTimeout keeps polling to get the object for timeout seconds until wantFound is met
-// (true for found, false for not found)
-func ListWithTimeout(
-	clientHubDynamic dynamic.Interface,
-	gvr schema.GroupVersionResource,
-	opts metav1.ListOptions,
-	size int,
-	wantFound bool,
-	timeout int,
-) *unstructured.UnstructuredList {
-	if timeout < 1 {
-		timeout = 1
-	}
-	var list *unstructured.UnstructuredList
-
-	EventuallyWithOffset(1, func(g Gomega) []unstructured.Unstructured {
-		var err error
-		list, err = clientHubDynamic.Resource(gvr).List(context.TODO(), opts)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		return list.Items
-	}, timeout, 1).Should(HaveLen(size))
-
-	if wantFound {
-		return list
-	}
-
-	return nil
-}
-
 func GetMatchingEvents(
 	client kubernetes.Interface, namespace, objName, reasonRegex, msgRegex string, timeout int,
 ) []corev1.Event {


### PR DESCRIPTION
The Config Policy controller's E2E tests in its repo takes roughly 45 minutes to run. This is due to all the test running serially. These could be optimized to run in parallel for faster execution.

Acceptance Criteria:

The config-policy-controller E2E tests run in under 20 minutes or Christine declares it impossible.