### PR TITLE
Add event log when deatached objs deleted

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1345,7 +1345,14 @@ func (r *ConfigurationPolicyReconciler) sortRelatedObjectsAndUpdate(
 
 	if !gocmp.Equal(related, oldRelated) {
 		if deleteDetachedObjs {
-			r.cleanUpChildObjects(*plc, related)
+			if failure := r.cleanUpChildObjects(*plc, related); len(failure) == 0 {
+				r.Recorder.Event(
+					plc,
+					eventNormal,
+					"Delete objects",
+					fmt.Sprintf("Clean detached objects in Policy %s/%s", plc.GetNamespace(), plc.GetName()),
+				)
+			}
 		}
 
 		plc.Status.RelatedObjects = related


### PR DESCRIPTION
Description: As a user, I would like to see the warning log when an object is deleted by the config controller.

Ref: https://issues.redhat.com/browse/ACM-5917