### PR TITLE
Improve OperatorGroup removal logic

### DIFF
--- a/api/v1beta1/operatorpolicy_types.go
+++ b/api/v1beta1/operatorpolicy_types.go
@@ -51,9 +51,9 @@ func (ra RemovalAction) IsDeleteIfUnused() bool {
 
 type RemovalBehavior struct {
 	//+kubebuilder:default=DeleteIfUnused
-	//+kubebuilder:validation:Enum=Keep;Delete;DeleteIfUnused
+	//+kubebuilder:validation:Enum=Keep;DeleteIfUnused
 	// Specifies whether to delete the OperatorGroup; defaults to 'DeleteIfUnused' which
-	// will only delete the OperatorGroup if there is not another Subscription using it.
+	// will only delete the OperatorGroup if there is not another resource using it.
 	OperatorGroups RemovalAction `json:"operatorGroups,omitempty"`
 
 	//+kubebuilder:default=Delete

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -850,6 +850,8 @@ func deletedObj(obj client.Object) policyv1.RelatedObject {
 	}
 }
 
+// deletingObj returns a NonCompliant RelatedObject with
+// reason = 'The object is being deleted but has not been removed yet'
 func deletingObj(obj client.Object) policyv1.RelatedObject {
 	return policyv1.RelatedObject{
 		Object:    policyv1.ObjectResourceFromObj(obj),

--- a/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -105,10 +105,9 @@ spec:
                     default: DeleteIfUnused
                     description: |-
                       Specifies whether to delete the OperatorGroup; defaults to 'DeleteIfUnused' which
-                      will only delete the OperatorGroup if there is not another Subscription using it.
+                      will only delete the OperatorGroup if there is not another resource using it.
                     enum:
                     - Keep
-                    - Delete
                     - DeleteIfUnused
                     type: string
                   subscriptions:

--- a/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -100,10 +100,9 @@ spec:
                     default: DeleteIfUnused
                     description: |-
                       Specifies whether to delete the OperatorGroup; defaults to 'DeleteIfUnused' which
-                      will only delete the OperatorGroup if there is not another Subscription using it.
+                      will only delete the OperatorGroup if there is not another resource using it.
                     enum:
                     - Keep
-                    - Delete
                     - DeleteIfUnused
                     type: string
                   subscriptions:

--- a/test/resources/case38_operator_install/operator-policy-mustnothave.yaml
+++ b/test/resources/case38_operator_install/operator-policy-mustnothave.yaml
@@ -25,7 +25,7 @@ spec:
   versions:
     - quay-operator.v3.8.13
   removalBehavior:
-    operatorGroups: Delete
+    operatorGroups: DeleteIfUnused
     subscriptions: Delete
     clusterServiceVersions: Delete
     installPlans: Delete


### PR DESCRIPTION
In some clusters, a default OperatorGroup might be provided in a namespace for "global" operators. This OperatorGroup was not being correctly identified by the policy: in fact any pre-existing group that did not match the group specified by the policy, or the one that would be generated when the policy does not specify a group, was not reported correctly.

Now, pre-existing "special" operator groups should be reported and handled correctly. If they are owned by another resource, they will be considered as "used" for the purposes of the DeleteIfUnused setting.

Refs:
 - https://issues.redhat.com/browse/ACM-11022
 - https://issues.redhat.com/browse/ACM-11077