### PR TITLE
Make the watch namespace on OperatorPolicy conditional

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,10 +228,13 @@ func main() {
 				"metadata.namespace": watchNamespace,
 			}),
 		}
-		cacheByObject[&policyv1beta1.OperatorPolicy{}] = cache.ByObject{
-			Field: fields.SelectorFromSet(fields.Set{
-				"metadata.namespace": watchNamespace,
-			}),
+
+		if opts.enableOperatorPolicy {
+			cacheByObject[&policyv1beta1.OperatorPolicy{}] = cache.ByObject{
+				Field: fields.SelectorFromSet(fields.Set{
+					"metadata.namespace": watchNamespace,
+				}),
+			}
 		}
 	} else {
 		log.Info("Skipping restrictions on the ConfigurationPolicy cache because watchNamespace is empty")


### PR DESCRIPTION
If OperatorPolicy is not enabled, the watch namespace shouldn't be set. It seems that setting the watch namespace causes the watch to start without the OperatorPolicy controller running.