### PR TITLE
Verify with the API server if an empty map is equal to nil

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -110,11 +110,17 @@ type ConfigurationPolicyReconciler struct {
 	// that reads objects from the cache and writes to the apiserver
 	client.Client
 	DecryptionConcurrency uint8
+	// Determines if the target Kubernetes cluster supports dry run update requests. When OpenShift <v4.5
+	// support is dropped, this can be removed as it's always true.
+	DryRunSupported bool
 	// Determines the number of Go routines that can evaluate policies concurrently.
 	EvaluationConcurrency uint8
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
-	InstanceName          string
+	// processedPolicyCache has the ConfigurationPolicy UID as the key and the values are a *sync.Map with the keys
+	// as object UIDs and the values as cachedEvaluationResult objects.
+	processedPolicyCache sync.Map
+	InstanceName         string
 	// The Kubernetes client to use when evaluating/enforcing policies. Most times, this will be the same cluster
 	// where the controller is running.
 	TargetK8sClient        kubernetes.Interface
@@ -239,6 +245,13 @@ func (r *ConfigurationPolicyReconciler) PeriodicallyExecConfigPolicies(
 
 				for i := range policiesList.Items {
 					policy := policiesList.Items[i]
+
+					// If the ConfigurationPolicy's spec field was updated, clear the cache of the objects that have
+					// been processed.
+					if policy.Status.LastEvaluatedGeneration != policy.Generation {
+						r.processedPolicyCache.Delete(policy.GetUID())
+					}
+
 					if !r.shouldEvaluatePolicy(&policy, cleanupImmediately) {
 						continue
 					}
@@ -965,6 +978,9 @@ func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.Confi
 			if templates.HasTemplate(rawData, "", true) {
 				log.V(1).Info("Processing policy templates")
 
+				// If there's a template, we can't rely on the cache results.
+				r.processedPolicyCache.Delete(plc.GetUID())
+
 				resolvedTemplate, tplErr := tmplResolver.ResolveTemplate(rawData, nil, &resolveOptions)
 
 				// If the error is because the padding is invalid, this either means the encrypted value was not
@@ -1493,6 +1509,9 @@ func (r *ConfigurationPolicyReconciler) handleObjects(
 			namespace,
 			r.TargetK8sDynamicClient,
 			strings.ToLower(string(objectT.ComplianceType)),
+			// Dry run API requests aren't run on unnamed object templates for performance reasons, so be less
+			// conservative in the comparison algorithm.
+			true,
 		)
 
 		// we do not support enforce on unnamed templates
@@ -1695,12 +1714,21 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 	if exists && obj.shouldExist {
 		log.V(2).Info("The object already exists. Verifying the object fields match what is desired.")
 
-		compType := strings.ToLower(string(objectT.ComplianceType))
-		mdCompType := strings.ToLower(string(objectT.MetadataComplianceType))
+		var throwSpecViolation, triedUpdate, updatedObj bool
+		var msg string
 
-		throwSpecViolation, msg, triedUpdate, updatedObj := r.checkAndUpdateResource(
-			obj, compType, mdCompType, remediation,
-		)
+		if evaluated, compliant := r.alreadyEvaluated(obj.policy, obj.existingObj); evaluated {
+			log.V(1).Info("Skipping object comparison since the resourceVersion hasn't changed")
+
+			throwSpecViolation = !compliant
+		} else {
+			compType := strings.ToLower(string(objectT.ComplianceType))
+			mdCompType := strings.ToLower(string(objectT.MetadataComplianceType))
+
+			throwSpecViolation, msg, triedUpdate, updatedObj = r.checkAndUpdateResource(
+				obj, compType, mdCompType, remediation,
+			)
+		}
 
 		if triedUpdate && !strings.Contains(msg, "Error validating the object") {
 			// The object was mismatched and was potentially fixed depending on the remediation action
@@ -1876,7 +1904,10 @@ func (r *ConfigurationPolicyReconciler) getMapping(
 
 // buildNameList is a helper function to pull names of resources that match an objectTemplate from a list of resources
 func buildNameList(
-	desiredObj unstructured.Unstructured, complianceType string, resList *unstructured.UnstructuredList,
+	desiredObj unstructured.Unstructured,
+	complianceType string,
+	resList *unstructured.UnstructuredList,
+	zeroValueEqualsNil bool,
 ) (kindNameList []string) {
 	for i := range resList.Items {
 		uObj := resList.Items[i]
@@ -1885,7 +1916,9 @@ func buildNameList(
 		for key := range desiredObj.Object {
 			// if any key in the object generates a mismatch, the object does not match the template and we
 			// do not add its name to the list
-			errorMsg, updateNeeded, _, skipped := handleSingleKey(key, desiredObj, &uObj, complianceType)
+			errorMsg, updateNeeded, _, skipped := handleSingleKey(
+				key, desiredObj, &uObj, complianceType, zeroValueEqualsNil,
+			)
 			if !skipped {
 				if errorMsg != "" || updateNeeded {
 					match = false
@@ -1910,6 +1943,7 @@ func getNamesOfKind(
 	ns string,
 	dclient dynamic.Interface,
 	complianceType string,
+	zeroValueEqualsNil bool,
 ) (kindNameList []string) {
 	if namespaced {
 		res := dclient.Resource(rsrc).Namespace(ns)
@@ -1921,7 +1955,7 @@ func getNamesOfKind(
 			return kindNameList
 		}
 
-		return buildNameList(desiredObj, complianceType, resList)
+		return buildNameList(desiredObj, complianceType, resList, zeroValueEqualsNil)
 	}
 
 	res := dclient.Resource(rsrc)
@@ -1933,7 +1967,7 @@ func getNamesOfKind(
 		return kindNameList
 	}
 
-	return buildNameList(desiredObj, complianceType, resList)
+	return buildNameList(desiredObj, complianceType, resList, zeroValueEqualsNil)
 }
 
 // enforceByCreatingOrDeleting can handle the situation where a musthave or mustonlyhave object is
@@ -2104,7 +2138,7 @@ func deleteObject(res dynamic.ResourceInterface, name, namespace string) (delete
 }
 
 // mergeSpecs is a wrapper for the recursive function to merge 2 maps.
-func mergeSpecs(templateVal, existingVal interface{}, ctype string) (interface{}, error) {
+func mergeSpecs(templateVal, existingVal interface{}, ctype string, zeroValueEqualsNil bool) (interface{}, error) {
 	// Copy templateVal since it will be modified in mergeSpecsHelper
 	data1, err := json.Marshal(templateVal)
 	if err != nil {
@@ -2118,7 +2152,7 @@ func mergeSpecs(templateVal, existingVal interface{}, ctype string) (interface{}
 		return nil, err
 	}
 
-	return mergeSpecsHelper(j1, existingVal, ctype), nil
+	return mergeSpecsHelper(j1, existingVal, ctype, zeroValueEqualsNil), nil
 }
 
 // mergeSpecsHelper is a helper function that takes an object from the existing object and merges in
@@ -2126,7 +2160,7 @@ func mergeSpecs(templateVal, existingVal interface{}, ctype string) (interface{}
 // that exists on the cluster will tell you whether the existing object is compliant with the template.
 // This function uses recursion to check mismatches in nested objects and is the basis for most
 // comparisons the controller makes.
-func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interface{} {
+func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string, zeroValueEqualsNil bool) interface{} {
 	switch templateVal := templateVal.(type) {
 	case map[string]interface{}:
 		existingVal, ok := existingVal.(map[string]interface{})
@@ -2139,7 +2173,7 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interf
 		// merge in missing values from the existing object
 		for k, v2 := range existingVal {
 			if v1, ok := templateVal[k]; ok {
-				templateVal[k] = mergeSpecsHelper(v1, v2, ctype)
+				templateVal[k] = mergeSpecsHelper(v1, v2, ctype, zeroValueEqualsNil)
 			} else {
 				templateVal[k] = v2
 			}
@@ -2154,7 +2188,7 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interf
 		if len(existingVal) > 0 {
 			// if both values are non-empty lists, we need to merge in the extra data in the existing
 			// object to do a proper compare
-			return mergeArrays(templateVal, existingVal, ctype)
+			return mergeArrays(templateVal, existingVal, ctype, zeroValueEqualsNil)
 		}
 	case nil:
 		// if template value is nil, pull data from existing, since the template does not care about it
@@ -2179,7 +2213,9 @@ type countedVal struct {
 
 // mergeArrays is a helper function that takes a list from the existing object and merges in all the data that is
 // different in the template.
-func mergeArrays(desiredArr []interface{}, existingArr []interface{}, ctype string) (result []interface{}) {
+func mergeArrays(
+	desiredArr []interface{}, existingArr []interface{}, ctype string, zeroValueEqualsNil bool,
+) (result []interface{}) {
 	if ctype == "mustonlyhave" {
 		return desiredArr
 	}
@@ -2246,12 +2282,12 @@ func mergeArrays(desiredArr []interface{}, existingArr []interface{}, ctype stri
 				}
 
 				// use map compare helper function to check equality on lists of maps
-				mergedObj, _ = compareSpecs(val1, val2, ctype)
+				mergedObj, _ = compareSpecs(val1, val2, ctype, zeroValueEqualsNil)
 			default:
 				mergedObj = val1
 			}
 			// if a match is found, this field is already in the template, so we can skip it in future checks
-			if sameNamedObjects || equalObjWithSort(mergedObj, val2) {
+			if sameNamedObjects || equalObjWithSort(mergedObj, val2, zeroValueEqualsNil) {
 				count++
 
 				desiredArr[desiredArrIdx] = mergedObj
@@ -2279,13 +2315,13 @@ func mergeArrays(desiredArr []interface{}, existingArr []interface{}, ctype stri
 // compareSpecs is a wrapper function that creates a merged map for mustHave
 // and returns the template map for mustonlyhave
 func compareSpecs(
-	newSpec, oldSpec map[string]interface{}, ctype string,
+	newSpec, oldSpec map[string]interface{}, ctype string, zeroValueEqualsNil bool,
 ) (updatedSpec map[string]interface{}, err error) {
 	if ctype == "mustonlyhave" {
 		return newSpec, nil
 	}
 	// if compliance type is musthave, create merged object to compare on
-	merged, err := mergeSpecs(newSpec, oldSpec, ctype)
+	merged, err := mergeSpecs(newSpec, oldSpec, ctype, zeroValueEqualsNil)
 	if err != nil {
 		return merged.(map[string]interface{}), err
 	}
@@ -2296,7 +2332,11 @@ func compareSpecs(
 // handleSingleKey checks whether a key/value pair in an object template matches with that in the existing
 // resource on the cluster
 func handleSingleKey(
-	key string, desiredObj unstructured.Unstructured, existingObj *unstructured.Unstructured, complianceType string,
+	key string,
+	desiredObj unstructured.Unstructured,
+	existingObj *unstructured.Unstructured,
+	complianceType string,
+	zeroValueEqualsNil bool,
 ) (errormsg string, update bool, merged interface{}, skip bool) {
 	log := log.WithValues("name", existingObj.GetName(), "namespace", existingObj.GetNamespace())
 	var err error
@@ -2323,7 +2363,7 @@ func handleSingleKey(
 	case []interface{}:
 		switch existingValue := existingValue.(type) {
 		case []interface{}:
-			mergedValue = mergeArrays(desiredValue, existingValue, complianceType)
+			mergedValue = mergeArrays(desiredValue, existingValue, complianceType, zeroValueEqualsNil)
 		case nil:
 			mergedValue = desiredValue
 		default:
@@ -2334,7 +2374,7 @@ func handleSingleKey(
 	case map[string]interface{}:
 		switch existingValue := existingValue.(type) {
 		case map[string]interface{}:
-			mergedValue, err = compareSpecs(desiredValue, existingValue, complianceType)
+			mergedValue, err = compareSpecs(desiredValue, existingValue, complianceType, zeroValueEqualsNil)
 		case nil:
 			mergedValue = desiredValue
 		default:
@@ -2387,7 +2427,7 @@ func handleSingleKey(
 	}
 
 	// sort objects before checking equality to ensure they're in the same order
-	if !equalObjWithSort(mergedValue, existingValue) {
+	if !equalObjWithSort(mergedValue, existingValue, zeroValueEqualsNil) {
 		updateNeeded = true
 	}
 
@@ -2441,6 +2481,11 @@ func (r *ConfigurationPolicyReconciler) validateObject(object *unstructured.Unst
 	)
 }
 
+type cachedEvaluationResult struct {
+	resourceVersion string
+	compliant       bool
+}
+
 // checkAndUpdateResource checks each individual key of a resource and passes it to handleKeys to see if it
 // matches the template and update it if the remediationAction is enforce. UpdateNeeded indicates whether the
 // function tried to update the child object and updateSucceeded indicates whether the update was applied
@@ -2488,6 +2533,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	updateSucceeded = false
 	// Use a copy since some values can be directly assigned to mergedObj in handleSingleKey.
 	existingObjectCopy := obj.existingObj.DeepCopy()
+	removeFieldsForComparison(existingObjectCopy)
 
 	for key := range obj.desiredObj.Object {
 		isStatus := key == "status"
@@ -2500,7 +2546,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 
 		// check key for mismatch
 		errorMsg, keyUpdateNeeded, mergedObj, skipped := handleSingleKey(
-			key, obj.desiredObj, existingObjectCopy, keyComplianceType,
+			key, obj.desiredObj, existingObjectCopy, keyComplianceType, !r.DryRunSupported,
 		)
 		if errorMsg != "" {
 			log.Info(errorMsg)
@@ -2528,14 +2574,26 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 		}
 
 		if keyUpdateNeeded {
-			if strings.EqualFold(string(remediation), string(policyv1.Inform)) {
+			isInform := strings.EqualFold(string(remediation), string(policyv1.Inform))
+
+			// If a key didn't match but the cluster supports dry run mode, then continue merging the object
+			// and then run a dry run update request to see if the Kubernetes API agrees with the assesment.
+			if isInform && !r.DryRunSupported {
+				r.setEvaluatedObject(obj.policy, obj.existingObj, false)
+
 				return true, "", false, false
-			} else if isStatus {
+			}
+
+			if isStatus {
 				throwSpecViolation = true
+
 				log.Info("Ignoring an update to the object status", "key", key)
 			} else {
 				updateNeeded = true
-				log.Info("Queuing an update for the object due to a value mismatch", "key", key)
+
+				if !isInform {
+					log.Info("Queuing an update for the object due to a value mismatch", "key", key)
+				}
 			}
 		}
 	}
@@ -2553,31 +2611,140 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 			}
 		}
 
-		_, err := res.Update(context.TODO(), obj.existingObj, metav1.UpdateOptions{
-			FieldValidation: metav1.FieldValidationStrict,
-		})
-		if k8serrors.IsNotFound(err) {
-			message := fmt.Sprintf("`%v` is not present and must be created", obj.existingObj.GetKind())
+		// If the cluster supports dry run requests, verify that the API server agrees with the local comparison logic.
+		// It's possible the dry run request shows the object does match. This can happen if the ConfigurationPolicy
+		// specifies an empty map and the API server omits it from the return value.
+		if r.DryRunSupported {
+			dryRunUpdatedObj, err := res.Update(context.TODO(), obj.existingObj, metav1.UpdateOptions{
+				FieldValidation: metav1.FieldValidationStrict,
+				DryRun:          []string{metav1.DryRunAll},
+			})
+			if err != nil {
+				// If an inform policy and the update is forbidden (i.e. modifying Pod spec fields), then return
+				// noncompliant since that confirms some fields don't match.
+				if k8serrors.IsForbidden(err) {
+					r.setEvaluatedObject(obj.policy, obj.existingObj, false)
 
-			return true, message, updateNeeded, false
-		}
+					return true, "", false, false
+				}
 
-		if err != nil {
-			if strings.Contains(err.Error(), "strict decoding error:") {
-				message := fmt.Sprintf("Error validating the object %s, the error is `%v`", obj.name, err)
+				message := getUpdateErrorMsg(err, obj.existingObj.GetKind(), obj.name)
+				if message == "" {
+					message = fmt.Sprintf(
+						"Error issuing a dry run update request for the object `%v`, the error is `%v`",
+						obj.name,
+						err,
+					)
+				}
 
 				return true, message, updateNeeded, false
 			}
 
-			message := fmt.Sprintf("Error updating the object `%v`, the error is `%v`", obj.name, err)
+			removeFieldsForComparison(dryRunUpdatedObj)
+
+			if reflect.DeepEqual(dryRunUpdatedObj.Object, existingObjectCopy.Object) {
+				log.Info(
+					"A mismatch was detected but a dry run update didn't make any changes. Assuming the object is " +
+						"compliant.",
+				)
+
+				r.setEvaluatedObject(obj.policy, obj.existingObj, true)
+
+				return false, "", false, false
+			}
+
+			// The object would have been updated, so if it's inform, return as noncompliant.
+			if strings.EqualFold(string(remediation), string(policyv1.Inform)) {
+				r.setEvaluatedObject(obj.policy, obj.existingObj, false)
+
+				return true, "", false, false
+			}
+		}
+
+		updatedObj, err := res.Update(context.TODO(), obj.existingObj, metav1.UpdateOptions{
+			FieldValidation: metav1.FieldValidationStrict,
+		})
+		if err != nil {
+			message := getUpdateErrorMsg(err, obj.existingObj.GetKind(), obj.name)
+			if message == "" {
+				message = fmt.Sprintf("Error updating the object `%v`, the error is `%v`", obj.name, err)
+			}
 
 			return true, message, updateNeeded, false
 		}
 
+		r.setEvaluatedObject(obj.policy, updatedObj, true)
+
 		updateSucceeded = true
+	} else {
+		r.setEvaluatedObject(obj.policy, obj.existingObj, !throwSpecViolation)
 	}
 
 	return throwSpecViolation, "", updateNeeded, updateSucceeded
+}
+
+func removeFieldsForComparison(obj *unstructured.Unstructured) {
+	unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(
+		obj.Object, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration",
+	)
+	// The generation might actually bump but the API output might be the same.
+	unstructured.RemoveNestedField(obj.Object, "metadata", "generation")
+}
+
+// setEvaluatedObject updates the cache to indicate that the ConfigurationPolicy has evaluated this
+// object at its current resourceVersion.
+func (r *ConfigurationPolicyReconciler) setEvaluatedObject(
+	policy *policyv1.ConfigurationPolicy, currentObject *unstructured.Unstructured, compliant bool,
+) {
+	policyMap := &sync.Map{}
+
+	loadedPolicyMap, loaded := r.processedPolicyCache.LoadOrStore(policy.GetUID(), policyMap)
+	if loaded {
+		policyMap = loadedPolicyMap.(*sync.Map)
+	}
+
+	policyMap.Store(
+		currentObject.GetUID(),
+		cachedEvaluationResult{
+			resourceVersion: currentObject.GetResourceVersion(),
+			compliant:       compliant,
+		},
+	)
+}
+
+// alreadyEvaluated will determine if this ConfigurationPolicy has already evaluated this object at its current
+// resourceVersion.
+func (r *ConfigurationPolicyReconciler) alreadyEvaluated(
+	policy *policyv1.ConfigurationPolicy, currentObject *unstructured.Unstructured,
+) (evaluated bool, compliant bool) {
+	loadedPolicyMap, loaded := r.processedPolicyCache.Load(policy.GetUID())
+	if !loaded {
+		return false, false
+	}
+
+	policyMap := loadedPolicyMap.(*sync.Map)
+
+	result, loaded := policyMap.Load(currentObject.GetUID())
+	if !loaded {
+		return false, false
+	}
+
+	resultTyped := result.(cachedEvaluationResult)
+
+	return resultTyped.resourceVersion == currentObject.GetResourceVersion(), resultTyped.compliant
+}
+
+func getUpdateErrorMsg(err error, kind string, name string) string {
+	if k8serrors.IsNotFound(err) {
+		return fmt.Sprintf("`%v` is not present and must be created", kind)
+	}
+
+	if err != nil && strings.Contains(err.Error(), "strict decoding error:") {
+		return fmt.Sprintf("Error validating the object %s, the error is `%v`", name, err)
+	}
+
+	return ""
 }
 
 // AppendCondition check and appends conditions to the policy status

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -91,7 +91,7 @@ func TestCompareSpecs(t *testing.T) {
 		},
 	}
 
-	merged, err := compareSpecs(spec1, spec2, "mustonlyhave")
+	merged, err := compareSpecs(spec1, spec2, "mustonlyhave", true)
 	if err != nil {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
@@ -123,7 +123,7 @@ func TestCompareSpecs(t *testing.T) {
 		},
 	}
 
-	merged, err = compareSpecs(spec1, spec2, "musthave")
+	merged, err = compareSpecs(spec1, spec2, "musthave", true)
 	if err != nil {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
@@ -291,7 +291,7 @@ func TestMergeArraysMustHave(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			actualMergedList := mergeArrays(test.desiredList, test.currentList, "musthave")
+			actualMergedList := mergeArrays(test.desiredList, test.currentList, "musthave", true)
 			assert.Equal(t, fmt.Sprintf("%+v", test.expectedList), fmt.Sprintf("%+v", actualMergedList))
 			assert.True(t, checkListsMatch(test.expectedList, actualMergedList))
 		})
@@ -378,7 +378,7 @@ func TestMergeArraysMustOnlyHave(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			actualMergedList := mergeArrays(test.desiredList, test.currentList, "mustonlyhave")
+			actualMergedList := mergeArrays(test.desiredList, test.currentList, "mustonlyhave", true)
 			assert.Equal(t, fmt.Sprintf("%+v", test.expectedList), fmt.Sprintf("%+v", actualMergedList))
 			assert.True(t, checkListsMatch(test.expectedList, actualMergedList))
 		})
@@ -541,14 +541,14 @@ status:
 	existingObjOrderOne := unstructured.Unstructured{Object: orderOneObj}
 	existingObjOrderTwo := unstructured.Unstructured{Object: orderTwoObj}
 
-	errormsg, updateNeeded, _, _ := handleSingleKey("status", desiredObj, &existingObjOrderOne, "musthave")
+	errormsg, updateNeeded, _, _ := handleSingleKey("status", desiredObj, &existingObjOrderOne, "musthave", true)
 	if len(errormsg) != 0 {
 		t.Error("Got unexpected error message", errormsg)
 	}
 
 	assert.False(t, updateNeeded)
 
-	errormsg, updateNeeded, _, _ = handleSingleKey("status", desiredObj, &existingObjOrderTwo, "musthave")
+	errormsg, updateNeeded, _, _ = handleSingleKey("status", desiredObj, &existingObjOrderTwo, "musthave", true)
 	if len(errormsg) != 0 {
 		t.Error("Got unexpected error message", errormsg)
 	}
@@ -1304,7 +1304,7 @@ func TestShouldHandleSingleKeyFalse(t *testing.T) {
 		unstruct.Object = test.input
 		unstructObj.Object = test.fromAPI
 		key := test.expectResult.key
-		_, update, _, skip = handleSingleKey(key, unstruct, &unstructObj, "musthave")
+		_, update, _, skip = handleSingleKey(key, unstruct, &unstructObj, "musthave", true)
 		assert.Equal(t, update, test.expectResult.expect)
 		assert.False(t, skip)
 	}

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -106,11 +106,11 @@ func updateRelatedObjectsStatus(
 
 // equalObjWithSort is a wrapper function that calls the correct function to check equality depending on what
 // type the objects to compare are
-func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool) {
+func equalObjWithSort(mergedObj interface{}, oldObj interface{}, zeroValueEqualsNil bool) (areEqual bool) {
 	switch mergedObj := mergedObj.(type) {
 	case map[string]interface{}:
 		if oldObjMap, ok := oldObj.(map[string]interface{}); ok {
-			return checkFieldsWithSort(mergedObj, oldObjMap)
+			return checkFieldsWithSort(mergedObj, oldObjMap, zeroValueEqualsNil)
 		}
 		// this includes the case where oldObj is nil
 		return false
@@ -125,20 +125,22 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 
 		return false
 	default: // when mergedObj's type is string, int, bool, or nil
-		if oldObj == nil && mergedObj != nil {
-			// compare the zero value of mergedObj's type to mergedObj
-			ref := reflect.ValueOf(mergedObj)
-			zero := reflect.Zero(ref.Type()).Interface()
+		if zeroValueEqualsNil {
+			if oldObj == nil && mergedObj != nil {
+				// compare the zero value of mergedObj's type to mergedObj
+				ref := reflect.ValueOf(mergedObj)
+				zero := reflect.Zero(ref.Type()).Interface()
 
-			return fmt.Sprint(zero) == fmt.Sprint(mergedObj)
-		}
+				return fmt.Sprint(zero) == fmt.Sprint(mergedObj)
+			}
 
-		if mergedObj == nil && oldObj != nil {
-			// compare the zero value of oldObj's type to oldObj
-			ref := reflect.ValueOf(oldObj)
-			zero := reflect.Zero(ref.Type()).Interface()
+			if mergedObj == nil && oldObj != nil {
+				// compare the zero value of oldObj's type to oldObj
+				ref := reflect.ValueOf(oldObj)
+				zero := reflect.Zero(ref.Type()).Interface()
 
-			return fmt.Sprint(zero) == fmt.Sprint(oldObj)
+				return fmt.Sprint(zero) == fmt.Sprint(oldObj)
+			}
 		}
 
 		return fmt.Sprint(mergedObj) == fmt.Sprint(oldObj)
@@ -147,7 +149,9 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 
 // checkFieldsWithSort is a check for maps that uses an arbitrary sort to ensure it is
 // comparing the right values
-func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]interface{}) (matches bool) {
+func checkFieldsWithSort(
+	mergedObj map[string]interface{}, oldObj map[string]interface{}, zeroValueEqualsNil bool,
+) (matches bool) {
 	// needed to compare lists, since merge messes up the order
 	if len(mergedObj) < len(oldObj) {
 		return false
@@ -159,14 +163,14 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 			// if field is a map, recurse to check for a match
 			oVal, ok := oldObj[i].(map[string]interface{})
 			if !ok {
-				if len(mVal) == 0 {
+				if zeroValueEqualsNil && len(mVal) == 0 {
 					break
 				}
 
 				return false
 			}
 
-			if !checkFieldsWithSort(mVal, oVal) {
+			if !checkFieldsWithSort(mVal, oVal, zeroValueEqualsNil) {
 				return false
 			}
 		case []interface{}:
@@ -280,7 +284,7 @@ func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 		case map[string]interface{}:
 			// if list contains maps, recurse on those maps to check for a match
 			if mVal, ok := mVal[idx].(map[string]interface{}); ok {
-				if len(mVal) != len(oNestedVal) || !checkFieldsWithSort(mVal, oNestedVal) {
+				if len(mVal) != len(oNestedVal) || !checkFieldsWithSort(mVal, oNestedVal, true) {
 					return false
 				}
 

--- a/controllers/configurationpolicy_utils_test.go
+++ b/controllers/configurationpolicy_utils_test.go
@@ -116,7 +116,30 @@ func TestCheckFieldsWithSort(t *testing.T) {
 		"resources":       []interface{}{},
 	}
 
-	assert.True(t, checkFieldsWithSort(mergedObj, oldObj))
+	assert.True(t, checkFieldsWithSort(mergedObj, oldObj, false))
+}
+
+func TestCheckFieldsWithSortEmptyMap(t *testing.T) {
+	oldObj := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"storage": map[string]interface{}{
+				"s3": map[string]interface{}{
+					"bucket": "some-bucket",
+				},
+			},
+		},
+	}
+	mergedObj := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"storage": map[string]interface{}{
+				"emptyDir": map[string]interface{}{},
+			},
+		},
+	}
+
+	assert.False(t, checkFieldsWithSort(mergedObj, oldObj, false))
+
+	assert.True(t, checkFieldsWithSort(mergedObj, oldObj, true))
 }
 
 func TestEqualObjWithSort(t *testing.T) {
@@ -133,8 +156,8 @@ func TestEqualObjWithSort(t *testing.T) {
 		"resources":       []interface{}{},
 	}
 
-	assert.True(t, equalObjWithSort(mergedObj, oldObj))
-	assert.False(t, equalObjWithSort(mergedObj, nil))
+	assert.True(t, equalObjWithSort(mergedObj, oldObj, true))
+	assert.False(t, equalObjWithSort(mergedObj, nil, true))
 
 	oldObj = map[string]interface{}{
 		"nonResourceURLs": []string{"/version", "/healthz"},
@@ -147,5 +170,30 @@ func TestEqualObjWithSort(t *testing.T) {
 		"resources":       []interface{}{},
 	}
 
-	assert.False(t, equalObjWithSort(mergedObj, oldObj))
+	assert.False(t, equalObjWithSort(mergedObj, oldObj, true))
+}
+
+func TestEqualObjWithSortString(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, equalObjWithSort("", nil, true))
+	assert.False(t, equalObjWithSort("", nil, false))
+	assert.True(t, equalObjWithSort(nil, "", true))
+	assert.False(t, equalObjWithSort(nil, "", false))
+}
+
+func TestEqualObjWithSortEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	oldObj := map[string]interface{}{
+		"cities": map[string]interface{}{},
+	}
+	mergedObj := map[string]interface{}{
+		"cities": map[string]interface{}{
+			"raleigh": map[string]interface{}{},
+		},
+	}
+
+	assert.True(t, equalObjWithSort(mergedObj, oldObj, true))
+	assert.False(t, equalObjWithSort(mergedObj, oldObj, false))
 }

--- a/test/e2e/case36_empty_map_test.go
+++ b/test/e2e/case36_empty_map_test.go
@@ -1,0 +1,70 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+var _ = Describe("Test resource creation when there are empty labels in configurationPolicy", Ordered, func() {
+	const (
+		case36AddEmptyMap     = "../resources/case36_empty_map/policy-should-add-empty-map.yaml"
+		case36AddEmptyMapName = "case36-check-selinux-options"
+		case36NoEmptyMap      = "../resources/case36_empty_map/policy-should-not-add-empty-map.yaml"
+		case36NoEmptyMapName  = "case36-check-node-selector"
+		case36Deployment      = "../resources/case36_empty_map/deployment.yaml"
+		case36DeploymentName  = "case36-deployment"
+	)
+
+	BeforeEach(func() {
+		By("creating the deployment " + case36DeploymentName)
+		utils.Kubectl("apply", "-f", case36Deployment)
+	})
+
+	AfterEach(func() {
+		By("deleting the deployment " + case36DeploymentName)
+		utils.Kubectl("delete", "-f", case36Deployment, "--ignore-not-found")
+		deleteConfigPolicies([]string{case36AddEmptyMapName, case36NoEmptyMapName})
+	})
+
+	It("verifies the policy "+case36AddEmptyMapName+"is NonCompliant", func() {
+		By("creating the policy " + case36AddEmptyMapName)
+		utils.Kubectl("apply", "-f", case36AddEmptyMap, "-n", testNamespace)
+
+		By("checking if the policy " + case36AddEmptyMapName + " is NonCompliant")
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				case36AddEmptyMapName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+	})
+
+	It("verifies the policy "+case36NoEmptyMapName+"is Compliant", func() {
+		By("creating the policy " + case36NoEmptyMapName)
+		utils.Kubectl("apply", "-f", case36NoEmptyMap, "-n", testNamespace)
+
+		By("checking if the policy " + case36NoEmptyMapName + " is Compliant")
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				case36NoEmptyMapName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+})

--- a/test/resources/case36_empty_map/deployment.yaml
+++ b/test/resources/case36_empty_map/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: case36-deployment
+  namespace: default
+  labels:
+    test: case36-deployment
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      test: case36-deployment
+  template:
+    metadata:
+      labels:
+        test: case36-deployment
+    spec:
+      securityContext: {}
+      containers:
+        - image: nginx:1.7.9
+          imagePullPolicy: Never
+          name: nginx

--- a/test/resources/case36_empty_map/policy-should-add-empty-map.yaml
+++ b/test/resources/case36_empty_map/policy-should-add-empty-map.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case36-check-selinux-options
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: case36-deployment
+          namespace: default
+        spec:
+          template:
+            spec:
+              # securityContext defaults to `{}` and seLinuxOptions has omitempty on the API server but is a pointer,
+              # so setting this to an empty object will cause the empty object to be returned by the API.
+              securityContext:
+                seLinuxOptions: {}

--- a/test/resources/case36_empty_map/policy-should-not-add-empty-map.yaml
+++ b/test/resources/case36_empty_map/policy-should-not-add-empty-map.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case36-check-node-selector
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: case36-deployment
+          namespace: default
+        spec:
+          template:
+            spec:
+              # This is omitempty and is type map[string]string, so an empty value will not be returned by the API.
+              nodeSelector: {}


### PR DESCRIPTION
If a policy specified an empty map but the object didn't return a value for the map, it was assumed that API server was just not returning an empty value.

This is true in most cases, however, if the underlying Go type of the map is a pointer to a struct, an empty map may have a different meaning than nil. One example is the `emptyDir` key in the "configs.imageregistry.operator.openshift.io" resource.

This commit changes the local comparison logic from considering empty maps being the same as a nil value. The controller then performs a dry run update request to see if the API server returns an empty map or omits the value entirely (i.e. seen as nil).

The result of the object comparison is now cached to not continuously making dry run update requests on every policy evaluation.

Relates:
https://issues.redhat.com/browse/ACM-7810