### PR TITLE
Unified not found behavior for Deployments with CRD and InstallPlan

### DIFF
--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -1197,9 +1197,10 @@ var noExistingCSVObj = policyv1.RelatedObject{
 	Reason:    "No relevant ClusterServiceVersion found",
 }
 
-// noExistingCRDObj is a Compliant RelatedObject for CustomResourceDefinitions,
+// noExistingCRDObj is a RelatedObject for CustomResourceDefinitions,
 // with Reason 'No relevant CustomResourceDefinitions found'. It is considered
-// compliant because not all operators will have CRDs.
+// UnknownCompliancy because the lack of a CRD does not imply Compliance
+// or NonCompliance.
 var noExistingCRDObj = policyv1.RelatedObject{
 	Object: policyv1.ObjectResource{
 		Kind:       customResourceDefinitionGVK.Kind,
@@ -1208,7 +1209,7 @@ var noExistingCRDObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: string(policyv1.Compliant),
+	Compliant: string(policyv1.UnknownCompliancy),
 	Reason:    "No relevant CustomResourceDefinitions found",
 }
 
@@ -1242,7 +1243,10 @@ func existingDeploymentObj(
 	}
 }
 
-// represents a lack of relevant deployments
+// noExistingDeploymentObj is a Compliant RelatedObject for Deployments,
+// with Reason 'No relevant Deployments found'. It is considered
+// UnknownCompliancy because the lack of a Deployment does not imply
+// Compliance or NonCompliance.
 var noExistingDeploymentObj = policyv1.RelatedObject{
 	Object: policyv1.ObjectResource{
 		Kind:       deploymentGVK.Kind,

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -1523,7 +1523,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "Compliant",
+					Compliant: "UnknownCompliancy",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -1855,7 +1855,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "Compliant",
+					Compliant: "UnknownCompliancy",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -2558,7 +2558,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "Compliant",
+					Compliant: "UnknownCompliancy",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -2732,7 +2732,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "Compliant",
+					Compliant: "UnknownCompliancy",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{


### PR DESCRIPTION
Changed noExistingDeploymentObj to Compliant instead of UnknownCompliancy. This change was made to reduce confusion and to unify behavior with the CRD and InstallPlan, which both report `Compliance` when there is no existing object instead of `UnknownCompliancy`.

Ref: https://issues.redhat.com/browse/ACM-12040