### PR TITLE
Add relatedObjs to unnamed musthave object

### DIFF
--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -65,6 +65,45 @@ func addRelatedObjects(
 	return relatedObjects
 }
 
+// addCondensedRelatedObjs does not include all of relatedObjs.
+// The Name field is "*". The list of objects will be presented on the console.
+func addCondensedRelatedObjs(
+	rsrc schema.GroupVersionResource,
+	compliant bool,
+	kind string,
+	namespace string,
+	namespaced bool,
+	reason string,
+) (relatedObjects []policyv1.RelatedObject) {
+	metadata := policyv1.ObjectMetadata{Name: "*"}
+
+	if namespaced {
+		metadata.Namespace = namespace
+	} else {
+		metadata.Namespace = ""
+	}
+
+	// Initialize the related object from the object handling
+	relatedObject := policyv1.RelatedObject{
+		Reason: reason,
+		Object: policyv1.ObjectResource{
+			APIVersion: rsrc.GroupVersion().String(),
+			Kind:       kind,
+			Metadata:   metadata,
+		},
+	}
+
+	if compliant {
+		relatedObject.Compliant = string(policyv1.Compliant)
+	} else {
+		relatedObject.Compliant = string(policyv1.NonCompliant)
+	}
+
+	relatedObjects = append(relatedObjects, relatedObject)
+
+	return relatedObjects
+}
+
 // unmarshalFromJSON unmarshals raw JSON data into an object
 func unmarshalFromJSON(rawData []byte) (unstructured.Unstructured, error) {
 	var unstruct unstructured.Unstructured

--- a/test/e2e/case14_selection_test.go
+++ b/test/e2e/case14_selection_test.go
@@ -164,11 +164,14 @@ var _ = Describe("Test policy compliance with namespace selection", Ordered, fun
 			// If an object name is specified in the policy, related objects match those in the template.
 			// If an object name is not specified in the policy, related objects match those in the
 			//   cluster as this is not enforceable.
-			if policy.hasObjName {
-				Expect(checkRelated(plc)).Should(HaveLen(len(testNamespaces) + 1))
-			} else {
-				Expect(checkRelated(plc)).Should(HaveLen(len(testNamespaces)))
-			}
+			// When hasObjName = false
+			// compliant: NonCompliant
+			//  metadata:
+			// 	  name: '*'
+			//    namespace: range3
+			// reason: Resource not found but should exist
+			// is attached for range3.
+			Expect(checkRelated(plc)).Should(HaveLen(len(testNamespaces) + 1))
 		}
 	})
 

--- a/test/e2e/case37_no_name_test.go
+++ b/test/e2e/case37_no_name_test.go
@@ -1,0 +1,396 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+var _ = Describe("Test a namespace-scope policy that is missing name", Ordered, func() {
+	const (
+		case37GoodIngressPath       string = "../resources/case37_no_name/case37_good_ingress.yaml"
+		case37BadIngressPath        string = "../resources/case37_no_name/case37_bad_ingresses.yaml"
+		case37PolicyNSPath          string = "../resources/case37_no_name/case37_no_name_policy.yaml"
+		case37PolicyNSName          string = "case37-test-policy-1"
+		case37PolicyNotHavePath     string = "../resources/case37_no_name/case37_no_name_policy_nothave.yaml"
+		case37PolicyMustnothaveName string = "case37-test-policy-mustnothave"
+	)
+	Describe("Test a musthave", Ordered, func() {
+		BeforeAll(func() {
+			By("Creating a policy on managed")
+			utils.Kubectl("apply", "-f", case37PolicyNSPath, "-n", testNamespace)
+			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyNSName, testNamespace, true, defaultTimeoutSeconds)
+			Expect(plc).ShouldNot(BeNil())
+		})
+		It("should have 1 NonCompliant relatedObject under the policy's status", func() {
+			By("Apply bad ingresses")
+			utils.Kubectl("apply", "-f", case37BadIngressPath)
+
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyNSName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+			var relatedObjects []interface{}
+
+			By("relatedObjects should exist")
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyNSName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(relatedObjects).ShouldNot(BeNil())
+
+				return relatedObjects
+				// Getting relatedObjects takes longer time
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			By("Check the kind of related object")
+			kind := relatedObjects[0].(map[string]interface{})["object"].(map[string]interface{})["kind"].(string)
+			Expect(kind).Should(Equal("Ingress"))
+
+			By("Check the reason of related object")
+			relatedObjectsOne := relatedObjects[0].(map[string]interface{})
+			Expect(relatedObjectsOne["reason"].(string)).Should(Equal("Resource found but does not match"))
+
+			By("Check the name of related object is *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).Should(Equal("*"))
+		})
+		It("should have 1 Compliant relatedObject under the policy's status", func() {
+			By("Apply good ingress")
+			utils.Kubectl("apply", "-f", case37GoodIngressPath)
+
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyNSName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+			var relatedObjects []interface{}
+
+			By("relatedObjects should exist")
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyNSName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(relatedObjects).ShouldNot(BeNil())
+
+				return relatedObjects
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			//  NonCompliant relatedObjects Should be deleted and only the Compliant relatedObject remain
+			By("Check the kind of related object")
+			kind := relatedObjects[0].(map[string]interface{})["object"].(map[string]interface{})["kind"].(string)
+			Expect(kind).Should(Equal("Ingress"))
+
+			By("Check the reason of related objects")
+			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
+			Expect(reason).Should(Equal("Resource found as expected"))
+
+			By("Check the name of related object is not *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).ShouldNot(Equal("*"))
+		})
+		AfterAll(func() {
+			utils.Kubectl("delete", "-f", case37PolicyNSPath, "-n", testNamespace, "--ignore-not-found")
+			utils.Kubectl("delete", "-f", case37GoodIngressPath, "--ignore-not-found")
+			utils.Kubectl("delete", "-f", case37BadIngressPath, "--ignore-not-found")
+			utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyNSName, testNamespace, false, defaultTimeoutSeconds)
+		})
+	})
+	Describe("Test a mustnothave", Ordered, func() {
+		BeforeAll(func() {
+			By("Creating a policy on managed")
+			utils.Kubectl("apply", "-f", case37PolicyNotHavePath, "-n", testNamespace)
+			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+			Expect(plc).ShouldNot(BeNil())
+		})
+		It("should have 1 Compliant relatedObject under the policy's status", func() {
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+			By("relatedObjects should exist")
+			var relatedObjects []interface{}
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+				g.Expect(err).ShouldNot(HaveOccurred())
+
+				return relatedObjects
+				// Getting relatedObjects takes longer time
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			By("Check the reasons of related object")
+			relatedObjectsOne := relatedObjects[0].(map[string]interface{})
+			Expect(relatedObjectsOne["reason"].(string)).Should(Equal("Resource not found as expected"))
+
+			By("Check the name of related object is *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).Should(Equal("*"))
+		})
+		It("should have 1 Compliant relatedObject under the policy's status", func() {
+			By("Apply a ingress that is not related to policy")
+			utils.Kubectl("apply", "-f", case37BadIngressPath)
+
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+			var relatedObjects []interface{}
+
+			By("relatedObjects should exist")
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(relatedObjects).ShouldNot(BeNil())
+
+				return relatedObjects
+				// Getting relatedObjects takes longer time
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			By("Check the kind of related objects")
+			kind := relatedObjects[0].(map[string]interface{})["object"].(map[string]interface{})["kind"].(string)
+			Expect(kind).Should(Equal("Ingress"))
+
+			By("Check the reasons of related objects")
+			relatedObjectsOne := relatedObjects[0].(map[string]interface{})
+			Expect(relatedObjectsOne["reason"].(string)).Should(Equal("Resource not found as expected"))
+
+			By("Check the name of related object is *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).Should(Equal("*"))
+		})
+		It("should have 1 NonCompliant relatedObject under the policy's status", func() {
+			By("Apply a ingress")
+			utils.Kubectl("apply", "-f", case37GoodIngressPath)
+
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+			var relatedObjects []interface{}
+
+			By("relatedObjects should exist")
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(relatedObjects).ShouldNot(BeNil())
+
+				return relatedObjects
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			//  NonCompliant relatedObjects Should be deleted and only the Compliant relatedObject remain
+			By("Check the kind of related objects")
+			kind := relatedObjects[0].(map[string]interface{})["object"].(map[string]interface{})["kind"].(string)
+			Expect(kind).Should(Equal("Ingress"))
+
+			By("Check the reason of related object")
+			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
+			Expect(reason).Should(Equal("Resource found but should not exist"))
+
+			By("Check the name of related object is not *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).ShouldNot(Equal("*"))
+		})
+		AfterAll(func() {
+			utils.Kubectl("delete", "-f", case37PolicyNotHavePath, "-n", testNamespace, "--ignore-not-found")
+			utils.Kubectl("delete", "-f", case37GoodIngressPath, "--ignore-not-found")
+			utils.Kubectl("delete", "-f", case37BadIngressPath, "--ignore-not-found")
+			utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyMustnothaveName, testNamespace, false, defaultTimeoutSeconds)
+		})
+	})
+})
+
+var _ = Describe("Test a cluster-scope policy that is missing name ", Ordered, func() {
+	const (
+		case37BadIngressClassPath     string = "../resources/case37_no_name/case37_bad_ingressclass.yaml"
+		case37PolicyCSPath            string = "../resources/case37_no_name/case37_no_name_clusterscope_policy.yaml"
+		case37PolicyCSName            string = "case37-test-policy-clusterscope"
+		case37PolicyCSMustnothavePath string = "../resources/case37_no_name/" +
+			"case37_no_name_clusterscope_policy_nothave.yaml"
+		case37PolicyCSMustnothaveName string = "case37-test-policy-clusterscope-mustnothave"
+	)
+
+	Describe("Test a musthave", func() {
+		BeforeEach(func() {
+			By("Creating a policy on managed")
+			utils.Kubectl("apply", "-f", case37PolicyCSPath, "-n", testNamespace)
+			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyCSName, testNamespace, true, defaultTimeoutSeconds)
+			Expect(plc).ShouldNot(BeNil())
+
+			By("Creating a IngressClass")
+			utils.Kubectl("apply", "-f", case37BadIngressClassPath)
+		})
+		It("should have 1 NonCompliant relatedObject under the policy's status", func() {
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyCSName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+			var relatedObjects []interface{}
+
+			By("relatedObjects should exist")
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyCSName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(relatedObjects).ShouldNot(BeNil())
+
+				return relatedObjects
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			By("Check the kind of related object")
+			kind := relatedObjects[0].(map[string]interface{})["object"].(map[string]interface{})["kind"].(string)
+			Expect(kind).Should(Equal("IngressClass"))
+
+			By("Check the reason of related object")
+			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
+			Expect(reason).Should(Equal("Resource found but does not match"))
+
+			By("Check the name of relatedObject is *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).Should(Equal("*"))
+		})
+		AfterEach(func() {
+			utils.Kubectl("delete", "-f", case37PolicyCSPath, "-n", testNamespace, "--ignore-not-found")
+			utils.Kubectl("delete", "-f", case37BadIngressClassPath, "--ignore-not-found")
+			utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyCSName, testNamespace, false, defaultTimeoutSeconds)
+		})
+	})
+	Describe("Test a mustnothave", func() {
+		BeforeEach(func() {
+			By("Creating a policy on managed")
+			utils.Kubectl("apply", "-f", case37PolicyCSMustnothavePath, "-n", testNamespace)
+			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyCSMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+			Expect(plc).ShouldNot(BeNil())
+
+			By("Creating a IngressClass that is not related to the policy")
+			utils.Kubectl("apply", "-f", case37BadIngressClassPath)
+		})
+		It("should have 1 Compliant relatedObject under the policy's status", func() {
+			var managedPlc *unstructured.Unstructured
+
+			Eventually(func() interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyCSMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				return utils.GetComplianceState(managedPlc)
+			}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+			var relatedObjects []interface{}
+
+			By("relatedObjects should exist")
+			Eventually(func(g Gomega) interface{} {
+				managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					case37PolicyCSMustnothaveName, testNamespace, true, defaultTimeoutSeconds)
+
+				var err error
+
+				relatedObjects, _, err = unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(relatedObjects).ShouldNot(BeNil())
+
+				return relatedObjects
+			}, defaultTimeoutSeconds*2, 1).Should(HaveLen(1))
+
+			By("Check the kind of relatedObject")
+			kind := relatedObjects[0].(map[string]interface{})["object"].(map[string]interface{})["kind"].(string)
+			Expect(kind).Should(Equal("IngressClass"))
+
+			By("Check the reason of relatedObject")
+			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
+			Expect(reason).Should(Equal("Resource not found as expected"))
+
+			By("Check the name of relatedObject is *")
+			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
+				"object", "metadata", "name")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(name).Should(Equal("*"))
+		})
+		AfterEach(func() {
+			utils.Kubectl("delete", "-f", case37PolicyCSMustnothavePath, "-n", testNamespace, "--ignore-not-found")
+			utils.Kubectl("delete", "-f", case37BadIngressClassPath, "--ignore-not-found")
+			utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case37PolicyCSMustnothaveName, testNamespace, false, defaultTimeoutSeconds)
+		})
+	})
+})

--- a/test/resources/case37_no_name/case37_bad_ingressclass.yaml
+++ b/test/resources/case37_no_name/case37_bad_ingressclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: case37-ingress-class
+spec:
+  controller: alien.giant/web

--- a/test/resources/case37_no_name/case37_bad_ingresses.yaml
+++ b/test/resources/case37_no_name/case37_bad_ingresses.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: case37-wrong-1-ingress
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: case37-wrong-2-ingress
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 801

--- a/test/resources/case37_no_name/case37_good_ingress.yaml
+++ b/test/resources/case37_no_name/case37_good_ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: good-ingress
+spec:
+  ingressClassName: test
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80

--- a/test/resources/case37_no_name/case37_no_name_clusterscope_policy.yaml
+++ b/test/resources/case37_no_name/case37_no_name_clusterscope_policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case37-test-policy-clusterscope
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: IngressClass
+        spec:
+          controller: ingress.k8s.aws/alb

--- a/test/resources/case37_no_name/case37_no_name_clusterscope_policy_nothave.yaml
+++ b/test/resources/case37_no_name/case37_no_name_clusterscope_policy_nothave.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case37-test-policy-clusterscope-mustnothave
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: mustnothave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: IngressClass
+        spec:
+          controller: ingress.k8s.aws/alb

--- a/test/resources/case37_no_name/case37_no_name_policy.yaml
+++ b/test/resources/case37_no_name/case37_no_name_policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case37-test-policy-1
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          namespace: default
+        spec:
+          ingressClassName: test

--- a/test/resources/case37_no_name/case37_no_name_policy_nothave.yaml
+++ b/test/resources/case37_no_name/case37_no_name_policy_nothave.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case37-test-policy-mustnothave
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: mustnothave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          namespace: default
+        spec:
+          ingressClassName: test


### PR DESCRIPTION
What the user wants: 
When the object, even if no having name,  turns compliant, appears in the list. We can see the object of Kind Node, compliant, and it does not match any specific name of the Kind object.

Ref: https://issues.redhat.com/browse/ACM-8782