### PR TITLE
Fix items in nested lists not always being matched

### DIFF
--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -226,6 +226,34 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 	return true
 }
 
+// sortAndSprint sorts any lists in the input, and formats the resulting object as a string
+func sortAndSprint(item interface{}) string {
+	switch item := item.(type) {
+	case map[string]interface{}:
+		sorted := make(map[string]string, len(item))
+
+		for key, val := range item {
+			sorted[key] = sortAndSprint(val)
+		}
+
+		return fmt.Sprintf("%v", sorted)
+	case []interface{}:
+		sorted := make([]string, len(item))
+
+		for i, val := range item {
+			sorted[i] = sortAndSprint(val)
+		}
+
+		sort.Slice(sorted, func(x, y int) bool {
+			return sorted[x] < sorted[y]
+		})
+
+		return fmt.Sprintf("%v", sorted)
+	default:
+		return fmt.Sprintf("%v", item)
+	}
+}
+
 // checkListsMatch is a generic list check that uses an arbitrary sort to ensure it is comparing the right values
 func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 	if (oldVal == nil && mergedVal != nil) || (oldVal != nil && mergedVal == nil) {
@@ -241,10 +269,10 @@ func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 	mVal := append([]interface{}{}, mergedVal...)
 
 	sort.Slice(oVal, func(i, j int) bool {
-		return fmt.Sprintf("%v", oVal[i]) < fmt.Sprintf("%v", oVal[j])
+		return sortAndSprint(oVal[i]) < sortAndSprint(oVal[j])
 	})
 	sort.Slice(mVal, func(x, y int) bool {
-		return fmt.Sprintf("%v", mVal[x]) < fmt.Sprintf("%v", mVal[y])
+		return sortAndSprint(mVal[x]) < sortAndSprint(mVal[y])
 	})
 
 	for idx, oNestedVal := range oVal {


### PR DESCRIPTION
When a policy is looking for a field in a list, which is itself nested in an object in a list, and when there are multiple items in these lists on the cluster, the controller was not always matching things correctly. This could result in the policy's compliance depending on the order of the items in the nested list on the cluster. (The new test case may be more clear than this problem description.)

This situation is difficult to reproduce: because of the way some lists were compared before, fields that don't seem like they should affect the result can change the outcome.