### PR TITLE
Hosted mode Testing for OperatorPolicy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,23 @@
                 "KUBECONFIG": "${workspaceFolder}/kubeconfig_managed_e2e",
             }
         },
+		// Set FDescribe or FIt on the test to debug. Then set the desired breakpoint.
+		{
+			"name": "Launch Hosted Test Function",
+			"type": "go",
+			"request": "launch",
+			"mode": "auto",
+			"program": "${workspaceFolder}/test/e2e/e2e_suite_test.go",
+			"args": [
+				"-ginkgo.debug",
+				"-ginkgo.v",
+				"-is_hosted=true"
+			],
+			"env": {
+				"KUBECONFIG": "${workspaceFolder}/kubeconfig_managed_e2e",
+				"TARGET_KUBECONFIG_PATH": "${workspaceFolder}/kubeconfig_managed2_e2e",
+			}
+		},
         // Set the correct path to the governance-policy-framework repo directory in the env section.
         {
             "name": "Launch Package (Framework E2E) (instructions in launch.json)",

--- a/test/e2e/case21_alternative_kubeconfig_test.go
+++ b/test/e2e/case21_alternative_kubeconfig_test.go
@@ -5,42 +5,24 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
 var _ = Describe("Test an alternative kubeconfig for policy evaluation", Ordered, Label("hosted-mode"), func() {
 	const (
-		envName          = "TARGET_KUBECONFIG_PATH"
 		namespaceName    = "e2e-test-ns"
 		policyName       = "create-ns"
 		policyYAML       = "../resources/case21_alternative_kubeconfig/policy.yaml"
 		parentPolicyName = "parent-create-ns"
 		parentPolicyYAML = "../resources/case21_alternative_kubeconfig/parent-policy.yaml"
 	)
-
-	var targetK8sClient *kubernetes.Clientset
-
-	BeforeAll(func() {
-		By("Checking that the " + envName + " environment variable is valid")
-		altKubeconfigPath := os.Getenv(envName)
-		Expect(altKubeconfigPath).ToNot(Equal(""))
-
-		targetK8sConfig, err := clientcmd.BuildConfigFromFlags("", altKubeconfigPath)
-		Expect(err).ToNot(HaveOccurred())
-
-		targetK8sClient, err = kubernetes.NewForConfig(targetK8sConfig)
-		Expect(err).ToNot(HaveOccurred())
-	})
 
 	AfterAll(func() {
 		deleteConfigPolicies([]string{policyName})

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -150,6 +150,10 @@ func GetMatchingEvents(
 
 // Kubectl executes kubectl commands
 func Kubectl(args ...string) {
+	if !strings.HasPrefix(args[len(args)-1], "--kubeconfig=") {
+		args = append(args, "--kubeconfig="+"../../kubeconfig_managed_e2e")
+	}
+
 	cmd := exec.Command("kubectl", args...)
 
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
The "hosting cluster" should be used for the Policy, OperatorPolicy, and compliance events, while the "target cluster" should be used for all the other resources like Subscription, InstallPlan, etc.
Ref: https://issues.redhat.com/browse/ACM-11255
