### PR TITLE
Include the compliance history database IDs in compliance events

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -3088,6 +3088,21 @@ func (r *ConfigurationPolicyReconciler) sendComplianceEvent(instance *policyv1.C
 		ReportingInstance:   r.InstanceName,
 	}
 
+	eventAnnotations := map[string]string{}
+
+	instanceAnnotations := instance.GetAnnotations()
+	if instanceAnnotations[common.ParentDBIDAnnotation] != "" {
+		eventAnnotations[common.ParentDBIDAnnotation] = instanceAnnotations[common.ParentDBIDAnnotation]
+	}
+
+	if instanceAnnotations[common.PolicyDBIDAnnotation] != "" {
+		eventAnnotations[common.PolicyDBIDAnnotation] = instanceAnnotations[common.PolicyDBIDAnnotation]
+	}
+
+	if len(eventAnnotations) > 0 {
+		event.Annotations = eventAnnotations
+	}
+
 	if instance.Status.ComplianceState != policyv1.Compliant {
 		event.Type = "Warning"
 	}

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -16,6 +16,7 @@ import (
 
 	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policyv1beta1 "open-cluster-management.io/config-policy-controller/api/v1beta1"
+	common "open-cluster-management.io/config-policy-controller/pkg/common"
 )
 
 // updateStatus takes one condition to update, and related objects for that condition. The related
@@ -290,6 +291,21 @@ func (r *OperatorPolicyReconciler) emitComplianceEvent(
 		},
 		ReportingController: ControllerName,
 		ReportingInstance:   r.InstanceName,
+	}
+
+	eventAnnotations := map[string]string{}
+
+	policyAnnotations := policy.GetAnnotations()
+	if policyAnnotations[common.ParentDBIDAnnotation] != "" {
+		eventAnnotations[common.ParentDBIDAnnotation] = policyAnnotations[common.ParentDBIDAnnotation]
+	}
+
+	if policyAnnotations[common.PolicyDBIDAnnotation] != "" {
+		eventAnnotations[common.PolicyDBIDAnnotation] = policyAnnotations[common.PolicyDBIDAnnotation]
+	}
+
+	if len(eventAnnotations) > 0 {
+		event.Annotations = eventAnnotations
 	}
 
 	if policy.Status.ComplianceState != policyv1.Compliant {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -11,7 +11,11 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-const UninstallingAnnotation string = "policy.open-cluster-management.io/uninstalling"
+const (
+	UninstallingAnnotation string = "policy.open-cluster-management.io/uninstalling"
+	PolicyDBIDAnnotation   string = "policy.open-cluster-management.io/policy-compliance-db-id"
+	ParentDBIDAnnotation   string = "policy.open-cluster-management.io/parent-policy-compliance-db-id"
+)
 
 // CreateRecorder return recorder
 func CreateRecorder(kubeClient kubernetes.Interface, componentName string) (record.EventRecorder, error) {

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -9,6 +9,7 @@ import (
 
 	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policyv1beta1 "open-cluster-management.io/config-policy-controller/api/v1beta1"
+	"open-cluster-management.io/config-policy-controller/pkg/common"
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
@@ -71,9 +72,19 @@ var _ = Describe("Test installing an operator from OperatorPolicy", Ordered, fun
 			g.Expect(actualCondition.Reason).To(Equal(expectedCondition.Reason))
 			g.Expect(actualCondition.Message).To(Equal(expectedCondition.Message))
 
-			g.Expect(utils.GetMatchingEvents(
+			events := utils.GetMatchingEvents(
 				clientManaged, opPolTestNS, parentPolicyName, "", expectedEventMsgSnippet, opPolTimeout,
-			)).NotTo(BeEmpty())
+			)
+			g.Expect(events).NotTo(BeEmpty())
+
+			for _, event := range events {
+				g.Expect(event.Annotations[common.ParentDBIDAnnotation]).To(
+					Equal("124"), common.ParentDBIDAnnotation+" should have the correct value",
+				)
+				g.Expect(event.Annotations[common.PolicyDBIDAnnotation]).To(
+					Equal("64"), common.PolicyDBIDAnnotation+" should have the correct value",
+				)
+			}
 		}
 
 		EventuallyWithOffset(1, checkFunc, opPolTimeout, 3).Should(Succeed())

--- a/test/resources/case15_event_format/case15_mnh_pod_alwayscompliant.yaml
+++ b/test/resources/case15_event_format/case15_mnh_pod_alwayscompliant.yaml
@@ -2,6 +2,9 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: mnh-pod-alwayscompliant
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "23"
+    policy.open-cluster-management.io/policy-compliance-db-id: "30"
   ownerReferences:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy

--- a/test/resources/case15_event_format/case15_parent_alwayscompliant.yaml
+++ b/test/resources/case15_event_format/case15_parent_alwayscompliant.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: parent-alwayscompliant
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "23"
 spec:
   remediationAction: inform
   disabled: false
@@ -11,6 +13,8 @@ spec:
         kind: ConfigurationPolicy
         metadata:
           name: mnh-pod-alwayscompliant
+          annotations:
+            policy.open-cluster-management.io/policy-compliance-db-id: "30"
         spec:
           remediationAction: inform
           namespaceSelector:

--- a/test/resources/case38_operator_install/operator-policy-no-group-csv-fail.yaml
+++ b/test/resources/case38_operator_install/operator-policy-no-group-csv-fail.yaml
@@ -2,6 +2,9 @@ apiVersion: policy.open-cluster-management.io/v1beta1
 kind: OperatorPolicy
 metadata:
   name: oppol-no-allnamespaces
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
   ownerReferences:
   - apiVersion: policy.open-cluster-management.io/v1
     kind: Policy

--- a/test/resources/case38_operator_install/operator-policy-no-group-enforce.yaml
+++ b/test/resources/case38_operator_install/operator-policy-no-group-enforce.yaml
@@ -2,6 +2,9 @@ apiVersion: policy.open-cluster-management.io/v1beta1
 kind: OperatorPolicy
 metadata:
   name: oppol-no-group-enforce
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
   ownerReferences:
   - apiVersion: policy.open-cluster-management.io/v1
     kind: Policy

--- a/test/resources/case38_operator_install/operator-policy-no-group.yaml
+++ b/test/resources/case38_operator_install/operator-policy-no-group.yaml
@@ -2,6 +2,9 @@ apiVersion: policy.open-cluster-management.io/v1beta1
 kind: OperatorPolicy
 metadata:
   name: oppol-no-group
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
   ownerReferences:
   - apiVersion: policy.open-cluster-management.io/v1
     kind: Policy

--- a/test/resources/case38_operator_install/operator-policy-with-group.yaml
+++ b/test/resources/case38_operator_install/operator-policy-with-group.yaml
@@ -2,6 +2,9 @@ apiVersion: policy.open-cluster-management.io/v1beta1
 kind: OperatorPolicy
 metadata:
   name: oppol-with-group
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
   ownerReferences:
   - apiVersion: policy.open-cluster-management.io/v1
     kind: Policy

--- a/test/resources/case38_operator_install/parent-policy.yaml
+++ b/test/resources/case38_operator_install/parent-policy.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: parent-policy
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
 spec:
   remediationAction: inform
   disabled: false


### PR DESCRIPTION
If the database IDs are set on the ConfigurationPolicy/OperatorPolicy, forward them along in the compliance event for the status-sync controller to record in the compliance events history API.

Relates:
https://issues.redhat.com/browse/ACM-6889

Depends on https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/111 to do anything.