### PR TITLE
Add support for approving InstallPlans with multiple CSVs

### DIFF
--- a/test/resources/case38_operator_install/multiple-subscriptions.yaml
+++ b/test/resources/case38_operator_install/multiple-subscriptions.yaml
@@ -1,0 +1,31 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: operator-policy-testns-abcdefg
+spec:
+  targetNamespaces:
+    - operator-policy-testns
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: argocd-operator
+spec:
+  name: argocd-operator
+  installPlanApproval: Manual
+  channel: alpha
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  startingCSV: "argocd-operator.v0.9.1"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: strimzi-kafka-operator
+spec:
+  name: strimzi-kafka-operator
+  installPlanApproval: Manual
+  channel: stable
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  startingCSV: "strimzi-cluster-operator.v0.35.0"

--- a/test/resources/case38_operator_install/operator-policy-argocd.yaml
+++ b/test/resources/case38_operator_install/operator-policy-argocd.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: argocd-operator
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
+  ownerReferences:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: parent-policy
+      uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: enforce
+  severity: medium
+  complianceType: musthave
+  subscription:
+    name: argocd-operator
+    namespace: operator-policy-testns
+    channel: alpha
+    startingCSV: "argocd-operator.v0.9.1"
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+  upgradeApproval: None

--- a/test/resources/case38_operator_install/operator-policy-strimzi-kafka-operator.yaml
+++ b/test/resources/case38_operator_install/operator-policy-strimzi-kafka-operator.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
+metadata:
+  name: strimzi-kafka-operator
+  annotations:
+    policy.open-cluster-management.io/parent-policy-compliance-db-id: "124"
+    policy.open-cluster-management.io/policy-compliance-db-id: "64"
+  ownerReferences:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: parent-policy
+      uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: enforce
+  severity: medium
+  complianceType: musthave
+  subscription:
+    name: strimzi-kafka-operator
+    namespace: operator-policy-testns
+    channel: stable
+    startingCSV: "strimzi-cluster-operator.v0.35.0"
+    source: operatorhubio-catalog
+    sourceNamespace: olm
+  upgradeApproval: None


### PR DESCRIPTION
# First Commit

The operatorpolicy.policy.open-cluster-management.io/managed label is set to an empty value on the Subscription. The
operatorpolicy.policy.open-cluster-management.io/managed annotation is set to <policy name>.<policy namespace>.

The label doesn't set a value because the value could be too long.

This will allow querying for subscriptions managed by operator policies.

# Second Commit

When an InstallPlan contains multiple CSVs, it will be approved if all CSVs can be approved by the current operator policies.

Rather than query the operator policies directly, the subscriptions in the namespace that are managed by an operator policy are queried and then their associated operator policies are queried to avoid having to resolve templates.

Relates:
https://issues.redhat.com/browse/ACM-11981