### PR TITLE
NamespaceSelector updates triggering evaluations

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -954,6 +954,8 @@ func TestShouldEvaluatePolicy(t *testing.T) {
 		},
 	}
 
+	r := &ConfigurationPolicyReconciler{}
+
 	for _, test := range tests {
 		test := test
 
@@ -970,7 +972,7 @@ func TestShouldEvaluatePolicy(t *testing.T) {
 				policy.ObjectMeta.DeletionTimestamp = test.deletionTimestamp
 				policy.ObjectMeta.Finalizers = test.finalizers
 
-				if actual := shouldEvaluatePolicy(policy, test.cleanupImmediately); actual != test.expected {
+				if actual := r.shouldEvaluatePolicy(policy, test.cleanupImmediately); actual != test.expected {
 					t.Fatalf("expected %v but got %v", test.expected, actual)
 				}
 			},

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
 	github.com/stolostron/go-template-utils/v3 v3.2.1
+	github.com/stolostron/kubernetes-dependency-watches v0.4.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/mod v0.10.0
 	k8s.io/api v0.27.1
@@ -73,7 +74,6 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/stolostron/kubernetes-dependency-watches v0.2.1 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRD
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
 github.com/stolostron/go-template-utils/v3 v3.2.1 h1:wRiCgHG1pcRYa4ZOb/rbzP45Quh8ChNrqXjHDsSaTQg=
 github.com/stolostron/go-template-utils/v3 v3.2.1/go.mod h1:D9uOV787ztGsIqh4FxZzkPfBQgy2zz9vK0cv8uDO5vM=
-github.com/stolostron/kubernetes-dependency-watches v0.2.1 h1:42oLxw+wm/LxHj/3WkJOpyry6dy9Svwgm6jHCttQ6qs=
-github.com/stolostron/kubernetes-dependency-watches v0.2.1/go.mod h1:u2NLFgX12/XwNJvxBpqEhfwGwx8dHWGPxzpDy5L3DIk=
+github.com/stolostron/kubernetes-dependency-watches v0.4.0 h1:wY2rYCspJ4xN9PiedCDCv+ZtzV2iNN0jlGfgxYfd+vU=
+github.com/stolostron/kubernetes-dependency-watches v0.4.0/go.mod h1:u2NLFgX12/XwNJvxBpqEhfwGwx8dHWGPxzpDy5L3DIk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=

--- a/pkg/common/namespace_selection.go
+++ b/pkg/common/namespace_selection.go
@@ -17,7 +17,7 @@ import (
 var log = ctrl.Log
 
 // Parse *Target.MatchLabels and *Target.MatchExpressions into metav1.LabelSelector for the k8s API
-func parseToLabelSelector(selector policyv1.Target) metav1.LabelSelector {
+func ParseToLabelSelector(selector policyv1.Target) metav1.LabelSelector {
 	// Build LabelSelector from provided MatchLabels and MatchExpressions
 	var labelSelector metav1.LabelSelector
 
@@ -46,7 +46,7 @@ func parseToLabelSelector(selector policyv1.Target) metav1.LabelSelector {
 // GetSelectedNamespaces returns the list of filtered namespaces according to the policy namespace selector.
 func GetSelectedNamespaces(client kubernetes.Interface, selector policyv1.Target) ([]string, error) {
 	// Build LabelSelector from provided MatchLabels and MatchExpressions
-	labelSelector := parseToLabelSelector(selector)
+	labelSelector := ParseToLabelSelector(selector)
 
 	// get all namespaces matching selector
 	allNamespaces, err := GetAllNamespaces(client, labelSelector)

--- a/test/e2e/case19_ns_selector_test.go
+++ b/test/e2e/case19_ns_selector_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Test results of namespace selection", Ordered, func() {
 	)
 })
 
-var _ = Describe("Test behavior of namespace selection as namespaces change", Ordered, Label("jkulikau"), func() {
+var _ = Describe("Test behavior of namespace selection as namespaces change", Ordered, func() {
 	const (
 		prereqYaml string = "../resources/case19_ns_selector/case19_behavior_prereq.yaml"
 		policyYaml string = "../resources/case19_ns_selector/case19_behavior_policy.yaml"
@@ -161,9 +161,10 @@ var _ = Describe("Test behavior of namespace selection as namespaces change", Or
 		Expect(found).To(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 
-		clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+		_, err = clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: "case19b-4-e2e"},
 		}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
 		Consistently(func() interface{} {
 			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
@@ -175,7 +176,7 @@ var _ = Describe("Test behavior of namespace selection as namespaces change", Or
 			Expect(err).ToNot(HaveOccurred())
 
 			return newEvalTime
-		}, "20s", 1).Should(Equal(evalTime))
+		}, "40s", "3s").Should(Equal(evalTime))
 	})
 
 	It("should evaluate when a namespace is labeled to match", func() {
@@ -211,7 +212,7 @@ var _ = Describe("Test behavior of namespace selection as namespaces change", Or
 		Expect(found).To(BeTrue())
 		Expect(err).ToNot(HaveOccurred())
 
-		clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+		_, err = clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "kube-case19b-e2e",
 				Labels: map[string]string{
@@ -219,6 +220,7 @@ var _ = Describe("Test behavior of namespace selection as namespaces change", Or
 				},
 			},
 		}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(func() interface{} {
 			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,

--- a/test/e2e/case19_ns_selector_test.go
+++ b/test/e2e/case19_ns_selector_test.go
@@ -4,144 +4,256 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
-const (
-	case19PolicyName    string = "policy-configmap-selector-e2e"
-	case19PolicyYaml    string = "../resources/case19_ns_selector/case19_cm_policy.yaml"
-	case19TemplatesName string = "configmap-selector-e2e"
-	case19TemplatesKind string = "ConfigMap"
-	case19PrereqYaml    string = "../resources/case19_ns_selector/case19_cm_manifest.yaml"
-	case19PatchPrefix   string = "[{\"op\":\"replace\",\"path\":\"/spec/namespaceSelector\",\"value\":"
-	case19PatchSuffix   string = "}]"
-)
+var _ = Describe("Test results of namespace selection", Ordered, func() {
+	const (
+		prereqYaml string = "../resources/case19_ns_selector/case19_results_prereq.yaml"
+		policyYaml string = "../resources/case19_ns_selector/case19_results_policy.yaml"
+		policyName string = "selector-results-e2e"
 
-// Test setup for namespace selection policy tests:
-// - Namespaces `case19-[1-5]-e2e`, each with a `name: <ns-name>` label
-// - Single deployed Configmap `configmap-selector-e2e` in namespace `case19-1-e2e`
-// - Deployed policy should be compliant since it matches the single deployed ConfigMap
-// - Policies are patched so that the namespace doesn't match and should be NonCompliant
-var _ = Describe("Test object namespace selection", Ordered, func() {
-	// NamespaceSelector patches to test
-	resetPatch := "{\"include\":[\"case19-1-e2e\"]}"
-	allPatch := "{\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"Exists\"}]}"
-	patches := map[string]struct {
-		patch   string
-		message string
-	}{
-		"no namespaceSelector specified": {
-			"{}",
-			"namespaced object " + case19TemplatesName + " of kind " + case19TemplatesKind +
-				" has no namespace specified" +
-				" from the policy namespaceSelector nor the object metadata",
-		},
-		"a non-matching LabelSelector": {
-			"{\"matchLabels\":{\"name\":\"not-a-namespace\"}}",
-			"namespaced object " + case19TemplatesName + " of kind " + case19TemplatesKind +
-				" has no namespace specified" +
-				" from the policy namespaceSelector nor the object metadata",
-		},
-		"LabelSelector and exclude": {
-			"{\"exclude\":[\"*-[3-4]-e2e\"],\"matchLabels\":{}," +
-				"\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"Exists\"}]}",
-			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-5-e2e",
-		},
-		"empty LabelSelector and include/exclude": {
-			"{\"include\":[\"case19-[2-5]-e2e\"],\"exclude\":[\"*-[3-4]-e2e\"]," +
-				"\"matchLabels\":{},\"matchExpressions\":[]}",
-			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-5-e2e",
-		},
-		"LabelSelector": {
-			"{\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"Exists\"}]}",
-			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-3-e2e, " +
-				"case19-4-e2e, case19-5-e2e",
-		},
-		"Malformed filepath in include": {
-			"{\"include\":[\"*-[a-z-*\"]}",
-			"Error filtering namespaces with provided namespaceSelector: " +
-				"error parsing 'include' pattern '*-[a-z-*': syntax error in pattern",
-		},
-		"MatchExpressions with incorrect operator": {
-			"{\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"Seriously\"}]}",
-			"Error filtering namespaces with provided namespaceSelector: " +
-				"error parsing namespace LabelSelector: \"Seriously\" is not a valid label selector operator",
-		},
-		"MatchExpressions with missing values": {
-			"{\"matchExpressions\":[{\"key\":\"name\",\"operator\":\"In\",\"values\":[]}]}",
-			"Error filtering namespaces with provided namespaceSelector: " +
-				"error parsing namespace LabelSelector: " +
-				"values: Invalid value: []string(nil): for 'in', 'notin' operators, values set can't be empty",
-		},
-	}
+		noMatchesMsg string = "namespaced object configmap-selector-e2e of kind ConfigMap has no " +
+			"namespace specified from the policy namespaceSelector nor the object metadata"
+		notFoundMsgFmt  string = "configmaps [configmap-selector-e2e] not found in namespaces: %s"
+		filterErrMsgFmt string = "Error filtering namespaces with provided namespaceSelector: %s"
+	)
 
-	It("creates prerequisite objects", func() {
-		utils.Kubectl("apply", "-f", case19PrereqYaml)
-		// Delete the last namespace so we can use it to test whether
-		// adding a namespace works as the final test
-		utils.Kubectl("delete", "namespace", "case19-6-e2e")
-		utils.Kubectl("apply", "-f", case19PolicyYaml, "-n", testNamespace)
-		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-			case19PolicyName, testNamespace, true, defaultTimeoutSeconds)
-		Expect(plc).NotTo(BeNil())
+	// Test setup for namespace selection policy tests:
+	// - Namespaces `case19a-[1-5]-e2e`, each with a `case19a: <ns-name>` label
+	// - Single deployed Configmap `configmap-selector-e2e` in namespace `case19a-1-e2e`
+	// - Deployed policy should be compliant since it matches the single deployed ConfigMap
+	// - Policies are patched so that the namespace doesn't match and should be NonCompliant
+	BeforeAll(func() {
+		By("Applying prerequisites")
+		utils.Kubectl("apply", "-f", prereqYaml)
+		DeferCleanup(func() {
+			utils.Kubectl("delete", "-f", prereqYaml)
+		})
+
+		utils.Kubectl("apply", "-f", policyYaml, "-n", testNamespace)
+		DeferCleanup(func() {
+			utils.Kubectl("delete", "-f", policyYaml, "-n", testNamespace)
+		})
 	})
 
-	It("should properly handle the namespaceSelector", func() {
-		for name, patch := range patches {
-			By("patching compliant policy " + case19PolicyName + " on the managed cluster")
-			utils.Kubectl("patch", "--namespace=managed", "configurationpolicy", case19PolicyName, "--type=json",
-				"--patch="+case19PatchPrefix+resetPatch+case19PatchSuffix,
-			)
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-					case19PolicyName, testNamespace, true, defaultTimeoutSeconds)
+	DescribeTable("Checking results of different namespaceSelectors", func(patch string, message string) {
+		patchFmt := `--patch=[{"op":"replace","path":"/spec/namespaceSelector","value":%s}]`
 
-				return utils.GetComplianceState(managedPlc)
-			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
-			By("patching with " + name)
-			utils.Kubectl("patch", "--namespace=managed", "configurationpolicy", case19PolicyName, "--type=json",
-				"--patch="+case19PatchPrefix+patch.patch+case19PatchSuffix,
-			)
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-					case19PolicyName, testNamespace, true, defaultTimeoutSeconds)
-
-				return utils.GetComplianceState(managedPlc)
-			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
-			Eventually(func() interface{} {
-				managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-					case19PolicyName, testNamespace, true, defaultTimeoutSeconds)
-
-				return utils.GetStatusMessage(managedPlc)
-			}, defaultTimeoutSeconds, 1).Should(Equal(patch.message))
-		}
-	})
-
-	It("should handle when a matching labeled namespace is added", func() {
-		utils.Kubectl("apply", "-f", case19PrereqYaml)
-		By("patching with a patch for all namespaces")
-		utils.Kubectl("patch", "--namespace=managed", "configurationpolicy", case19PolicyName, "--type=json",
-			"--patch="+case19PatchPrefix+allPatch+case19PatchSuffix,
+		By("patching policy with the test selector")
+		utils.Kubectl("patch", "--namespace=managed", "configurationpolicy", policyName, "--type=json",
+			fmt.Sprintf(patchFmt, patch),
 		)
 		Eventually(func() interface{} {
 			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
-				case19PolicyName, testNamespace, true, defaultTimeoutSeconds)
+				policyName, testNamespace, true, defaultTimeoutSeconds)
 
 			return utils.GetStatusMessage(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal(
-			"configmaps [configmap-selector-e2e] not found in namespaces: case19-2-e2e, case19-3-e2e, case19-4-e2e, " +
-				"case19-5-e2e, case19-6-e2e",
-		))
+		}, defaultTimeoutSeconds, 1).Should(Equal(message))
+	},
+		Entry("No namespaceSelector specified",
+			"{}",
+			noMatchesMsg),
+		Entry("LabelSelector and exclude",
+			`{"exclude":["*19a-[3-4]-e2e"],"matchExpressions":[{"key":"case19a","operator":"Exists"}]}`,
+			fmt.Sprintf(notFoundMsgFmt, "case19a-2-e2e, case19a-5-e2e"),
+		),
+		Entry("A non-matching LabelSelector",
+			`{"matchLabels":{"name":"not-a-namespace"}}`,
+			noMatchesMsg),
+		Entry("Empty LabelSelector and include/exclude",
+			`{"include":["case19a-[2-5]-e2e"],"exclude":["*-[3-4]-e2e"],"matchLabels":{},"matchExpressions":[]}`,
+			fmt.Sprintf(notFoundMsgFmt, "case19a-2-e2e, case19a-5-e2e"),
+		),
+		Entry("LabelSelector",
+			`{"matchExpressions":[{"key":"case19a","operator":"Exists"}]}`,
+			fmt.Sprintf(notFoundMsgFmt, "case19a-2-e2e, case19a-3-e2e, case19a-4-e2e, case19a-5-e2e"),
+		),
+		Entry("Malformed filepath in include",
+			`{"include":["*-[a-z-*"]}`,
+			fmt.Sprintf(filterErrMsgFmt, "error parsing 'include' pattern '*-[a-z-*': syntax error in pattern"),
+		),
+		Entry("MatchExpressions with incorrect operator",
+			`{"matchExpressions":[{"key":"name","operator":"Seriously"}]}`,
+			fmt.Sprintf(filterErrMsgFmt, "error parsing namespace LabelSelector: "+
+				`"Seriously" is not a valid label selector operator`),
+		),
+		Entry("MatchExpressions with missing values",
+			`{"matchExpressions":[{"key":"name","operator":"In","values":[]}]}`,
+			fmt.Sprintf(filterErrMsgFmt, "error parsing namespace LabelSelector: "+
+				"values: Invalid value: []string(nil): for 'in', 'notin' operators, values set can't be empty"),
+		),
+	)
+})
+
+var _ = Describe("Test behavior of namespace selection as namespaces change", Ordered, Label("jkulikau"), func() {
+	const (
+		prereqYaml string = "../resources/case19_ns_selector/case19_behavior_prereq.yaml"
+		policyYaml string = "../resources/case19_ns_selector/case19_behavior_policy.yaml"
+		policyName string = "selector-behavior-e2e"
+
+		notFoundMsgFmt string = "configmaps [configmap-selector-e2e] not found in namespaces: %s"
+	)
+
+	BeforeAll(func() {
+		By("Applying prerequisites")
+		utils.Kubectl("apply", "-f", prereqYaml)
+		// cleaned up in an AfterAll because that will cover other namespaces created in the tests
+
+		utils.Kubectl("apply", "-f", policyYaml, "-n", testNamespace)
+		DeferCleanup(func() {
+			utils.Kubectl("delete", "-f", policyYaml, "-n", testNamespace)
+		})
+
+		By("Verifying initial compliance message")
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(notFoundMsgFmt,
+			"case19b-1-e2e, case19b-2-e2e")))
 	})
 
 	AfterAll(func() {
-		utils.Kubectl("delete", "-f", case19PrereqYaml)
-		policies := []string{
-			case19PolicyName,
-		}
-		deleteConfigPolicies(policies)
+		utils.Kubectl("delete", "ns", "case19b-1-e2e", "--ignore-not-found")
+		utils.Kubectl("delete", "ns", "case19b-2-e2e", "--ignore-not-found")
+		utils.Kubectl("delete", "ns", "case19b-3-e2e", "--ignore-not-found")
+		utils.Kubectl("delete", "ns", "case19b-4-e2e", "--ignore-not-found")
+		utils.Kubectl("delete", "ns", "kube-case19b-e2e", "--ignore-not-found")
+	})
+
+	It("should evaluate when a matching labeled namespace is added", func() {
+		_, err := clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "case19b-3-e2e",
+				Labels: map[string]string{
+					"case19b": "case19b-3-e2e",
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(notFoundMsgFmt,
+			"case19b-1-e2e, case19b-2-e2e, case19b-3-e2e")))
+	})
+
+	It("should not evaluate early if a non-matching namespace is added", func() {
+		managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+			policyName, testNamespace, true, defaultTimeoutSeconds)
+
+		evalTime, found, err := unstructured.NestedString(managedPlc.Object, "status", "lastEvaluated")
+		Expect(evalTime).ToNot(BeEmpty())
+		Expect(found).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "case19b-4-e2e"},
+		}, metav1.CreateOptions{})
+
+		Consistently(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			newEvalTime, found, err := unstructured.NestedString(managedPlc.Object, "status", "lastEvaluated")
+			Expect(newEvalTime).ToNot(BeEmpty())
+			Expect(found).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			return newEvalTime
+		}, "20s", 1).Should(Equal(evalTime))
+	})
+
+	It("should evaluate when a namespace is labeled to match", func() {
+		utils.Kubectl("label", "ns", "case19b-4-e2e", "case19b=case19b-4-e2e")
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(notFoundMsgFmt,
+			"case19b-1-e2e, case19b-2-e2e, case19b-3-e2e, case19b-4-e2e")))
+	})
+
+	It("should evaluate when a matching namespace label is removed", func() {
+		utils.Kubectl("label", "ns", "case19b-3-e2e", "case19b-")
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(notFoundMsgFmt,
+			"case19b-1-e2e, case19b-2-e2e, case19b-4-e2e")))
+	})
+
+	It("should evaluate when an excluded namespace is added", Label("buggy-behavior"), func() {
+		managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+			policyName, testNamespace, true, defaultTimeoutSeconds)
+
+		evalTime, found, err := unstructured.NestedString(managedPlc.Object, "status", "lastEvaluated")
+		Expect(evalTime).ToNot(BeEmpty())
+		Expect(found).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		clientManaged.CoreV1().Namespaces().Create(context.TODO(), &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "kube-case19b-e2e",
+				Labels: map[string]string{
+					"case19b": "kube-case19b-e2e",
+				},
+			},
+		}, metav1.CreateOptions{})
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			newEvalTime, found, err := unstructured.NestedString(managedPlc.Object, "status", "lastEvaluated")
+			Expect(newEvalTime).ToNot(BeEmpty())
+			Expect(found).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			return newEvalTime
+		}, defaultTimeoutSeconds, 1).ShouldNot(Equal(evalTime))
+	})
+
+	It("should evaluate when a matched namespace is changed", Label("buggy-behavior"), func() {
+		managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+			policyName, testNamespace, true, defaultTimeoutSeconds)
+
+		evalTime, found, err := unstructured.NestedString(managedPlc.Object, "status", "lastEvaluated")
+		Expect(evalTime).ToNot(BeEmpty())
+		Expect(found).To(BeTrue())
+		Expect(err).ToNot(HaveOccurred())
+
+		utils.Kubectl("label", "ns", "case19b-1-e2e", "extra-label=hello")
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				policyName, testNamespace, true, defaultTimeoutSeconds)
+
+			newEvalTime, found, err := unstructured.NestedString(managedPlc.Object, "status", "lastEvaluated")
+			Expect(newEvalTime).ToNot(BeEmpty())
+			Expect(found).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			return newEvalTime
+		}, defaultTimeoutSeconds, 1).ShouldNot(Equal(evalTime))
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,8 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
+	format.TruncatedDiff = false
+
 	By("Setup Hub client")
 	gvrPod = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	gvrNS = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}

--- a/test/resources/case19_ns_selector/case19_behavior_policy.yaml
+++ b/test/resources/case19_ns_selector/case19_behavior_policy.yaml
@@ -1,11 +1,17 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-configmap-selector-e2e
+  name: selector-behavior-e2e
 spec:
+  evaluationInterval:
+    compliant: 2h
+    noncompliant: 2h
   namespaceSelector:
-    include:
-      - case19-1-e2e
+    exclude:
+      - "kube-*"
+    matchExpressions:
+      - key: case19b
+        operator: Exists
   remediationAction: inform
   object-templates:
     - complianceType: musthave

--- a/test/resources/case19_ns_selector/case19_behavior_prereq.yaml
+++ b/test/resources/case19_ns_selector/case19_behavior_prereq.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19b: case19b-1-e2e
+  name: case19b-1-e2e
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19b: case19b-2-e2e
+  name: case19b-2-e2e

--- a/test/resources/case19_ns_selector/case19_cm_long_interval_policy.yaml
+++ b/test/resources/case19_ns_selector/case19_cm_long_interval_policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-configmap-selector-e2e
+spec:
+  namespaceSelector:
+    matchLabels:
+      sample: test
+  remediationAction: inform
+  evaluationInterval:
+    compliant: 2h
+    noncompliant: 2h
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: configmap-selector-e2e

--- a/test/resources/case19_ns_selector/case19_cm_manifest.yaml
+++ b/test/resources/case19_ns_selector/case19_cm_manifest.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     name: case19-1-e2e
+    sample: test
   name: case19-1-e2e
 ---
 apiVersion: v1
@@ -10,6 +11,7 @@ kind: Namespace
 metadata:
   labels:
     name: case19-2-e2e
+    sample: test
   name: case19-2-e2e
 ---
 apiVersion: v1

--- a/test/resources/case19_ns_selector/case19_results_policy.yaml
+++ b/test/resources/case19_ns_selector/case19_results_policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: selector-results-e2e
+spec:
+  namespaceSelector:
+    include:
+      - case19a-1-e2e
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: configmap-selector-e2e

--- a/test/resources/case19_ns_selector/case19_results_prereq.yaml
+++ b/test/resources/case19_ns_selector/case19_results_prereq.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19a: case19a-1-e2e
+  name: case19a-1-e2e
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19a: case19a-2-e2e
+  name: case19a-2-e2e
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19a: case19a-3-e2e
+  name: case19a-3-e2e
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19a: case19a-4-e2e
+  name: case19a-4-e2e
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19a: case19a-5-e2e
+  name: case19a-5-e2e
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-selector-e2e
+  namespace: case19a-1-e2e


### PR DESCRIPTION
This approach uses the new feature in github.com/stolostron/kubernetes-dependency-watches, but it comes with some downsides (compare to https://github.com/open-cluster-management-io/config-policy-controller/pull/158):
- that library doesn't help if the NamespaceSelector only uses Include and Exclude
- extra evaluations can be triggered when there aren't actually updates

This implementation also uses a channel for communication as opposed to a shared map that would likely require a mutex, but I don't know if this approach is actually better.