### PR TITLE
Add the recreateOption to the object template

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -195,6 +195,15 @@ type ObjectTemplate struct {
 
 	MetadataComplianceType MetadataComplianceType `json:"metadataComplianceType,omitempty"`
 
+	// RecreateOption describes whether to delete and recreate an object when an update is required. `IfRequired`
+	// will recreate the object when updating an immutable field. `Always` will always recreate the object if a mismatch
+	// is detected. `RecreateOption` has no effect when the `remediationAction` is `inform`. `IfRequired` has no effect
+	// on clusters without dry run update support. The default value is `None`.
+	//
+	//+kubebuilder:validation:Enum=None;IfRequired;Always
+	//+kubebuilder:default=None
+	RecreateOption RecreateOption `json:"recreateOption,omitempty"`
+
 	// ObjectDefinition defines required fields for the object
 	// +kubebuilder:pruning:PreserveUnknownFields
 	ObjectDefinition runtime.RawExtension `json:"objectDefinition"`
@@ -339,6 +348,14 @@ func (c ComplianceType) IsMustNotHave() bool {
 // MetadataComplianceType describes how to check compliance for the labels/annotations of a given object
 // +kubebuilder:validation:Enum=MustHave;Musthave;musthave;MustOnlyHave;Mustonlyhave;mustonlyhave
 type MetadataComplianceType string
+
+type RecreateOption string
+
+const (
+	None       RecreateOption = "None"
+	IfRequired RecreateOption = "IfRequired"
+	Always     RecreateOption = "Always"
+)
 
 // RelatedObject is the list of objects matched by this Policy resource.
 type RelatedObject struct {

--- a/deploy/crds/kustomize_configurationpolicy/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/kustomize_configurationpolicy/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -177,6 +177,18 @@ spec:
                       - InStatus
                       - None
                       type: string
+                    recreateOption:
+                      default: None
+                      description: |-
+                        RecreateOption describes whether to delete and recreate an object when an update is required. `IfRequired`
+                        will recreate the object when updating an immutable field. `Always` will always recreate the object if a mismatch
+                        is detected. `RecreateOption` has no effect when the `remediationAction` is `inform`. `IfRequired` has no effect
+                        on clusters without dry run update support. The default value is `None`.
+                      enum:
+                      - None
+                      - IfRequired
+                      - Always
+                      type: string
                   required:
                   - complianceType
                   - objectDefinition

--- a/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -184,6 +184,18 @@ spec:
                       - InStatus
                       - None
                       type: string
+                    recreateOption:
+                      default: None
+                      description: |-
+                        RecreateOption describes whether to delete and recreate an object when an update is required. `IfRequired`
+                        will recreate the object when updating an immutable field. `Always` will always recreate the object if a mismatch
+                        is detected. `RecreateOption` has no effect when the `remediationAction` is `inform`. `IfRequired` has no effect
+                        on clusters without dry run update support. The default value is `None`.
+                      enum:
+                      - None
+                      - IfRequired
+                      - Always
+                      type: string
                   required:
                   - complianceType
                   - objectDefinition

--- a/test/e2e/case40_recreate_option_test.go
+++ b/test/e2e/case40_recreate_option_test.go
@@ -1,0 +1,226 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"open-cluster-management.io/config-policy-controller/test/utils"
+)
+
+var _ = Describe("Recreate options", Ordered, func() {
+	const (
+		deploymentYAML           = "../resources/case40_recreate_option/deployment.yaml"
+		configMapYAML            = "../resources/case40_recreate_option/configmap-with-finalizer.yaml"
+		policyNoRecreateYAML     = "../resources/case40_recreate_option/policy-no-recreate-options.yaml"
+		policyAlwaysRecreateYAML = "../resources/case40_recreate_option/policy-always-recreate-option.yaml"
+	)
+
+	AfterAll(func(ctx SpecContext) {
+		deleteConfigPolicies([]string{"case40"})
+
+		By("Deleting the case40 Deployment in the default namespace")
+		utils.Kubectl("-n", "default", "delete", "deployment", "case40", "--ignore-not-found")
+
+		By("Deleting the case40 ConfigMap in the default namespace")
+		configmap, err := clientManagedDynamic.Resource(gvrConfigMap).Namespace("default").Get(
+			ctx, "case40", metav1.GetOptions{},
+		)
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+
+		Expect(err).ToNot(HaveOccurred())
+
+		if len(configmap.GetFinalizers()) != 0 {
+			utils.Kubectl(
+				"-n", "default",
+				"patch",
+				"configmap",
+				"case40",
+				"--type",
+				"json",
+				`-p=[{"op":"remove","path":"/metadata/finalizers"}]`,
+			)
+		}
+
+		utils.Kubectl("-n", "default", "delete", "configmap", "case40", "--ignore-not-found")
+	})
+
+	It("should fail to update due to immutable fields not matching", func() {
+		By("Creating the case40 Deployment in the default namespace")
+		utils.Kubectl("create", "-f", deploymentYAML)
+
+		By("Creating the case40 ConfigurationPolicy with different selectors on the Deployment")
+		utils.Kubectl("-n", testNamespace, "create", "-f", policyNoRecreateYAML)
+
+		By("Verifying the ConfigurationPolicy is NonCompliant")
+		var managedPlc *unstructured.Unstructured
+
+		Eventually(func() interface{} {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				"case40",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+
+		By("Verifying the diff is present")
+		relatedObjects, _, err := unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(relatedObjects).To(HaveLen(1))
+
+		diff, _, _ := unstructured.NestedString(relatedObjects[0].(map[string]interface{}), "properties", "diff")
+		Expect(diff).To(ContainSubstring("-      app: case40\n+      app: case40-2\n"))
+
+		expected := `deployments [case40] in namespace default cannot be updated, likely due to immutable fields not ` +
+			`matching, you may set spec["object-templates"][].recreateOption to recreate the object`
+		Expect(utils.GetStatusMessage(managedPlc)).To(Equal(expected))
+	})
+
+	It("should update the immutable fields when recreateOption=IfRequired", func(ctx SpecContext) {
+		By("Setting recreateOption=IfRequired on the case40 ConfigurationPolicy")
+		deployment, err := clientManagedDynamic.Resource(gvrDeployment).Namespace("default").Get(
+			ctx, "case40", metav1.GetOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		uid := deployment.GetUID()
+
+		utils.Kubectl(
+			"-n", testNamespace, "patch", "configurationpolicy", "case40", "--type=json", "-p",
+			`[{ "op": "replace", "path": "/spec/object-templates/0/recreateOption", "value": 'IfRequired' }]`,
+		)
+
+		By("Verifying the ConfigurationPolicy is Compliant")
+		var managedPlc *unstructured.Unstructured
+
+		Eventually(func() interface{} {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				"case40",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Verifying the diff is not set")
+		relatedObjects, _, err := unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(relatedObjects).To(HaveLen(1))
+
+		relatedObject := relatedObjects[0].(map[string]interface{})
+
+		diff, _, _ := unstructured.NestedString(relatedObject, "properties", "diff")
+		Expect(diff).To(BeEmpty())
+
+		propsUID, _, _ := unstructured.NestedString(relatedObject, "properties", "uid")
+		Expect(propsUID).ToNot(BeEmpty())
+
+		createdByPolicy, _, _ := unstructured.NestedBool(relatedObject, "properties", "createdByPolicy")
+		Expect(createdByPolicy).To(BeTrue())
+
+		deployment, err = clientManagedDynamic.Resource(gvrDeployment).Namespace("default").Get(
+			ctx, "case40", metav1.GetOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the Deployment was recreated")
+		Expect(deployment.GetUID()).ToNot(Equal(uid), "Expected a new UID on the Deployment after it got recreated")
+		Expect(propsUID).To(
+			BeEquivalentTo(deployment.GetUID()), "Expect the object properties UID to match the new Deployment",
+		)
+
+		selector, _, _ := unstructured.NestedString(deployment.Object, "spec", "selector", "matchLabels", "app")
+		Expect(selector).To(Equal("case40-2"))
+
+		deleteConfigPolicies([]string{"case40"})
+	})
+
+	It("should timeout on the delete when there is a finalizer", func(ctx SpecContext) {
+		By("Creating the case40 ConfigMap in the default namespace")
+		utils.Kubectl("create", "-f", configMapYAML)
+
+		configmap, err := clientManagedDynamic.Resource(gvrConfigMap).Namespace("default").Get(
+			ctx, "case40", metav1.GetOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		uid := configmap.GetUID()
+
+		By("Creating the case40 ConfigurationPolicy with different data on the ConfigMap")
+		utils.Kubectl("-n", testNamespace, "create", "-f", policyAlwaysRecreateYAML)
+
+		expected := `configmaps [case40] in namespace default timed out waiting for the object to delete during ` +
+			`recreate, will retry on the next policy evaluation`
+
+		By("Verifying the ConfigurationPolicy is NonCompliant")
+		var managedPlc *unstructured.Unstructured
+
+		Eventually(func(g Gomega) {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				"case40",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			g.Expect(utils.GetComplianceState(managedPlc)).To(Equal("NonCompliant"))
+			g.Expect(utils.GetStatusMessage(managedPlc)).To(Equal(expected))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		By("Removing the finalizer on the ConfigMap")
+		utils.Kubectl(
+			"-n", "default",
+			"patch",
+			"configmap",
+			"case40",
+			"--type",
+			"json",
+			`-p=[{"op":"remove","path":"/metadata/finalizers"}]`,
+		)
+
+		By("Verifying the ConfigurationPolicy is Compliant")
+		Eventually(func() interface{} {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				"case40",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			return utils.GetComplianceState(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+
+		By("Verifying the ConfigMap was recreated")
+
+		configmap, err = clientManagedDynamic.Resource(gvrConfigMap).Namespace("default").Get(
+			ctx, "case40", metav1.GetOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(configmap.GetUID()).ToNot(Equal(uid), "Expected a new UID on the ConfigMap after it got recreated")
+
+		city, _, _ := unstructured.NestedString(configmap.Object, "data", "city")
+		Expect(city).To(Equal("Raleigh"))
+
+		deleteConfigPolicies([]string{"case40"})
+	})
+})

--- a/test/resources/case40_recreate_option/configmap-with-finalizer.yaml
+++ b/test/resources/case40_recreate_option/configmap-with-finalizer.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case40
+  namespace: default
+  finalizers:
+    - policy.open-cluster-management.io/case40
+data:
+  city: Durham
+  state: NC

--- a/test/resources/case40_recreate_option/deployment.yaml
+++ b/test/resources/case40_recreate_option/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: case40
+  namespace: default
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: case40
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: case40
+    spec:
+      containers:
+        - args:
+            - do-not-start
+          command:
+            - config-policy-controller
+          image: quay.io/open-cluster-management/config-policy-controller:latest
+          imagePullPolicy: IfNotPresent
+          name: case40
+      restartPolicy: Always

--- a/test/resources/case40_recreate_option/policy-always-recreate-option.yaml
+++ b/test/resources/case40_recreate_option/policy-always-recreate-option.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case40
+spec:
+  pruneObjectBehavior: DeleteAll
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      recreateOption: Always
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case40
+          namespace: default
+        data:
+          city: Raleigh
+          state: NC

--- a/test/resources/case40_recreate_option/policy-no-recreate-options.yaml
+++ b/test/resources/case40_recreate_option/policy-no-recreate-options.yaml
@@ -1,0 +1,36 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case40
+spec:
+  pruneObjectBehavior: DeleteAll
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: case40
+          namespace: default
+        spec:
+          replicas: 0
+          selector:
+            matchLabels:
+              app: case40-2
+          strategy:
+            type: Recreate
+          template:
+            metadata:
+              labels:
+                app: case40-2
+            spec:
+              containers:
+                - args:
+                    - do-not-start
+                  command:
+                    - config-policy-controller
+                  image: quay.io/open-cluster-management/config-policy-controller:latest
+                  imagePullPolicy: IfNotPresent
+                  name: case40
+              restartPolicy: Always


### PR DESCRIPTION
When a user needs to update an object's immutable fields, the object must be replaced. The user may opt-in to setting recreateOption on an object template to "IfRequired" and "Always". When set to "IfRequired", normal updates proceed when possible.

Relates:
https://issues.redhat.com/browse/ACM-11846