### PR TITLE
Fix constraints not satisfiable message causing compliance flood

### DIFF
--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -199,3 +199,62 @@ func TestMessageIncludesSubscription(t *testing.T) {
 		)
 	}
 }
+
+func TestMessageContentOrderMatching(t *testing.T) {
+	t.Parallel()
+
+	testPolicy := &policyv1beta1.OperatorPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "default",
+		},
+		Spec: policyv1beta1.OperatorPolicySpec{
+			Severity:          "low",
+			RemediationAction: "enforce",
+			ComplianceType:    "musthave",
+			Subscription: runtime.RawExtension{
+				Raw: []byte(`{
+					"source": "my-catalog",
+					"sourceNamespace": "my-ns",
+					"name": "my-operator",
+					"channel": "stable",
+					"startingCSV": "my-operator-v1",
+					"installPlanApproval": "Automatic"
+				}`),
+			},
+		},
+		Status: policyv1beta1.OperatorPolicyStatus{
+			ComplianceState: "NonCompliant",
+			Conditions: []metav1.Condition{
+				{
+					Type:               "SubscriptionCompliant",
+					Status:             "False",
+					ObservedGeneration: 0,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "ConstraintsNotSatisfiable",
+					Message: "constraints not satisfiable: " +
+						"no operators found in package gatekeeper-operator-product " +
+						"in the catalog referenced by subscription gatekeeper-operator-product, " +
+						"clusterserviceversion gatekeeper-operator-product.v3.11.1 exists " +
+						"and is not referenced by a subscription, " +
+						"subscription gatekeeper-operator-product4 exists",
+				},
+			},
+		},
+	}
+
+	testCond := &operatorv1alpha1.SubscriptionCondition{
+		Type:   "ResolutionFailed",
+		Status: "True",
+		Reason: "ConstraintsNotSatisfiable",
+		Message: "constraints not satisfiable: " +
+			"subscription gatekeeper-operator-product4 exists, " +
+			"no operators found in package gatekeeper-operator-product " +
+			"in the catalog referenced by subscription gatekeeper-operator-product, " +
+			"clusterserviceversion gatekeeper-operator-product.v3.11.1 exists " +
+			"and is not referenced by a subscription",
+	}
+
+	ret := constraintMessageMatch(testPolicy, testCond)
+	assert.Equal(t, true, ret)
+}

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -473,6 +473,22 @@ func validationCond(validationErrors []error) metav1.Condition {
 	}
 }
 
+// subResFailedCond takes a failed SubscriptionCondition and converts it to a generic Condition
+func subResFailedCond(subFailedCond operatorv1alpha1.SubscriptionCondition) metav1.Condition {
+	cond := metav1.Condition{
+		Type:    subConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  subFailedCond.Reason,
+		Message: subFailedCond.Message,
+	}
+
+	if subFailedCond.LastTransitionTime != nil {
+		cond.LastTransitionTime = *subFailedCond.LastTransitionTime
+	}
+
+	return cond
+}
+
 // opGroupPreexistingCond is a Compliant condition with Reason 'PreexistingOperatorGroupFound',
 // and Message 'the policy does not specify an OperatorGroup but one already exists in the
 // namespace - assuming that OperatorGroup is correct'


### PR DESCRIPTION
`ConstraintsNotSatisfiable` message types in the subscription status are formatted `"constraints not satisfiable: clause1, clause2, clause3 ..."`. However, the order of the clauses is nondeterministic, which causes compliance event flapping as each update leads to a different ordering of messages, which in turn triggers another update. This was fixed by sorting the message prior to evaluation.

Ref: https://issues.redhat.com/browse/ACM-10204