### PR TITLE
Handle InstallPlan approval based on spec.versions

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -50,6 +50,8 @@ var (
 	gvrOperatorPolicy           schema.GroupVersionResource
 	gvrSubscription             schema.GroupVersionResource
 	gvrOperatorGroup            schema.GroupVersionResource
+	gvrInstallPlan              schema.GroupVersionResource
+	gvrClusterServiceVersion    schema.GroupVersionResource
 	defaultImageRegistry        string
 )
 
@@ -92,6 +94,16 @@ var _ = BeforeSuite(func() {
 		Group:    "operators.coreos.com",
 		Version:  "v1",
 		Resource: "operatorgroups",
+	}
+	gvrInstallPlan = schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "installplans",
+	}
+	gvrClusterServiceVersion = schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "clusterserviceversions",
 	}
 	gvrAPIService = schema.GroupVersionResource{
 		Group:    "apiregistration.k8s.io",

--- a/test/resources/case38_operator_install/operator-policy-manual-upgrades.yaml
+++ b/test/resources/case38_operator_install/operator-policy-manual-upgrades.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: oppol-manual-upgrades
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    kind: Policy
+    name: parent-policy
+    uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: enforce
+  severity: medium
+  complianceType: musthave
+  subscription:
+    channel: strimzi-0.36.x
+    installPlanApproval: Manual
+    name: strimzi-kafka-operator
+    namespace: operator-policy-testns
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+    startingCSV: strimzi-cluster-operator.v0.0.0.1337 # shouldn't match a real version
+  versions:
+    - strimzi-cluster-operator.v0.36.0


### PR DESCRIPTION
When enforcing a policy that specifies which versions should be allowed, the controller will now set the Subscription.InstallPlanApproval to Manual, and will approve only the InstallPlans that match the versions specified in the policy.

The controller now also reports the status of related InstallPlans.

Refs:
 - https://issues.redhat.com/browse/ACM-9286