### PR TITLE
Use suggested namespaces of packages

### DIFF
--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -43,7 +43,7 @@ func TestBuildSubscription(t *testing.T) {
 	}
 
 	// Check values are correctly bootstrapped to the Subscription
-	ret, err := buildSubscription(testPolicy, "my-operators", nil)
+	ret, err := buildSubscription(testPolicy, nil)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, ret.GroupVersionKind(), desiredGVK)
 	assert.Equal(t, ret.ObjectMeta.Name, "my-operator")
@@ -103,7 +103,7 @@ func TestBuildSubscriptionInvalidNames(t *testing.T) {
 				}
 
 				// Check values are correctly bootstrapped to the Subscription
-				_, err := buildSubscription(testPolicy, "my-operators", nil)
+				_, err := buildSubscription(testPolicy, nil)
 				assert.Equal(t, err.Error(), test.expected)
 			},
 		)

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -212,11 +212,20 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 
 	Describe("Testing an all default operator policy", Ordered, func() {
 		const (
-			opPolYAML = "../resources/case38_operator_install/operator-policy-all-defaults.yaml"
-			opPolName = "oppol-all-defaults"
-			subName   = "project-quay"
+			opPolYAML   = "../resources/case38_operator_install/operator-policy-all-defaults.yaml"
+			opPolName   = "oppol-all-defaults"
+			subName     = "airflow-helm-operator"
+			suggestedNS = "airflow-helm"
 		)
 		BeforeAll(func() {
+			DeferCleanup(func() {
+				utils.Kubectl("delete", "ns", suggestedNS, "--ignore-not-found")
+
+				if IsHosted {
+					KubectlTarget("delete", "ns", suggestedNS, "--ignore-not-found")
+				}
+			})
+
 			preFunc()
 
 			createObjWithParent(parentPolicyYAML, parentPolicyName,
@@ -246,7 +255,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 			)
 
 			By("Verifying the subscription has the correct defaults")
-			sub, err := targetK8sDynamic.Resource(gvrSubscription).Namespace(opPolTestNS).
+			sub, err := targetK8sDynamic.Resource(gvrSubscription).Namespace(suggestedNS).
 				Get(ctx, subName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/test/resources/case38_operator_install/operator-policy-all-defaults.yaml
+++ b/test/resources/case38_operator_install/operator-policy-all-defaults.yaml
@@ -18,6 +18,5 @@ spec:
   severity: medium
   complianceType: musthave
   subscription:
-    name: project-quay
-    namespace: operator-policy-testns
+    name: airflow-helm-operator
   upgradeApproval: Automatic


### PR DESCRIPTION
(Originally this PR had 2 commits - 1 has been removed to be handled later if necessary)

Previously, if the namespace was not set for a Subscription in an
OperatorPolicy, the default namespace on the controller (if set) would
be used in all cases. But many packages specify a suggested namespace in
their PackageManifests, which would be better to use, when provided.

Additionally, if the OperatorPolicy was already managing a subscription,
the namespace of that subscription will be used (if not set in the
policy). This may prevent some issues that could occur if the suggested
namespace for an operator changes at some point.

Refs:
 - https://issues.redhat.com/browse/ACM-12057
