### PR TITLE
Ignore imagePullSecrets and secrets on ServiceAccounts

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2982,6 +2982,12 @@ func handleKeys(
 				continue
 			}
 
+			// for ServiceAccounts, ignore "secrets" and "imagePullSecrets" fields, as these are managed by Kubernetes
+			if (existingObj.GetKind() == "ServiceAccount" && existingObj.GetAPIVersion() == "v1") &&
+				(key == "secrets" || key == "imagePullSecrets") {
+				continue
+			}
+
 			delete(existingObj.Object, key)
 
 			updateNeeded = true


### PR DESCRIPTION
When policy is mustonlyhave for a ServiceAccount, infinite secrets are created due to consistent mismatch of imagePullSecrets and secrets fields. Thus, an exception is made to ignore those fields for ServiceAccounts.

Ref: https://issues.redhat.com/browse/ACM-12270