### PR TITLE
Don't attempt to merge `mustonlyhave` list

### DIFF
--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -141,12 +141,8 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 			return fmt.Sprint(zero) == fmt.Sprint(oldObj)
 		}
 
-		if !reflect.DeepEqual(fmt.Sprint(mergedObj), fmt.Sprint(oldObj)) {
-			return false
-		}
+		return fmt.Sprint(mergedObj) == fmt.Sprint(oldObj)
 	}
-
-	return true
 }
 
 // checkFieldsWithSort is a check for maps that uses an arbitrary sort to ensure it is


### PR DESCRIPTION
Most objects have lists that are nested, so the `compareLists()` function was never called (since when it's nested `mergeArrays()` is ultimately called). However, in the case of Openshift Template objects, it has an un-nested list, which called the buggy code. To illustrate, this looks like:
```
objects
 - ...
```
Rather than:
```
spec:
  listKey:
   - ...
```

ref: https://issues.redhat.com/browse/ACM-7799