### PR TITLE
Report compliant when NS missing in mustnothave

### DIFF
--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -369,7 +369,7 @@ func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *p
 			return sub, opGroup, false, fmt.Errorf("error getting operator namespace: %w", err)
 		}
 
-		if gotNamespace == nil {
+		if gotNamespace == nil && policy.Spec.ComplianceType.IsMustHave() {
 			validationErrors = append(validationErrors,
 				fmt.Errorf("the operator namespace ('%v') does not exist", opGroupNS))
 		}

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -2685,6 +2685,44 @@ var _ = Describe("Testing OperatorPolicy", Ordered, func() {
 			)
 		})
 	})
+	Describe("Test mustnothave message when the namespace does not exist", func() {
+		const (
+			opPolYAML = "../resources/case38_operator_install/operator-policy-no-group.yaml"
+			opPolName = "oppol-no-group"
+			subName   = "project-quay"
+		)
+
+		BeforeEach(func() {
+			utils.Kubectl("create", "ns", opPolTestNS)
+			DeferCleanup(func() {
+				utils.Kubectl("delete", "ns", opPolTestNS)
+			})
+
+			createObjWithParent(parentPolicyYAML, parentPolicyName,
+				opPolYAML, opPolTestNS, gvrPolicy, gvrOperatorPolicy)
+		})
+
+		It("should report compliant", func() {
+			// change the subscription namespace, and the complianceType to mustnothave
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", opPolTestNS, "--type=json", "-p",
+				`[{"op": "replace", "path": "/spec/subscription/namespace", "value": "imaginaryfriend"},`+
+					`{"op": "replace", "path": "/spec/complianceType", "value": "mustnothave"}]`)
+
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{},
+				metav1.Condition{
+					Type:    "ValidPolicySpec",
+					Status:  metav1.ConditionTrue,
+					Reason:  "PolicyValidated",
+					Message: "the policy spec is valid",
+				},
+				"the policy spec is valid",
+			)
+			checkCompliance(opPolName, opPolTestNS, eventuallyTimeout, policyv1.Compliant)
+		})
+	})
 	Describe("Testing mustnothave behavior of operator groups in DeleteIfUnused mode", Ordered, func() {
 		const (
 			opPolYAML = "../resources/case38_operator_install/operator-policy-mustnothave-any-version.yaml"


### PR DESCRIPTION
Previously, when the namespace specified for the operator in an OperatorPolicy was not found, the policy would always be noncompliant. But in mustnothave mode, it should be compliant (assuming everything else is right).

Refs:
 - https://issues.redhat.com/browse/ACM-11549