### PR TITLE
Allow configuring a default namespace for operators

### DIFF
--- a/api/v1beta1/operatorpolicy_types.go
+++ b/api/v1beta1/operatorpolicy_types.go
@@ -100,6 +100,7 @@ type OperatorPolicyStatus struct {
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// List of resources processed by the policy
+	// +optional
 	RelatedObjects []policyv1.RelatedObject `json:"relatedObjects"`
 }
 

--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -41,7 +41,7 @@ func TestBuildSubscription(t *testing.T) {
 	}
 
 	// Check values are correctly bootstrapped to the Subscription
-	ret, err := buildSubscription(testPolicy)
+	ret, err := buildSubscription(testPolicy, "my-operators")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, ret.GroupVersionKind(), desiredGVK)
 	assert.Equal(t, ret.ObjectMeta.Name, "my-operator")
@@ -60,7 +60,6 @@ func TestBuildOperatorGroup(t *testing.T) {
 			ComplianceType:    "musthave",
 			Subscription: runtime.RawExtension{
 				Raw: []byte(`{
-					"namespace": "default",
 					"source": "my-catalog",
 					"sourceNamespace": "my-ns",
 					"name": "my-operator",
@@ -78,9 +77,9 @@ func TestBuildOperatorGroup(t *testing.T) {
 	}
 
 	// Ensure OperatorGroup values are populated correctly
-	ret, err := buildOperatorGroup(testPolicy)
+	ret, err := buildOperatorGroup(testPolicy, "my-operators")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, ret.GroupVersionKind(), desiredGVK)
-	assert.Equal(t, ret.ObjectMeta.GetGenerateName(), "default-")
-	assert.Equal(t, ret.ObjectMeta.GetNamespace(), "default")
+	assert.Equal(t, ret.ObjectMeta.GetGenerateName(), "my-operators-")
+	assert.Equal(t, ret.ObjectMeta.GetNamespace(), "my-operators")
 }

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -149,6 +149,10 @@ func (r *OperatorPolicyReconciler) updateStatus(
 	}
 
 	if condChanged || relObjsChanged {
+		if policy.Status.RelatedObjects == nil {
+			policy.Status.RelatedObjects = []policyv1.RelatedObject{}
+		}
+
 		return r.Status().Update(ctx, policy)
 	}
 

--- a/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -219,8 +219,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - relatedObjects
             type: object
         type: object
     served: true

--- a/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -213,8 +213,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - relatedObjects
             type: object
         type: object
     served: true

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ type ctrlOpts struct {
 	targetKubeConfig      string
 	metricsAddr           string
 	probeAddr             string
+	operatorPolDefaultNS  string
 	clientQPS             float32
 	clientBurst           uint
 	frequency             uint
@@ -432,9 +433,10 @@ func main() {
 		<-watcher.Started()
 
 		OpReconciler := controllers.OperatorPolicyReconciler{
-			Client:         mgr.GetClient(),
-			DynamicWatcher: watcher,
-			InstanceName:   instanceName,
+			Client:           mgr.GetClient(),
+			DynamicWatcher:   watcher,
+			InstanceName:     instanceName,
+			DefaultNamespace: opts.operatorPolDefaultNS,
 		}
 
 		if err = OpReconciler.SetupWithManager(mgr, depEvents); err != nil {
@@ -698,6 +700,13 @@ func parseOpts(flags *pflag.FlagSet, args []string) *ctrlOpts {
 		"enable-operator-policy",
 		false,
 		"Enable operator policy controller",
+	)
+
+	flags.StringVar(
+		&opts.operatorPolDefaultNS,
+		"operator-policy-default-namespace",
+		"",
+		"The default namespace to be used by an OperatorPolicy if not specified in the policy.",
 	)
 
 	_ = flags.Parse(args)


### PR DESCRIPTION
This adds a command line flag for setting a default namespace for subscriptions/operatorgroups when not specified in an OperatorPolicy spec. This will allow (for example) OpenShift clusters to default to the "openshift-operators" namespace, which is conventionally used for cluster-wide operator installations.

Note to reviewers: the first commit is just re-arranging code blocks to a more consistent order; going through the other 2 commit by commit is probably easier to read.