### PR TITLE
Adjust polarity of condition when CSV not found

### DIFF
--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -586,8 +586,8 @@ func buildCSVCond(csv *operatorv1alpha1.ClusterServiceVersion) metav1.Condition 
 
 var noCSVCond = metav1.Condition{
 	Type:    csvConditionType,
-	Status:  metav1.ConditionTrue,
-	Reason:  "NoRelevantClusterServiceVersion",
+	Status:  metav1.ConditionFalse,
+	Reason:  "RelevantCSVFound",
 	Message: "A relevant installed ClusterServiceVersion could not be found",
 }
 

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -718,6 +718,16 @@ var _ = Describe("Test installing an operator from OperatorPolicy", Ordered, fun
 				"No existing operator Deployments",
 			)
 		})
+
+		It("Should not have any compliant events", func() {
+			// This test is meant to find an incorrect compliant event that is emitted between some
+			// correct noncompliant events.
+			events := utils.GetMatchingEvents(
+				clientManaged, opPolTestNS, parentPolicyName, "", "^Compliant;", eventuallyTimeout,
+			)
+
+			Expect(events).To(BeEmpty())
+		})
 	})
 	Describe("Test status reporting for CatalogSource", Ordered, func() {
 		const (


### PR DESCRIPTION
In situations where a subscription does not reference a CSV, a special condition is created and an event emitted to report that no relevant CSV was found. Previously, this condition was "True", which made sense with its reason, but not with the "ClusterServiceVersionCompliant" type. Now the condition will be "False", and the reason has been changed to still make sense.

Refs:
 - https://issues.redhat.com/browse/ACM-10190