### PR TITLE
Log "Forbidden" update errors

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2628,6 +2628,8 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 				// If an inform policy and the update is forbidden (i.e. modifying Pod spec fields), then return
 				// noncompliant since that confirms some fields don't match.
 				if k8serrors.IsForbidden(err) {
+					log.Info(fmt.Sprintf("Dry run update failed with error: %s", err.Error()))
+
 					r.setEvaluatedObject(obj.policy, obj.existingObj, false)
 
 					return true, "", false, false


### PR DESCRIPTION
I debated whether this message should be returned to the Policy status, but it seems that could be confusing when a user only wants to know whether it matches in `inform`, and I suspect the error would be returned in `enforce`.

ref: https://issues.redhat.com/browse/ACM-10612