### PR TITLE
Filter out unrelated subscription resolution failures

### DIFF
--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -1,8 +1,10 @@
 package controllers
 
 import (
+	"fmt"
 	"testing"
 
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,4 +84,118 @@ func TestBuildOperatorGroup(t *testing.T) {
 	assert.Equal(t, ret.GroupVersionKind(), desiredGVK)
 	assert.Equal(t, ret.ObjectMeta.GetGenerateName(), "my-operators-")
 	assert.Equal(t, ret.ObjectMeta.GetNamespace(), "my-operators")
+}
+
+func TestMessageIncludesSubscription(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		subscriptionName string
+		packageName      string
+		message          string
+		expected         bool
+	}{
+		{
+			subscriptionName: "quay-does-not-exist",
+			packageName:      "quay-does-not-exist",
+			message: "no operators found from catalog some-catalog in namespace default referenced by subscription " +
+				"quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "quay",
+			packageName:      "quay",
+			message: "no operators found from catalog some-catalog in namespace default referenced by subscription " +
+				"quay-operator-does-not-exist",
+			expected: false,
+		},
+		{
+			subscriptionName: "quay-does-not-exist",
+			packageName:      "quay-does-not-exist",
+			message: "no operators found in package quay-does-not-exist in the catalog referenced by subscription " +
+				"quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "quay-does-not-exist",
+			packageName:      "quay-does-not-exist",
+			message: "no operators found in package quay-does-not-exist in the catalog referenced by subscription " +
+				"quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "quay-does-not-exist",
+			packageName:      "quay-does-not-exist",
+			message: "no operators found in channel a channel of package quay-does-not-exist in the catalog " +
+				"referenced by subscription quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "quay-does-not-exist",
+			packageName:      "other",
+			message: "no operators found in channel a channel of package quay-does-not-exist in the catalog " +
+				"referenced by subscription quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "other",
+			packageName:      "quay-does-not-exist",
+			message: "no operators found in channel a channel of package quay-does-not-exist in the catalog " +
+				"referenced by subscription quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "quay-does-not-exist",
+			packageName:      "quay-does-not-exist",
+			//nolint: dupword
+			message: "no operators found with name quay-does-not-exist in channel channel of package " +
+				" quay-does-not-exist in the catalog referenced by subscription quay-does-not-exist",
+			expected: true,
+		},
+		{
+			subscriptionName: "quay",
+			packageName:      "quay",
+			//nolint: dupword
+			message: "no operators found with name quay-does-not-exist in channel channel of package " +
+				" quay-does-not-exist in the catalog referenced by subscription quay-does-not-exist",
+			expected: false,
+		},
+		{
+			subscriptionName: "quay",
+			packageName:      "quay",
+			message:          "multiple name matches for status.installedCSV of subscription default/quay: quay.v123",
+			expected:         true,
+		},
+		{
+			subscriptionName: "quay",
+			packageName:      "quay",
+			message:          "multiple name matches for status.installedCSV of subscription some-ns/quay: quay.v123",
+			expected:         false,
+		},
+	}
+
+	for i, test := range testCases {
+		test := test
+
+		t.Run(
+			fmt.Sprintf("test[%d]", i),
+			func(t *testing.T) {
+				t.Parallel()
+
+				subscription := &operatorv1alpha1.Subscription{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      test.subscriptionName,
+						Namespace: "default",
+					},
+					Spec: &operatorv1alpha1.SubscriptionSpec{
+						Package: test.packageName,
+					},
+				}
+
+				match, err := messageIncludesSubscription(subscription, test.message)
+				assert.Equal(t, err, nil)
+				assert.Equal(t, match, test.expected)
+			},
+		)
+	}
 }

--- a/test/resources/case38_operator_install/operator-policy-no-exist-enforce.yaml
+++ b/test/resources/case38_operator_install/operator-policy-no-exist-enforce.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: oppol-no-exist-enforce
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    kind: Policy
+    name: parent-policy
+    uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: enforce
+  severity: medium
+  complianceType: musthave
+  subscription:
+    channel: stable-3.8
+    name: project-quay-does-not-exist
+    namespace: operator-policy-testns
+    installPlanApproval: Automatic
+    source: operatorhubio-catalog
+    sourceNamespace: olm


### PR DESCRIPTION
Since OLM includes a subscription error on all subscriptions in the namespace, even if that subscription itself is unaffected, operator policy needs to know if the error is related to the subscription. This adds some regex filtering to parse the messages since the message format is consistent.

Relates:
https://issues.redhat.com/browse/ACM-10195