### PR TITLE
Remove `fail-fast` for Ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ install-resources:
 
 .PHONY: e2e-test
 e2e-test: e2e-dependencies
-	$(GINKGO) -v -p -procs=20 --fail-fast $(E2E_TEST_ARGS) test/e2e
+	$(GINKGO) -v --procs=20 $(E2E_TEST_ARGS) test/e2e
 
 .PHONY: e2e-test-coverage
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode && !running-in-cluster' --output-dir=.

--- a/test/e2e/case13_templatization_test.go
+++ b/test/e2e/case13_templatization_test.go
@@ -52,7 +52,7 @@ const (
 const (
 	case13Unterminated     string = "policy-pod-create-unterminated"
 	case13UnterminatedYaml string = "../resources/case13_templatization/case13_unterminated.yaml"
-	case13WrongArgs        string = "policy-pod-create-wrong-args"
+	case13WrongArgs        string = "case13-policy-pod-create-wrong-args"
 	case13WrongArgsYaml    string = "../resources/case13_templatization/case13_wrong_args.yaml"
 )
 

--- a/test/e2e/case30_multiline_templatization_test.go
+++ b/test/e2e/case30_multiline_templatization_test.go
@@ -28,7 +28,7 @@ const (
 const (
 	case30Unterminated       string = "case30-configpolicy"
 	case30UnterminatedYaml   string = "../resources/case30_multiline_templatization/case30_unterminated.yaml"
-	case30WrongArgs          string = "policy-pod-create-wrong-args"
+	case30WrongArgs          string = "case30-policy-pod-create-wrong-args"
 	case30WrongArgsYaml      string = "../resources/case30_multiline_templatization/case30_wrong_args.yaml"
 	case30NoObject           string = "case30-configpolicy-no-object"
 	case30NoObjectPolicyYaml string = "../resources/case30_multiline_templatization/case30_no_object.yaml"

--- a/test/e2e/case5_multi_test.go
+++ b/test/e2e/case5_multi_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Test multiple obj template handling", func() {
 		})
 	})
 
-	Describe("Check messages when it is multiple namesapces and multiple obj-templates", Ordered, func() {
+	Describe("Check messages when it is multiple namespaces and multiple obj-templates", Ordered, func() {
 		const (
 			case5MultiNamespace1               string = "n1"
 			case5MultiNamespace2               string = "n2"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -194,7 +194,7 @@ func deleteConfigPolicies(policyNames []string) {
 			context.TODO(), policyName, metav1.DeleteOptions{},
 		)
 		if !errors.IsNotFound(err) {
-			Expect(err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		}
 	}
 
@@ -212,7 +212,7 @@ func deletePods(podNames []string, namespaces []string) {
 				context.TODO(), podName, metav1.DeleteOptions{},
 			)
 			if !errors.IsNotFound(err) {
-				Expect(err).ToNot(HaveOccurred())
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			}
 		}
 	}

--- a/test/resources/case13_templatization/case13_wrong_args.yaml
+++ b/test/resources/case13_templatization/case13_wrong_args.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-create-wrong-args
+  name: case13-policy-pod-create-wrong-args
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case30_multiline_templatization/case30_wrong_args.yaml
+++ b/test/resources/case30_multiline_templatization/case30_wrong_args.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-pod-create-wrong-args
+  name: case30-policy-pod-create-wrong-args
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -105,7 +105,8 @@ func GetWithTimeout(
 			return err
 		}
 		if !wantFound && err == nil {
-			return fmt.Errorf("expected to return IsNotFound error")
+			return fmt.Errorf("expected '%s/%s' in namespace '%s' to return IsNotFound error",
+				gvr.Resource, name, namespace)
 		}
 		if !wantFound && err != nil && !errors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
Parallel tests cause parallel processes to get interrupted on a failure, creating too much noise (and it's unnecessary now that the tests complete in a reasonable time).

The `-p` flag is also redundant since `--procs` is already specifying parallelism since its default is 1.