### PR TITLE
Fix a bug related to unnamed objects

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1525,6 +1525,13 @@ func (r *ConfigurationPolicyReconciler) handleObjects(
 
 		if len(objNames) == 0 {
 			exists = false
+		} else if len(objNames) == 1 {
+			// If the object couldn't be retrieved, this will be handled later on.
+			existingObj, _ = getObject(
+				objDetails.isNamespaced, namespace, objNames[0], mapping.Resource, r.TargetK8sDynamicClient,
+			)
+
+			exists = existingObj != nil
 		}
 	}
 
@@ -2746,6 +2753,10 @@ func (r *ConfigurationPolicyReconciler) setEvaluatedObject(
 func (r *ConfigurationPolicyReconciler) alreadyEvaluated(
 	policy *policyv1.ConfigurationPolicy, currentObject *unstructured.Unstructured,
 ) (evaluated bool, compliant bool) {
+	if policy == nil || currentObject == nil {
+		return false, false
+	}
+
 	loadedPolicyMap, loaded := r.processedPolicyCache.Load(policy.GetUID())
 	if !loaded {
 		return false, false

--- a/test/resources/case10_kind_field/case10_kind_check.yaml
+++ b/test/resources/case10_kind_field/case10_kind_check.yaml
@@ -6,6 +6,13 @@ spec:
   remediationAction: inform # will be overridden by remediationAction in parent policy
   severity: low
   object-templates:
+    # The first object template is ensure no regression for https://issues.redhat.com/browse/ACM-8731
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: default
     - complianceType: musthave
       objectDefinition:
         apiVersion: v1


### PR DESCRIPTION
In the case where an object-template included an unnamed object and only one object was returned, it went into the typical `handleSingleObj` flow but marked `exists` as true without setting `existingObj` in the input to `handleSingleObj`. There was an assumption that `existingObj` would always be set if `exists` was set.

Commit ffc115c made this panic because `GetUID` was being called on a nil `existingObj`. Prior to this, it seems it would just erroneously say it was compliant without checking it.

Relates:
https://issues.redhat.com/browse/ACM-8731