### PR TITLE
Reduce debug logs for operatorpolicy test

### DIFF
--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -33,16 +33,26 @@ var _ = Describe("Test installing an operator from OperatorPolicy", Ordered, fun
 		expectedCondition metav1.Condition,
 		expectedEventMsgSnippet string,
 	) {
+		var debugMessage string
+
+		defer func() {
+			if CurrentSpecReport().Failed() {
+				GinkgoWriter.Println(debugMessage)
+			}
+		}()
+
 		checkFunc := func(g Gomega) {
 			GinkgoHelper()
 
 			unstructPolicy := utils.GetWithTimeout(clientManagedDynamic, gvrOperatorPolicy, polName,
 				opPolTestNS, true, eventuallyTimeout)
 
+			unstructured.RemoveNestedField(unstructPolicy.Object, "metadata", "managedFields")
+
 			policyJSON, err := json.MarshalIndent(unstructPolicy.Object, "", "  ")
 			g.Expect(err).NotTo(HaveOccurred())
 
-			GinkgoWriter.Printf("Debug info for failure.\npolicy JSON: %s\nwanted related objects: %+v\n"+
+			debugMessage = fmt.Sprintf("Debug info for failure.\npolicy JSON: %s\nwanted related objects: %+v\n"+
 				"wanted condition: %+v\n", string(policyJSON), expectedRelatedObjs, expectedCondition)
 
 			policy := policyv1beta1.OperatorPolicy{}


### PR DESCRIPTION
Instead of printing the log every time the function fails in one of the Eventually runs, it saves a message and will only print it if the test overall fails. This should reduce noise during the tests.