### PR TITLE
Limit the OperatorPolicy watches to the managed cluster namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,6 +228,11 @@ func main() {
 				"metadata.namespace": watchNamespace,
 			}),
 		}
+		cacheByObject[&policyv1beta1.OperatorPolicy{}] = cache.ByObject{
+			Field: fields.SelectorFromSet(fields.Set{
+				"metadata.namespace": watchNamespace,
+			}),
+		}
 	} else {
 		log.Info("Skipping restrictions on the ConfigurationPolicy cache because watchNamespace is empty")
 	}


### PR DESCRIPTION
Always having a clusterwide watch is incompatible with hosted mode and does not match ConfigurationPolicy.

Related:
https://issues.redhat.com/browse/ACM-11952