### PR TITLE
Update to UBI 9 to match downstream

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make build
 
 # Stage 2: Copy the binaries from the image builder to the base image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV COMPONENT=config-policy-controller
 ENV REPO_PATH=/go/src/github.com/open-cluster-management/${COMPONENT}
@@ -26,7 +26,7 @@ RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint", "controller"]
 
-RUN microdnf update && \
+RUN microdnf update -y && \
     microdnf clean all
 
 USER ${USER_UID}


### PR DESCRIPTION
Adding the "-y" to the microdnf update command will fix the downstream CI too once it syncs.