### PR TITLE
Allow OperatorPolicy to create OLM subscriptions

### DIFF
--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"testing"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	policyv1beta1 "open-cluster-management.io/config-policy-controller/api/v1beta1"
+)
+
+func TestBuildSubscription(t *testing.T) {
+	testSubscription := new(operatorv1alpha1.Subscription)
+	testPolicy := &policyv1beta1.OperatorPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-policy",
+			Namespace: "default",
+		},
+		Spec: policyv1beta1.OperatorPolicySpec{
+			Severity:          "low",
+			RemediationAction: "enforce",
+			ComplianceType:    "musthave",
+			Subscription: policyv1beta1.SubscriptionSpec{
+				SubscriptionSpec: operatorv1alpha1.SubscriptionSpec{
+					Channel:                "stable",
+					Package:                "my-operator",
+					InstallPlanApproval:    "Automatic",
+					CatalogSource:          "my-catalog",
+					CatalogSourceNamespace: "my-ns",
+					StartingCSV:            "my-operator-v1",
+				},
+				Namespace: "default",
+			},
+		},
+	}
+	desiredGVK := schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "Subscription",
+	}
+
+	// Check values are correctly bootstrapped to the Subscription
+	ret := buildSubscription(testPolicy, testSubscription)
+	assert.Equal(t, ret.GetObjectKind().GroupVersionKind(), desiredGVK)
+	assert.Equal(t, ret.ObjectMeta.Name, "my-operator")
+	assert.Equal(t, ret.ObjectMeta.Namespace, "default")
+	assert.Equal(t, ret.Spec, &testPolicy.Spec.Subscription.SubscriptionSpec)
+}
+
+func TestBuildOperatorGroup(t *testing.T) {
+	testPolicy := &policyv1beta1.OperatorPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-policy",
+			Namespace: "default",
+		},
+		Spec: policyv1beta1.OperatorPolicySpec{
+			Severity:          "low",
+			RemediationAction: "enforce",
+			ComplianceType:    "musthave",
+			Subscription: policyv1beta1.SubscriptionSpec{
+				SubscriptionSpec: operatorv1alpha1.SubscriptionSpec{
+					Channel:                "stable",
+					Package:                "my-operator",
+					InstallPlanApproval:    "Automatic",
+					CatalogSource:          "my-catalog",
+					CatalogSourceNamespace: "my-ns",
+					StartingCSV:            "my-operator-v1",
+				},
+				Namespace: "default",
+			},
+		},
+	}
+	desiredGVK := schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1",
+		Kind:    "OperatorGroup",
+	}
+
+	// Ensure OperatorGroup values are populated correctly
+	ret := buildOperatorGroup(testPolicy)
+	assert.Equal(t, ret.GetObjectKind().GroupVersionKind(), desiredGVK)
+	assert.Equal(t, ret.ObjectMeta.GetName(), "my-operator-operator-group")
+	assert.Equal(t, ret.ObjectMeta.GetNamespace(), "default")
+	assert.Equal(t, ret.Spec.TargetNamespaces, []string{"*"})
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,6 +53,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = policyv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = operatorv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/go-logr/zapr"
+	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/spf13/pflag"
 	"github.com/stolostron/go-log-utils/zaputil"
 	appsv1 "k8s.io/api/apps/v1"
@@ -68,6 +70,8 @@ func init() {
 	utilruntime.Must(policyv1beta1.AddToScheme(scheme))
 	utilruntime.Must(extensionsv1.AddToScheme(scheme))
 	utilruntime.Must(extensionsv1beta1.AddToScheme(scheme))
+	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(operatorv1.AddToScheme(scheme))
 }
 
 type ctrlOpts struct {


### PR DESCRIPTION
Modified the controller logic such that the OperatorPolicy controller can create OLM subscriptions based on the policy spec. Currently, an OperatorGroup is created for each Subscription. Future implementation will support creating OperatorGroups based on installModes supported by the generated CSVs.

ref: https://issues.redhat.com/browse/ACM-6597