### PR TITLE
Restrict permissions

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -129,7 +129,7 @@ type ConfigurationPolicyReconciler struct {
 	lock sync.RWMutex
 }
 
-//+kubebuilder:rbac:groups=*,resources=*,verbs=*
+//+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;create;delete;patch;update
 
 // Reconcile currently does nothing except that it removes a policy's metric when the policy is deleted. All the logic
 // is handled in the PeriodicallyExecConfigPolicies method.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,13 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -11,4 +11,10 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
Listing verbs explicitly excludes such verbs as "escalate", "bind", and "impersonate".

ref: https://issues.redhat.com/browse/ACM-5408