### PR TITLE
NamespaceSelector 'reconciler' to help trigger evaluations

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -103,7 +103,9 @@ func (t Target) String() string {
 	return fmt.Sprintf(fmtSelectorStr, t.Include, t.Exclude, *t.MatchLabels, *t.MatchExpressions)
 }
 
-// Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated
+// Configures the minimum elapsed time before a ConfigurationPolicy is reevaluated. If the policy
+// spec is changed, or if the list of namespaces selected by the policy changes, the policy may be
+// evaluated regardless of the settings here.
 type EvaluationInterval struct {
 	//+kubebuilder:validation:Pattern=`^(?:(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))|never)+$`
 	// The minimum elapsed time before a ConfigurationPolicy is reevaluated when in the compliant state. Set this to

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -954,6 +954,10 @@ func TestShouldEvaluatePolicy(t *testing.T) {
 		},
 	}
 
+	r := &ConfigurationPolicyReconciler{
+		SelectorReconciler: &fakeSR{},
+	}
+
 	for _, test := range tests {
 		test := test
 
@@ -970,12 +974,25 @@ func TestShouldEvaluatePolicy(t *testing.T) {
 				policy.ObjectMeta.DeletionTimestamp = test.deletionTimestamp
 				policy.ObjectMeta.Finalizers = test.finalizers
 
-				if actual := shouldEvaluatePolicy(policy, test.cleanupImmediately); actual != test.expected {
+				if actual := r.shouldEvaluatePolicy(policy, test.cleanupImmediately); actual != test.expected {
 					t.Fatalf("expected %v but got %v", test.expected, actual)
 				}
 			},
 		)
 	}
+}
+
+type fakeSR struct{}
+
+func (r *fakeSR) Get(_ string, _ policyv1.Target) ([]string, error) {
+	return nil, nil
+}
+
+func (r *fakeSR) HasUpdate(_ string) bool {
+	return false
+}
+
+func (r *fakeSR) Stop(_ string) {
 }
 
 func TestShouldHandleSingleKeyFalse(t *testing.T) {

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -43,7 +43,9 @@ spec:
             properties:
               evaluationInterval:
                 description: Configures the minimum elapsed time before a ConfigurationPolicy
-                  is reevaluated
+                  is reevaluated. If the policy spec is changed, or if the list of
+                  namespaces selected by the policy changes, the policy may be evaluated
+                  regardless of the settings here.
                 properties:
                   compliant:
                     description: The minimum elapsed time before a ConfigurationPolicy

--- a/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -50,7 +50,9 @@ spec:
             properties:
               evaluationInterval:
                 description: Configures the minimum elapsed time before a ConfigurationPolicy
-                  is reevaluated
+                  is reevaluated. If the policy spec is changed, or if the list of
+                  namespaces selected by the policy changes, the policy may be evaluated
+                  regardless of the settings here.
                 properties:
                   compliant:
                     description: The minimum elapsed time before a ConfigurationPolicy

--- a/main.go
+++ b/main.go
@@ -266,6 +266,9 @@ func main() {
 			os.Exit(1)
 		}
 
+		targetK8sConfig.Burst = int(opts.clientBurst)
+		targetK8sConfig.QPS = opts.clientQPS
+
 		targetK8sClient = kubernetes.NewForConfigOrDie(targetK8sConfig)
 		targetK8sDynamicClient = dynamic.NewForConfigOrDie(targetK8sConfig)
 
@@ -309,7 +312,7 @@ func main() {
 	managerCtx, managerCancel := context.WithCancel(context.Background())
 
 	// PeriodicallyExecConfigPolicies is the go-routine that periodically checks the policies
-	log.V(1).Info("Perodically processing Configuration Policies", "frequency", opts.frequency)
+	log.V(1).Info("Periodically processing Configuration Policies", "frequency", opts.frequency)
 
 	go func() {
 		reconciler.PeriodicallyExecConfigPolicies(terminatingCtx, opts.frequency, mgr.Elected())

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ func TestRunMain(t *testing.T) {
 		args,
 		"--leader-elect=false",
 		fmt.Sprintf("--target-kubeconfig-path=%s", os.Getenv("TARGET_KUBECONFIG_PATH")),
+		"--log-level=1",
 	)
 
 	main()

--- a/pkg/common/namespace_selection.go
+++ b/pkg/common/namespace_selection.go
@@ -6,10 +6,23 @@ package common
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
+	"sync"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 )
@@ -102,4 +115,221 @@ func GetAllNamespaces(client kubernetes.Interface, labelSelector metav1.LabelSel
 	}
 
 	return namespacesNames, nil
+}
+
+// SelectorReconciler keeps a cache of NamespaceSelector results, which it should update when
+// namespaces are created, deleted, or re-labeled.
+type SelectorReconciler interface {
+	// Get returns the items matching the given Target for the given name. If no selection for that
+	// name and Target has been calculated, it will be calculated now. Otherwise, a cached value
+	// may be used.
+	Get(string, policyv1.Target) ([]string, error)
+
+	// HasUpdate indicates when the cached selection for this name has been changed since the last
+	// time that Get was called for that name.
+	HasUpdate(string) bool
+
+	// Stop tells the SelectorReconciler to stop updating the cached selection for the name.
+	Stop(string)
+}
+
+type NamespaceSelectorReconciler struct {
+	Client     client.Client
+	selections map[string]namespaceSelection
+	lock       sync.RWMutex
+}
+
+type namespaceSelection struct {
+	target     policyv1.Target
+	namespaces []string
+	hasUpdate  bool
+	err        error
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NamespaceSelectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.selections = make(map[string]namespaceSelection)
+
+	neverEnqueue := predicate.NewPredicateFuncs(func(o client.Object) bool { return false })
+
+	// Instead of reconciling for each Namespace, just reconcile once
+	// - that reconcile will do a list on all the Namespaces anyway.
+	mapToSingleton := func(_ client.Object) []reconcile.Request {
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{
+			Name: "NamespaceSelector",
+		}}}
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("NamespaceSelector").
+		For( // This is a workaround because a `For` is required, but doesn't allow the enqueueing to be customized
+			&corev1.Namespace{},
+			builder.WithPredicates(neverEnqueue)).
+		Watches(
+			&source.Kind{Type: &corev1.Namespace{}},
+			handler.EnqueueRequestsFromMapFunc(mapToSingleton),
+			builder.WithPredicates(predicate.LabelChangedPredicate{})).
+		Complete(r)
+}
+
+// Reconcile runs whenever a namespace on the target cluster is created, deleted, or has a change in
+// labels. It updates the cached selections for NamespaceSelectors that it knows about.
+func (r *NamespaceSelectorReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	log := logf.Log.WithValues("Reconciler", "NamespaceSelector")
+	oldSelections := make(map[string]namespaceSelection)
+
+	r.lock.RLock()
+
+	for name, selection := range r.selections {
+		oldSelections[name] = selection
+	}
+
+	r.lock.RUnlock()
+
+	// No selections to populate, just skip.
+	if len(r.selections) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	namespaces := corev1.NamespaceList{}
+
+	// This List will be from the cache
+	if err := r.Client.List(ctx, &namespaces); err != nil {
+		log.Error(err, "Unable to list namespaces from the cache")
+
+		return ctrl.Result{}, err
+	}
+
+	for name, oldSelection := range oldSelections {
+		newNamespaces, err := filter(namespaces, oldSelection.target)
+		if err != nil {
+			log.Error(err, "Unable to filter namespaces for policy", "name", name)
+
+			r.update(name, namespaceSelection{
+				target:     oldSelection.target,
+				namespaces: newNamespaces,
+				hasUpdate:  oldSelection.err == nil, // it has an update if the error state changed
+				err:        err,
+			})
+
+			continue
+		}
+
+		if !reflect.DeepEqual(newNamespaces, oldSelection.namespaces) {
+			log.V(2).Info("Updating selection from Reconcile", "policy", name, "selection", newNamespaces)
+
+			r.update(name, namespaceSelection{
+				target:     oldSelection.target,
+				namespaces: newNamespaces,
+				hasUpdate:  true,
+				err:        nil,
+			})
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// Get returns the items matching the given Target for the given policy. If no selection for that
+// policy and Target has been calculated, it will be calculated now. Otherwise, a cached value
+// may be used.
+func (r *NamespaceSelectorReconciler) Get(name string, t policyv1.Target) ([]string, error) {
+	log := logf.Log.WithValues("Reconciler", "NamespaceSelector")
+
+	r.lock.Lock()
+
+	// If found, and target has not been changed
+	if selection, found := r.selections[name]; found && selection.target.String() == t.String() {
+		selection.hasUpdate = false
+		r.selections[name] = selection
+
+		r.lock.Unlock()
+
+		return selection.namespaces, selection.err
+	}
+
+	// unlock for now, the list filtering could take a non-trivial amount of time
+	r.lock.Unlock()
+
+	// New, or the target has changed.
+	nsList := corev1.NamespaceList{}
+
+	labelSelector := parseToLabelSelector(t)
+
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing namespace LabelSelector: %w", err)
+	}
+
+	// This List will be from the cache
+	if err := r.Client.List(context.TODO(), &nsList, &client.ListOptions{LabelSelector: selector}); err != nil {
+		log.Error(err, "Unable to list namespaces from the cache")
+
+		return nil, err
+	}
+
+	nsToMatch := make([]string, len(nsList.Items))
+	for i, ns := range nsList.Items {
+		nsToMatch[i] = ns.Name
+	}
+
+	selected, err := Matches(nsToMatch, t.Include, t.Exclude)
+	sort.Strings(selected)
+
+	log.V(2).Info("Updating selection from Reconcile", "policy", name, "selection", selected)
+
+	r.update(name, namespaceSelection{
+		target:     t,
+		namespaces: selected,
+		hasUpdate:  false,
+		err:        err,
+	})
+
+	return selected, err
+}
+
+// HasUpdate indicates when the cached selection for this policy has been changed since the last
+// time that Get was called for that policy.
+func (r *NamespaceSelectorReconciler) HasUpdate(name string) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	return r.selections[name].hasUpdate
+}
+
+// Stop tells the SelectorReconciler to stop updating the cached selection for the name.
+func (r *NamespaceSelectorReconciler) Stop(name string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	delete(r.selections, name)
+}
+
+func (r *NamespaceSelectorReconciler) update(name string, sel namespaceSelection) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.selections[name] = sel
+}
+
+func filter(allNSList corev1.NamespaceList, t policyv1.Target) ([]string, error) {
+	labelSelector := parseToLabelSelector(t)
+
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing namespace LabelSelector: %w", err)
+	}
+
+	nsToFilter := make([]string, 0)
+
+	for _, ns := range allNSList.Items {
+		if selector.Matches(labels.Set(ns.GetLabels())) {
+			nsToFilter = append(nsToFilter, ns.Name)
+		}
+	}
+
+	namespaces, err := Matches(nsToFilter, t.Include, t.Exclude)
+	sort.Strings(namespaces)
+
+	return namespaces, err
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +63,8 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
+	format.TruncatedDiff = false
+
 	By("Setup Hub client")
 	gvrPod = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	gvrNS = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}

--- a/test/resources/case19_ns_selector/case19_behavior_policy.yaml
+++ b/test/resources/case19_ns_selector/case19_behavior_policy.yaml
@@ -1,11 +1,17 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-configmap-selector-e2e
+  name: selector-behavior-e2e
 spec:
+  evaluationInterval:
+    compliant: 2h
+    noncompliant: 2h
   namespaceSelector:
-    include:
-      - case19-1-e2e
+    exclude:
+      - "kube-*"
+    matchExpressions:
+      - key: case19b
+        operator: Exists
   remediationAction: inform
   object-templates:
     - complianceType: musthave

--- a/test/resources/case19_ns_selector/case19_behavior_prereq.yaml
+++ b/test/resources/case19_ns_selector/case19_behavior_prereq.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19b: case19b-1-e2e
+  name: case19b-1-e2e
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    case19b: case19b-2-e2e
+  name: case19b-2-e2e

--- a/test/resources/case19_ns_selector/case19_results_policy.yaml
+++ b/test/resources/case19_ns_selector/case19_results_policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: selector-results-e2e
+spec:
+  namespaceSelector:
+    include:
+      - case19a-1-e2e
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: configmap-selector-e2e

--- a/test/resources/case19_ns_selector/case19_results_prereq.yaml
+++ b/test/resources/case19_ns_selector/case19_results_prereq.yaml
@@ -2,46 +2,39 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: case19-1-e2e
-  name: case19-1-e2e
+    case19a: case19a-1-e2e
+  name: case19a-1-e2e
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: case19-2-e2e
-  name: case19-2-e2e
+    case19a: case19a-2-e2e
+  name: case19a-2-e2e
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: case19-3-e2e
-  name: case19-3-e2e
+    case19a: case19a-3-e2e
+  name: case19a-3-e2e
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: case19-4-e2e
-  name: case19-4-e2e
+    case19a: case19a-4-e2e
+  name: case19a-4-e2e
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: case19-5-e2e
-  name: case19-5-e2e
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    name: case19-6-e2e
-  name: case19-6-e2e
+    case19a: case19a-5-e2e
+  name: case19a-5-e2e
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-selector-e2e
-  namespace: case19-1-e2e
+  namespace: case19a-1-e2e


### PR DESCRIPTION
Instead of a watch for each policy's namespace selector, this implementation uses a separate controller, watching all the namespaces on the target cluster. (Note: since the existing controller manager was based on the cluster the controller is running on, but this is not always the same as the target cluster, some additional setup was needed.)

Being able to list all of the namespaces on the target cluster is needed for policies that only use Include and Exclude in their NamespaceSelector. Since that list can be cached, it seems nicer to the API server to do the LabelSelector calculations locally, and just have the one watch.

This implementation addresses the limitations noted in https://github.com/open-cluster-management-io/config-policy-controller/pull/157, and has adjusted the tests accordingly.