### PR TITLE
WIP: Set only a single namespace in the OperatorPolicy template test

### DIFF
--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -3194,7 +3194,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 			targetNamespaces, found, err := unstructured.NestedStringSlice(og.Object, "spec", "targetNamespaces")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
-			Expect(targetNamespaces).To(HaveExactElements("foo", "bar", opPolTestNS))
+			Expect(targetNamespaces).To(HaveExactElements(opPolTestNS))
 
 			By("Verifying the Subscription channel")
 			sub, err := targetK8sDynamic.Resource(gvrSubscription).Namespace(opPolTestNS).

--- a/test/resources/case38_operator_install/template-configmap.yaml
+++ b/test/resources/case38_operator_install/template-configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: op-config
 data:
   channel: "fakechannel"
-  namespaces: '["foo", "bar", "operator-policy-testns"]'
+  namespaces: '["operator-policy-testns"]'


### PR DESCRIPTION
This is to help with test cleanup.