### PR TITLE
Add diff logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,6 @@ e2e-test: e2e-dependencies
 e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode && !running-in-cluster' --output-dir=.
 e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
-.PHONY: e2e-test-coverage-foreground
-e2e-test-coverage-foreground: LOG_REDIRECT = 
-e2e-test-coverage-foreground: e2e-test-coverage
-
 .PHONY: e2e-test-hosted-mode-coverage
 e2e-test-hosted-mode-coverage: E2E_TEST_ARGS = --json-report=report_e2e_hosted_mode.json --label-filter="hosted-mode && !running-in-cluster" --output-dir=.
 e2e-test-hosted-mode-coverage: COVERAGE_E2E_OUT = coverage_e2e_hosted_mode.out
@@ -244,9 +240,8 @@ e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
 .PHONY: e2e-run-instrumented
-LOG_REDIRECT ?= &>build/_output/controller.log
 e2e-run-instrumented: e2e-build-instrumented
-	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(COVERAGE_E2E_OUT) $(LOG_REDIRECT) &
+	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(COVERAGE_E2E_OUT) 2>&1 | tee ./build/_output/controller.log &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:

--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -187,7 +187,19 @@ type ObjectTemplate struct {
 	// ObjectDefinition defines required fields for the object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	ObjectDefinition runtime.RawExtension `json:"objectDefinition"`
+
+	// RecordDiff specifies whether (and where) to log the diff between the object on the
+	// cluster and the objectDefinition in the policy. Defaults to "None".
+	RecordDiff RecordDiff `json:"recordDiff,omitempty"`
 }
+
+// +kubebuilder:validation:Enum=Log;None
+type RecordDiff string
+
+const (
+	RecordDiffLog  RecordDiff = "Log"
+	RecordDiffNone RecordDiff = "None"
+)
 
 // ConfigurationPolicyStatus defines the observed state of ConfigurationPolicy
 type ConfigurationPolicyStatus struct {
@@ -210,9 +222,6 @@ type CompliancePerClusterStatus struct {
 
 // ComplianceMap map to hold CompliancePerClusterStatus objects
 type ComplianceMap map[string]*CompliancePerClusterStatus
-
-// ResourceState genric description of a state
-type ResourceState string
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status

--- a/deploy/crds/kustomize_configurationpolicy/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/kustomize_configurationpolicy/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -161,6 +161,14 @@ spec:
                         object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    recordDiff:
+                      description: RecordDiff specifies whether (and where) to log
+                        the diff between the object on the cluster and the objectDefinition
+                        in the policy. Defaults to "None".
+                      enum:
+                      - Log
+                      - None
+                      type: string
                   required:
                   - complianceType
                   - objectDefinition

--- a/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -168,6 +168,14 @@ spec:
                         object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    recordDiff:
+                      description: RecordDiff specifies whether (and where) to log
+                        the diff between the object on the cluster and the objectDefinition
+                        in the policy. Defaults to "None".
+                      enum:
+                      - Log
+                      - None
+                      type: string
                   required:
                   - complianceType
                   - objectDefinition

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.28.1
 	github.com/operator-framework/api v0.17.6
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
@@ -69,7 +70,6 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/test/e2e/case21_alternative_kubeconfig_test.go
+++ b/test/e2e/case21_alternative_kubeconfig_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Test an alternative kubeconfig for policy evaluation", Ordered
 			)
 
 			return utils.GetComplianceState(managedPlc)
-		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+		}, defaultTimeoutSeconds*2, 1).Should(Equal("Compliant"))
 
 		By("Verifying that the " + policyName + " was created using the alternative kubeconfig")
 		_, err := targetK8sClient.CoreV1().Namespaces().Get(context.TODO(), namespaceName, metav1.GetOptions{})

--- a/test/e2e/case27_showupdateinstatus_test.go
+++ b/test/e2e/case27_showupdateinstatus_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	case27ConfigPolicyName string = "policy-cfgmap-create"
+	case27ConfigPolicyName string = "case27-policy-cfgmap-create"
 	case27CreateYaml       string = "../resources/case27_showupdateinstatus/case27-create-cfgmap-policy.yaml"
 	case27UpdateYaml       string = "../resources/case27_showupdateinstatus/case27-update-cfgmap-policy.yaml"
 )

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -99,10 +99,12 @@ var _ = Describe("Test installing an operator from OperatorPolicy", Ordered, fun
 			})
 
 			It("Should become Compliant", func() {
-				OpPlc := utils.GetWithTimeout(clientManagedDynamic, gvrOperatorPolicy,
-					case38OpPolicyDefaultOgName, case38OpPolicyDefaultOgNS, true, defaultTimeoutSeconds)
+				Eventually(func() interface{} {
+					OpPlc := utils.GetWithTimeout(clientManagedDynamic, gvrOperatorPolicy,
+						case38OpPolicyDefaultOgName, case38OpPolicyDefaultOgNS, true, defaultTimeoutSeconds)
 
-				Expect(utils.GetComplianceState(OpPlc)).To(Equal("Compliant"))
+					return utils.GetComplianceState(OpPlc)
+				}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
 			})
 
 			It("Should have installed the operator", func() {

--- a/test/e2e/case39_diff_generation_test.go
+++ b/test/e2e/case39_diff_generation_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+var _ = Describe("Generate the diff", Ordered, func() {
+	const (
+		logPath          string = "../../build/_output/controller.log"
+		configPolicyName string = "case39-policy-cfgmap-create"
+		createYaml       string = "../resources/case39_diff_generation/case39-create-cfgmap-policy.yaml"
+		updateYaml       string = "../resources/case39_diff_generation/case39-update-cfgmap-policy.yaml"
+	)
+
+	BeforeAll(func() {
+		_, err := os.Stat(logPath)
+		if err != nil {
+			Skip(fmt.Sprintf("Skipping. Failed to find log file %s: %s", logPath, err.Error()))
+		}
+	})
+
+	It("configmap should be created properly on the managed cluster", func() {
+		By("Creating " + configPolicyName + " on managed")
+		utils.Kubectl("apply", "-f", createYaml, "-n", testNamespace)
+		plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+			configPolicyName, testNamespace, true, defaultTimeoutSeconds)
+		Expect(plc).NotTo(BeNil())
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				configPolicyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, 120, 1).Should(Equal("configmaps [case39-map] found as specified in namespace default"))
+	})
+
+	It("configmap and status should be updated properly on the managed cluster", func() {
+		By("Updating " + configPolicyName + " on managed")
+		utils.Kubectl("apply", "-f", updateYaml, "-n", testNamespace)
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				configPolicyName, testNamespace, true, defaultTimeoutSeconds)
+
+			return utils.GetStatusMessage(managedPlc)
+		}, 30, 0.5).Should(Equal("configmaps [case39-map] was updated successfully in namespace default"))
+	})
+
+	It("diff should be logged by the controller", func() {
+		By("Checking the controller logs")
+		logFile, err := os.Open(logPath)
+		Expect(err).ToNot(HaveOccurred())
+		defer logFile.Close()
+
+		diff := ""
+		foundDiff := false
+		logScanner := bufio.NewScanner(logFile)
+		logScanner.Split(bufio.ScanLines)
+		for logScanner.Scan() {
+			line := logScanner.Text()
+			if foundDiff && strings.HasPrefix(line, "\t{") {
+				foundDiff = false
+			} else if foundDiff || strings.Contains(line, "Logging the diff:") {
+				foundDiff = true
+			} else {
+				continue
+			}
+
+			diff += line + "\n"
+		}
+
+		Expect(diff).Should(ContainSubstring(`Logging the diff:
+--- default/case39-map : existing
++++ default/case39-map : updated
+@@ -2,3 +2,3 @@
+ data:
+-  fieldToUpdate: "1"
++  fieldToUpdate: "2"
+ kind: ConfigMap
+	{"policy": "case39-policy-cfgmap-create", "name": "case39-map", "namespace": "default", "resource": "configmaps"}`))
+	})
+
+	AfterAll(func() {
+		deleteConfigPolicies([]string{configPolicyName})
+		utils.Kubectl("delete", "configmap", "case39-map", "--ignore-not-found")
+	})
+})

--- a/test/resources/case27_showupdateinstatus/case27-create-cfgmap-policy.yaml
+++ b/test/resources/case27_showupdateinstatus/case27-create-cfgmap-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: policy-cfgmap-create
+  name: case27-policy-cfgmap-create
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case39_diff_generation/case39-create-cfgmap-policy.yaml
+++ b/test/resources/case39_diff_generation/case39-create-cfgmap-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: case27-policy-cfgmap-create
+  name: case39-policy-cfgmap-create
 spec:
   remediationAction: enforce
   namespaceSelector:
@@ -9,10 +9,11 @@ spec:
     include: ["default"]
   object-templates:
     - complianceType: musthave
+      recordDiff: Log
       objectDefinition:
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: case27-map
+          name: case39-map
         data:
-          fieldToUpdate: "2"
+          fieldToUpdate: "1"

--- a/test/resources/case39_diff_generation/case39-update-cfgmap-policy.yaml
+++ b/test/resources/case39_diff_generation/case39-update-cfgmap-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: case27-policy-cfgmap-create
+  name: case39-policy-cfgmap-create
 spec:
   remediationAction: enforce
   namespaceSelector:
@@ -9,10 +9,11 @@ spec:
     include: ["default"]
   object-templates:
     - complianceType: musthave
+      recordDiff: Log
       objectDefinition:
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: case27-map
+          name: case39-map
         data:
           fieldToUpdate: "2"


### PR DESCRIPTION
Adds a `recordDiff` enum parameter to the `ConfigurationPolicy`. When set to `Log`, it uses the `go-difflib` package to compare the YAML marshalled into strings, with unified output similar to the `diff` command in the shell. While `go-difflib` is unmaintained, it's extensively imported, in particular by the `stretchr/testify` package here.

For simplicity, the diff for objectDefinitions without a name specified are not logged.

Further enhancements could be made by making the diff object-aware. For instance, the ArgoCD diff goes so far as to hack around the Kubernetes library that implements `apply`. However, I think this is a good, simple implementation as far as an MVP goes and is likely more performant than an object-aware implementation.

ref: https://issues.redhat.com/browse/ACM-9072