### PR TITLE
Handle values omitted from the API server in arrays of objects

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -471,6 +471,34 @@ func TestCheckListsMatch(t *testing.T) {
 	assert.False(t, checkListsMatch(oneBigOneSmall, twoFullItems))
 }
 
+func TestCheckListsMatchDiffMapLength(t *testing.T) {
+	existingObject := []interface{}{
+		map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "my-container",
+					"image": "quay.io/org/test:latest",
+				},
+			},
+		},
+	}
+
+	mergedObject := []interface{}{
+		map[string]interface{}{
+			"containers": []interface{}{
+				map[string]interface{}{
+					"name":  "my-container",
+					"image": "quay.io/org/test:latest",
+					"stdin": false,
+					"tty":   false,
+				},
+			},
+		},
+	}
+
+	assert.True(t, checkListsMatch(existingObject, mergedObject))
+}
+
 func TestNestedUnsortedLists(t *testing.T) {
 	objDefYaml := `
 kind: FakeOperator

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -280,7 +280,7 @@ func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 		case map[string]interface{}:
 			// if list contains maps, recurse on those maps to check for a match
 			if mVal, ok := mVal[idx].(map[string]interface{}); ok {
-				if len(mVal) != len(oNestedVal) || !checkFieldsWithSort(mVal, oNestedVal) {
+				if !checkFieldsWithSort(mVal, oNestedVal) {
 					return false
 				}
 

--- a/test/resources/case12_list_compare/case12_whitespace_create.yaml
+++ b/test/resources/case12_list_compare/case12_whitespace_create.yaml
@@ -32,3 +32,5 @@ spec:
                   env:
                     - name: DEMO_GREETING
                       value: " \t hello with tricky whitespace \n "
+                  stdin: false
+                  tty: false


### PR DESCRIPTION
In the example of a Pod definition in a Deployment, you could set `stdin: false` and `tty: false` for the container in a ConfigurationPolicy, but the API server would omit them from the return value. This would lead to the merged map and existing map to have a different length, and causing the comparison to end early. This was wrong in this case since a missing boolean should be treated the same as `false` set in the ConfigurationPolicy.

Relates:
https://issues.redhat.com/browse/ACM-8391