### PR TITLE
Delete the hosting test namespace before the hosted test namespace

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,26 @@
                 "KUBECONFIG": "${workspaceFolder}/kubeconfig_managed",
             }
         },
+        // Run `make kind-bootstrap-cluster-dev` and `make kind-additional-cluster` before launching this.
+        {
+            "name": "Launch Package (Hosted Mode)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "args": [
+                "controller",
+                "--leader-elect=false",
+                "--log-level=3",
+                "--v=5",
+                "--enable-operator-policy=true",
+                "--target-kubeconfig-path=${workspaceFolder}/kubeconfig_managed2",
+            ],
+            "env": {
+                "WATCH_NAMESPACE": "managed",
+                "KUBECONFIG": "${workspaceFolder}/kubeconfig_managed",
+            }
+        },
         // Set FDescribe or FIt on the test to debug. Then set the desired breakpoint.
         {
             "name": "Launch Test Function (instructions in launch.json)",

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -172,15 +172,18 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 	}
 
 	preFunc := func() {
+		utils.Kubectl("create", "ns", opPolTestNS)
+
 		if IsHosted {
 			KubectlTarget("create", "ns", opPolTestNS)
-			DeferCleanup(func() {
-				KubectlTarget("delete", "ns", opPolTestNS)
-			})
 		}
-		utils.Kubectl("create", "ns", opPolTestNS)
+
 		DeferCleanup(func() {
-			utils.Kubectl("delete", "ns", opPolTestNS)
+			utils.Kubectl("delete", "ns", opPolTestNS, "--ignore-not-found")
+
+			if IsHosted {
+				KubectlTarget("delete", "ns", opPolTestNS, "--ignore-not-found")
+			}
 		})
 	}
 


### PR DESCRIPTION
This ensures the OperatorPolicy is deleted before the operator is deleted. Hopefully this will address some of the test flakes.

The first commit includes a launch.json configuration for hosted mode.