### PR TITLE
Make the capitalization consistent of operator policy messages

### DIFF
--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -754,11 +754,11 @@ func buildDeploymentCond(
 ) metav1.Condition {
 	status := metav1.ConditionTrue
 	reason := "DeploymentsAvailable"
-	message := "All operator Deployments have their minimum availability"
+	message := "all operator Deployments have their minimum availability"
 
 	if !depsExist {
 		reason = "NoExistingDeployments"
-		message = "No existing operator Deployments"
+		message = "no existing operator Deployments"
 	}
 
 	if len(unavailableDeps) != 0 {
@@ -771,7 +771,7 @@ func buildDeploymentCond(
 		}
 
 		names := strings.Join(depNames, ", ")
-		message = fmt.Sprintf("Deployments %s do not have their minimum availability", names)
+		message = fmt.Sprintf("the deployments %s do not have their minimum availability", names)
 	}
 
 	return metav1.Condition{

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -773,9 +773,9 @@ var _ = Describe("Testing OperatorPolicy", Ordered, func() {
 					Type:    "DeploymentCompliant",
 					Status:  metav1.ConditionTrue,
 					Reason:  "DeploymentsAvailable",
-					Message: "All operator Deployments have their minimum availability",
+					Message: "all operator Deployments have their minimum availability",
 				},
-				"All operator Deployments have their minimum availability",
+				"all operator Deployments have their minimum availability",
 			)
 		})
 
@@ -892,9 +892,9 @@ var _ = Describe("Testing OperatorPolicy", Ordered, func() {
 					Type:    "DeploymentCompliant",
 					Status:  metav1.ConditionTrue,
 					Reason:  "NoExistingDeployments",
-					Message: "No existing operator Deployments",
+					Message: "no existing operator Deployments",
 				},
-				"No existing operator Deployments",
+				"no existing operator Deployments",
 			)
 		})
 


### PR DESCRIPTION
This one was missed in a previous PR.