### PR TITLE
Check the CSV against the allowed versions list

### DIFF
--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -1890,7 +1890,31 @@ func (r *OperatorPolicyReconciler) handleCSV(
 		return foundCSV, nil, updateStatus(policy, missingWantedCond("ClusterServiceVersion"), relatedCSVs...), nil
 	}
 
-	return foundCSV, nil, updateStatus(policy, buildCSVCond(foundCSV), relatedCSVs...), nil
+	// Check if the CSV is an approved version
+	if len(policy.Spec.Versions) != 0 {
+		allowedVersions := make([]policyv1.NonEmptyString, 0, len(policy.Spec.Versions)+1)
+		allowedVersions = append(allowedVersions, policy.Spec.Versions...)
+
+		if sub.Spec.StartingCSV != "" {
+			allowedVersions = append(allowedVersions, policyv1.NonEmptyString(sub.Spec.StartingCSV))
+		}
+
+		allowed := false
+
+		for _, allowedVersion := range allowedVersions {
+			if string(allowedVersion) == foundCSV.Name {
+				allowed = true
+
+				break
+			}
+		}
+
+		if !allowed {
+			return foundCSV, nil, updateStatus(policy, disallowedCSVCond(foundCSV), disallowedCSVObj(foundCSV)), nil
+		}
+	}
+
+	return foundCSV, nil, updateStatus(policy, allowedCSVCond(foundCSV), relatedCSVs...), nil
 }
 
 func (r *OperatorPolicyReconciler) mustnothaveCSV(

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -3541,4 +3541,84 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 			}, olmWaitTimeout, 1).Should(Succeed())
 		})
 	})
+	Describe("Test reporting of unapproved version after installation", func() {
+		const (
+			opPolYAML = "../resources/case38_operator_install/operator-policy-no-group-enforce.yaml"
+			opPolName = "oppol-no-group-enforce"
+		)
+
+		BeforeEach(func() {
+			preFunc()
+
+			createObjWithParent(parentPolicyYAML, parentPolicyName,
+				opPolYAML, testNamespace, gvrPolicy, gvrOperatorPolicy)
+		})
+
+		It("Should start compliant", func(ctx SpecContext) {
+			Eventually(func(ctx SpecContext) string {
+				csv, _ := targetK8sDynamic.Resource(gvrClusterServiceVersion).Namespace(opPolTestNS).
+					Get(ctx, "quay-operator.v3.10.5", metav1.GetOptions{})
+
+				if csv == nil {
+					return ""
+				}
+
+				reason, _, _ := unstructured.NestedString(csv.Object, "status", "reason")
+
+				return reason
+			}, olmWaitTimeout, 5, ctx).Should(Equal("InstallSucceeded"))
+
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{{
+					Object: policyv1.ObjectResource{
+						Kind:       "InstallPlan",
+						APIVersion: "operators.coreos.com/v1alpha1",
+						Metadata: policyv1.ObjectMetadata{
+							Namespace: opPolTestNS,
+						},
+					},
+					Compliant: "Compliant",
+					Reason:    "The InstallPlan is Complete",
+				}},
+				metav1.Condition{
+					Type:    "InstallPlanCompliant",
+					Status:  metav1.ConditionTrue,
+					Reason:  "NoInstallPlansRequiringApproval",
+					Message: "no InstallPlans requiring approval were found",
+				},
+				"no InstallPlans requiring approval were found",
+			)
+		})
+		It("Should report a violation after the versions list is patched to exclude the current version", func() {
+			By("Patching the versions field to exclude the installed version")
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
+				`[{"op": "replace", "path": "/spec/versions", "value": ["pie.v3.14159"]}]`)
+
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{{
+					Object: policyv1.ObjectResource{
+						Kind:       "ClusterServiceVersion",
+						APIVersion: "operators.coreos.com/v1alpha1",
+						Metadata: policyv1.ObjectMetadata{
+							Namespace: opPolTestNS,
+							Name:      "quay-operator.v3.10.5",
+						},
+					},
+					Compliant: "NonCompliant",
+					Reason:    "ClusterServiceVersion (quay-operator.v3.10.5) is not an approved version",
+				}},
+				metav1.Condition{
+					Type:    "ClusterServiceVersionCompliant",
+					Status:  metav1.ConditionFalse,
+					Reason:  "UnapprovedVersion",
+					Message: "ClusterServiceVersion (quay-operator.v3.10.5) is not an approved version",
+				},
+				"ClusterServiceVersion .* is not an approved version",
+			)
+		})
+	})
 })


### PR DESCRIPTION
Previously, OperatorPolicy would only check the versions list in the policy when considering whether to approve InstallPlans. This meant that the version of an existing operator was not checked.

Refs:
 - https://issues.redhat.com/browse/ACM-12056