### PR TITLE
Add more validation to the OperatorPolicy

### DIFF
--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -643,7 +643,7 @@ var noDeploymentsCond = metav1.Condition{
 
 // catalogSourceFindCond is a conditionally compliant condition with reason
 // based on the `isUnhealthy` and `isMissing` parameters
-func catalogSourceFindCond(isUnhealthy bool, isMissing bool) metav1.Condition {
+func catalogSourceFindCond(isUnhealthy bool, isMissing bool, name string) metav1.Condition {
 	status := metav1.ConditionFalse
 	reason := "CatalogSourcesFound"
 	message := "CatalogSource was found"
@@ -657,7 +657,7 @@ func catalogSourceFindCond(isUnhealthy bool, isMissing bool) metav1.Condition {
 	if isMissing {
 		status = metav1.ConditionTrue
 		reason = "CatalogSourcesNotFound"
-		message = "CatalogSource was not found"
+		message = "CatalogSource '" + name + "' was not found"
 	}
 
 	return metav1.Condition{

--- a/test/resources/case38_operator_install/operator-policy-validity-test.yaml
+++ b/test/resources/case38_operator_install/operator-policy-validity-test.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: oppol-validity-test
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    kind: Policy
+    name: parent-policy
+    uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: inform
+  severity: medium
+  complianceType: musthave
+  operatorGroup: # optional
+    foo: bar
+    name: scoped-operator-group
+    namespace: operator-policy-testns
+    targetNamespaces:
+      - operator-policy-testns
+  subscription:
+    actually: incorrect
+    channel: stable-3.8
+    name: project-quay
+    namespace: nonexist-testns
+    installPlanApproval: Incorrect
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+    startingCSV: quay-operator.v3.8.1


### PR DESCRIPTION
The `ValidPolicySpec` condition now reports when the subscription or operatorGroup in the policy have unknown fields. It also reports if the InstallPlanApproval value in the subscription is not correct.

That condition also reports when the namespace for the subscription does not exist, and the controller now watches that namespace so that if it is created (or deleted), the policy will be reconciled and the status will be updated.

Refs:
 - https://issues.redhat.com/browse/ACM-9993