### PR TITLE
Require `objectDefinition` and `remediationAction`

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -152,8 +152,8 @@ func (e EvaluationInterval) GetNonCompliantInterval() (time.Duration, error) {
 
 // ConfigurationPolicySpec defines the desired state of ConfigurationPolicy
 type ConfigurationPolicySpec struct {
-	Severity          Severity          `json:"severity,omitempty"`          // low, medium, high
-	RemediationAction RemediationAction `json:"remediationAction,omitempty"` // enforce, inform
+	Severity          Severity          `json:"severity,omitempty"` // low, medium, high
+	RemediationAction RemediationAction `json:"remediationAction"`  // enforce, inform
 	// 'namespaceSelector' defines the list of namespaces to include/exclude for objects defined in
 	// spec.objectTemplates. All selector rules are ANDed. If 'include' is not provided but
 	// 'matchLabels' and/or 'matchExpressions' are, 'include' will behave as if ['*'] were given. If
@@ -186,7 +186,7 @@ type ObjectTemplate struct {
 
 	// ObjectDefinition defines required fields for the object
 	// +kubebuilder:pruning:PreserveUnknownFields
-	ObjectDefinition runtime.RawExtension `json:"objectDefinition,omitempty"`
+	ObjectDefinition runtime.RawExtension `json:"objectDefinition"`
 }
 
 // ConfigurationPolicyStatus defines the observed state of ConfigurationPolicy

--- a/deploy/crds/kustomize_configurationpolicy/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/kustomize_configurationpolicy/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -163,6 +163,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   required:
                   - complianceType
+                  - objectDefinition
                   type: object
                 type: array
               object-templates-raw:
@@ -202,6 +203,8 @@ spec:
                 - critical
                 - Critical
                 type: string
+            required:
+            - remediationAction
             type: object
           status:
             description: ConfigurationPolicyStatus defines the observed state of ConfigurationPolicy

--- a/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -170,6 +170,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                   required:
                   - complianceType
+                  - objectDefinition
                   type: object
                 type: array
               object-templates-raw:
@@ -209,6 +210,8 @@ spec:
                 - critical
                 - Critical
                 type: string
+            required:
+            - remediationAction
             type: object
           status:
             description: ConfigurationPolicyStatus defines the observed state of ConfigurationPolicy


### PR DESCRIPTION
Without these fields, the policy is meaningless. When they're optional, a ConfigurationPolicy can be created without an `objectDefinition` and, if there was an attempt to put the object at the `objectDefinition` level (i.e. apiVersion, kind, metadata), all those fields get wiped out without notice for the user. It'd be a better experience to make these required and surface the error sooner.

I tested it out, and the status is returned properly:
>NonCompliant; template-error; Failed to create policy template: ConfigurationPolicy.policy.open-cluster-management.io "7799-policy-crd" is invalid: spec.object-templates[0].objectDefinition: Required value
