### PR TITLE
Change unnamed related object from * to -

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1626,7 +1626,7 @@ func (r *ConfigurationPolicyReconciler) handleObjects(
 		result = objectTmplEvalResult{objectNames: objNames, events: []objectTmplEvalEvent{resultEvent}}
 
 		if shouldAddCondensedRelatedObj {
-			// relatedObjs name is *
+			// relatedObjs name is -
 			relatedObjects = addCondensedRelatedObjs(
 				mapping.Resource,
 				resultEvent.compliant,

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -68,7 +68,7 @@ func addRelatedObjects(
 }
 
 // addCondensedRelatedObjs does not include all of relatedObjs.
-// The Name field is "*". The list of objects will be presented on the console.
+// The Name field is "-". The list of objects will be presented on the console.
 func addCondensedRelatedObjs(
 	rsrc schema.GroupVersionResource,
 	compliant bool,
@@ -77,7 +77,7 @@ func addCondensedRelatedObjs(
 	namespaced bool,
 	reason string,
 ) (relatedObjects []policyv1.RelatedObject) {
-	metadata := policyv1.ObjectMetadata{Name: "*"}
+	metadata := policyv1.ObjectMetadata{Name: "-"}
 
 	if namespaced {
 		metadata.Namespace = namespace

--- a/test/e2e/case14_selection_test.go
+++ b/test/e2e/case14_selection_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Test policy compliance with namespace selection", Ordered, fun
 			// When hasObjName = false
 			// compliant: NonCompliant
 			//  metadata:
-			// 	  name: '*'
+			// 	  name: '-'
 			//    namespace: range3
 			// reason: Resource not found but should exist
 			// is attached for range3.

--- a/test/e2e/case37_no_name_test.go
+++ b/test/e2e/case37_no_name_test.go
@@ -64,11 +64,11 @@ var _ = Describe("Test a namespace-scope policy that is missing name", Ordered, 
 			relatedObjectsOne := relatedObjects[0].(map[string]interface{})
 			Expect(relatedObjectsOne["reason"].(string)).Should(Equal("Resource found but does not match"))
 
-			By("Check the name of related object is *")
+			By("Check the name of related object is -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).Should(Equal("*"))
+			Expect(name).Should(Equal("-"))
 		})
 		It("should have 1 Compliant relatedObject under the policy's status", func() {
 			By("Apply good ingress")
@@ -109,11 +109,11 @@ var _ = Describe("Test a namespace-scope policy that is missing name", Ordered, 
 			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
 			Expect(reason).Should(Equal("Resource found as expected"))
 
-			By("Check the name of related object is not *")
+			By("Check the name of related object is not -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).ShouldNot(Equal("*"))
+			Expect(name).ShouldNot(Equal("-"))
 		})
 		AfterAll(func() {
 			utils.Kubectl("delete", "-f", case37PolicyNSPath, "-n", testNamespace, "--ignore-not-found")
@@ -159,11 +159,11 @@ var _ = Describe("Test a namespace-scope policy that is missing name", Ordered, 
 			relatedObjectsOne := relatedObjects[0].(map[string]interface{})
 			Expect(relatedObjectsOne["reason"].(string)).Should(Equal("Resource not found as expected"))
 
-			By("Check the name of related object is *")
+			By("Check the name of related object is -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).Should(Equal("*"))
+			Expect(name).Should(Equal("-"))
 		})
 		It("should have 1 Compliant relatedObject under the policy's status", func() {
 			By("Apply a ingress that is not related to policy")
@@ -204,11 +204,11 @@ var _ = Describe("Test a namespace-scope policy that is missing name", Ordered, 
 			relatedObjectsOne := relatedObjects[0].(map[string]interface{})
 			Expect(relatedObjectsOne["reason"].(string)).Should(Equal("Resource not found as expected"))
 
-			By("Check the name of related object is *")
+			By("Check the name of related object is -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).Should(Equal("*"))
+			Expect(name).Should(Equal("-"))
 		})
 		It("should have 1 NonCompliant relatedObject under the policy's status", func() {
 			By("Apply a ingress")
@@ -249,11 +249,11 @@ var _ = Describe("Test a namespace-scope policy that is missing name", Ordered, 
 			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
 			Expect(reason).Should(Equal("Resource found but should not exist"))
 
-			By("Check the name of related object is not *")
+			By("Check the name of related object is not -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).ShouldNot(Equal("*"))
+			Expect(name).ShouldNot(Equal("-"))
 		})
 		AfterAll(func() {
 			utils.Kubectl("delete", "-f", case37PolicyNotHavePath, "-n", testNamespace, "--ignore-not-found")
@@ -321,11 +321,11 @@ var _ = Describe("Test a cluster-scope policy that is missing name ", Ordered, f
 			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
 			Expect(reason).Should(Equal("Resource found but does not match"))
 
-			By("Check the name of relatedObject is *")
+			By("Check the name of relatedObject is -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).Should(Equal("*"))
+			Expect(name).Should(Equal("-"))
 		})
 		AfterEach(func() {
 			utils.Kubectl("delete", "-f", case37PolicyCSPath, "-n", testNamespace, "--ignore-not-found")
@@ -380,11 +380,11 @@ var _ = Describe("Test a cluster-scope policy that is missing name ", Ordered, f
 			reason := relatedObjects[0].(map[string]interface{})["reason"].(string)
 			Expect(reason).Should(Equal("Resource not found as expected"))
 
-			By("Check the name of relatedObject is *")
+			By("Check the name of relatedObject is -")
 			name, _, err := unstructured.NestedString(relatedObjects[0].(map[string]interface{}),
 				"object", "metadata", "name")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(name).Should(Equal("*"))
+			Expect(name).Should(Equal("-"))
 		})
 		AfterEach(func() {
 			utils.Kubectl("delete", "-f", case37PolicyCSMustnothavePath, "-n", testNamespace, "--ignore-not-found")


### PR DESCRIPTION
Since we just want one thing to possibly match, using "*" makes it seem like all of the things are bad. Using "-" also matches what we do for some things when we don’t know/care about the namespace

Ref: https://issues.redhat.com/browse/ACM-8782