### PR TITLE
Refactor to split up handleObjectTemplates and help understandability

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -146,11 +146,6 @@ func (e EvaluationInterval) GetNonCompliantInterval() (time.Duration, error) {
 	return e.parseInterval(e.NonCompliant)
 }
 
-// ComplianceType describes how objects on the cluster should be compared with the object definition
-// of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
-// `MustNotHave`.
-//
-// +kubebuilder:validation:Enum=MustHave;Musthave;musthave;MustOnlyHave;Mustonlyhave;mustonlyhave;MustNotHave;Mustnothave;mustnothave
 type ComplianceType string
 
 const (
@@ -176,14 +171,6 @@ func (c ComplianceType) IsMustNotHave() bool {
 	return strings.EqualFold(string(c), string(MustNotHave))
 }
 
-// MetadataComplianceType describes how the labels and annotations of objects on the cluster should
-// be compared with the object definition of the configuration policy. The supported options are
-// `MustHave` or `MustOnlyHave`. The default value is the value defined in `complianceType` for the
-// object template.
-//
-// +kubebuilder:validation:Enum=MustHave;Musthave;musthave;MustOnlyHave;Mustonlyhave;mustonlyhave
-type MetadataComplianceType string
-
 // +kubebuilder:validation:Enum=Log;InStatus;None
 type RecordDiff string
 
@@ -206,8 +193,20 @@ const (
 
 // ObjectTemplate describes the desired state of an object on the cluster.
 type ObjectTemplate struct {
-	ComplianceType         ComplianceType         `json:"complianceType"`
-	MetadataComplianceType MetadataComplianceType `json:"metadataComplianceType,omitempty"`
+	// ComplianceType describes how objects on the cluster should be compared with the object definition
+	// of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
+	// `MustNotHave`.
+	//
+	// +kubebuilder:validation:Enum=MustHave;Musthave;musthave;MustOnlyHave;Mustonlyhave;mustonlyhave;MustNotHave;Mustnothave;mustnothave
+	ComplianceType ComplianceType `json:"complianceType"`
+
+	// MetadataComplianceType describes how the labels and annotations of objects on the cluster should
+	// be compared with the object definition of the configuration policy. The supported options are
+	// `MustHave` or `MustOnlyHave`. The default value is the value defined in `complianceType` for the
+	// object template.
+	//
+	// +kubebuilder:validation:Enum=MustHave;Musthave;musthave;MustOnlyHave;Mustonlyhave;mustonlyhave
+	MetadataComplianceType ComplianceType `json:"metadataComplianceType,omitempty"`
 
 	// RecreateOption describes when to delete and recreate an object when an update is required. When you set the
 	// object to `IfRequired`, the policy recreates the object when updating an immutable field. When you set the

--- a/api/v1beta1/operatorpolicy_types.go
+++ b/api/v1beta1/operatorpolicy_types.go
@@ -140,7 +140,13 @@ type ComplianceConfig struct {
 type OperatorPolicySpec struct {
 	Severity          policyv1.Severity          `json:"severity,omitempty"`
 	RemediationAction policyv1.RemediationAction `json:"remediationAction,omitempty"`
-	ComplianceType    policyv1.ComplianceType    `json:"complianceType"`
+
+	// ComplianceType specifies the desired state of the operator on the cluster. If set to
+	// `musthave`, the policy is compliant when the operator is found. If set to `mustnothave`,
+	// the policy is compliant when the operator is not found.
+	//
+	// +kubebuilder:validation:Enum=musthave;mustnothave
+	ComplianceType policyv1.ComplianceType `json:"complianceType"`
 
 	// OperatorGroup specifies which `OperatorGroup` to inspect. Include the name, namespace, and any
 	// `spec` fields for the operator group. For more info, see `kubectl explain operatorgroups.spec`

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2095,7 +2095,6 @@ func (r *ConfigurationPolicyReconciler) enforceByCreatingOrDeleting(obj singleOb
 		} else {
 			reason = reasonDeleteSuccess
 			msg = fmt.Sprintf("%v %v was deleted successfully", obj.scopedGVR.Resource, idStr)
-			obj.existingObj = nil
 		}
 	}
 

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -1056,8 +1056,8 @@ secrets:
 	desiredObj := unstructured.Unstructured{Object: serviceAccountObj}
 	existingObj := unstructured.Unstructured{Object: existingServiceAccountObj}
 	existingObjCopy := unstructured.Unstructured{Object: existingServiceAccountObjCopy}
-	compType := "mustonlyhave"
-	mdCompType := ""
+	compType := policyv1.MustOnlyHave
+	mdCompType := policyv1.MustOnlyHave
 	zeroValueEqualsNil := false
 
 	throwSpecViolation, _, updateNeeded, statusMismatch := handleKeys(desiredObj, &existingObj,

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -633,7 +633,7 @@ func TestAddRelatedObject(t *testing.T) {
 	assert.True(t, related.Object.Metadata.Name == name)
 }
 
-func TestSortRelatedObjectsAndUpdate(t *testing.T) {
+func TestUpdatedRelatedObjects(t *testing.T) {
 	r := &ConfigurationPolicyReconciler{}
 
 	policy := &policyv1.ConfigurationPolicy{
@@ -669,9 +669,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 		true, scopedGVR, "ConfigurationPolicy", "default", []string{name}, "reason", nil)...,
 	)
 
-	empty := []policyv1.RelatedObject{}
-
-	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
+	r.updatedRelatedObjects(policy, relatedList)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 
 	// append another object named bar but also with namespace bar
@@ -679,7 +677,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 		true, scopedGVR, "ConfigurationPolicy", "bar", []string{name}, "reason", nil)...,
 	)
 
-	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
+	r.updatedRelatedObjects(policy, relatedList)
 	assert.True(t, relatedList[0].Object.Metadata.Namespace == "bar")
 
 	// clear related objects and test sorting with no namespace
@@ -691,7 +689,7 @@ func TestSortRelatedObjectsAndUpdate(t *testing.T) {
 		true, scopedGVR, "ConfigurationPolicy", "", []string{name}, "reason", nil)...,
 	)
 
-	r.sortRelatedObjectsAndUpdate(policy, relatedList, empty, false)
+	r.updatedRelatedObjects(policy, relatedList)
 	assert.True(t, relatedList[0].Object.Metadata.Name == "bar")
 }
 

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -1058,10 +1058,9 @@ secrets:
 	existingObjCopy := unstructured.Unstructured{Object: existingServiceAccountObjCopy}
 	compType := policyv1.MustOnlyHave
 	mdCompType := policyv1.MustOnlyHave
-	zeroValueEqualsNil := false
 
 	throwSpecViolation, _, updateNeeded, statusMismatch := handleKeys(desiredObj, &existingObj,
-		&existingObjCopy, compType, mdCompType, zeroValueEqualsNil)
+		&existingObjCopy, compType, mdCompType)
 
 	assert.False(t, throwSpecViolation)
 	assert.False(t, updateNeeded)

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -60,7 +60,7 @@ func addRelatedObjects(
 		relatedObject.Object.APIVersion = scopedGVR.GroupVersion().String()
 		relatedObject.Object.Kind = kind
 		relatedObject.Object.Metadata = metadata
-		relatedObjects = updateRelatedObjectsStatus(relatedObjects, relatedObject)
+		relatedObjects = addOrUpdateRelatedObject(relatedObjects, relatedObject)
 	}
 
 	return relatedObjects
@@ -117,8 +117,9 @@ func unmarshalFromJSON(rawData []byte) (unstructured.Unstructured, error) {
 	return unstruct, nil
 }
 
-// updateRelatedObjectsStatus adds or updates the RelatedObject in the policy status.
-func updateRelatedObjectsStatus(
+// addOrUpdateRelatedObject adds or updates the RelatedObject in the given list
+// and returns the resulting updated list
+func addOrUpdateRelatedObject(
 	list []policyv1.RelatedObject, relatedObject policyv1.RelatedObject,
 ) (result []policyv1.RelatedObject) {
 	present := false

--- a/controllers/metric.go
+++ b/controllers/metric.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/prometheus/client_golang/prometheus"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -100,4 +101,16 @@ func init() {
 	if regErr != nil && !errors.As(regErr, alreadyReg) {
 		panic(regErr)
 	}
+}
+
+func removeConfigPolicyMetrics(request ctrl.Request) {
+	// If a metric has an error while deleting, that means the policy was never evaluated so it can be ignored.
+	_ = policyEvalSecondsCounter.DeleteLabelValues(request.Name)
+	_ = policyEvalCounter.DeleteLabelValues(request.Name)
+	_ = plcTempsProcessSecondsCounter.DeleteLabelValues(request.Name)
+	_ = plcTempsProcessCounter.DeleteLabelValues(request.Name)
+	_ = compareObjEvalCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
+	_ = compareObjSecondsCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
+	_ = policyUserErrorsCounter.DeletePartialMatch(prometheus.Labels{"template": request.Name})
+	_ = policySystemErrorsCounter.DeletePartialMatch(prometheus.Labels{"template": request.Name})
 }

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -905,9 +905,7 @@ func (r *OperatorPolicyReconciler) musthaveOpGroup(
 			return false, nil, false, fmt.Errorf("error converting desired OperatorGroup to an Unstructured: %w", err)
 		}
 
-		updateNeeded, skipUpdate, err := r.mergeObjects(
-			ctx, desiredUnstruct, &opGroup, string(policy.Spec.ComplianceType),
-		)
+		updateNeeded, skipUpdate, err := r.mergeObjects(ctx, desiredUnstruct, &opGroup, policy.Spec.ComplianceType)
 		if err != nil {
 			return false, nil, false, fmt.Errorf("error checking if the OperatorGroup needs an update: %w", err)
 		}
@@ -1196,7 +1194,7 @@ func (r *OperatorPolicyReconciler) musthaveSubscription(
 		unstructured.RemoveNestedField(desiredUnstruct, "spec", "installPlanApproval")
 	}
 
-	updateNeeded, skipUpdate, err := r.mergeObjects(ctx, desiredUnstruct, foundSub, string(policy.Spec.ComplianceType))
+	updateNeeded, skipUpdate, err := r.mergeObjects(ctx, desiredUnstruct, foundSub, policy.Spec.ComplianceType)
 	if err != nil {
 		return nil, nil, false, fmt.Errorf("error checking if the Subscription needs an update: %w", err)
 	}
@@ -2357,7 +2355,7 @@ func (r *OperatorPolicyReconciler) mergeObjects(
 	ctx context.Context,
 	desired map[string]interface{},
 	existing *unstructured.Unstructured,
-	complianceType string,
+	complianceType policyv1.ComplianceType,
 ) (updateNeeded, updateIsForbidden bool, err error) {
 	desiredObj := unstructured.Unstructured{Object: desired}
 

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -2363,9 +2363,7 @@ func (r *OperatorPolicyReconciler) mergeObjects(
 	existingObjectCopy := existing.DeepCopy()
 	removeFieldsForComparison(existingObjectCopy)
 
-	_, errMsg, updateNeeded, _ := handleKeys(
-		desiredObj, existing, existingObjectCopy, complianceType, "", false,
-	)
+	_, errMsg, updateNeeded, _ := handleKeys(desiredObj, existing, existingObjectCopy, complianceType, "")
 	if errMsg != "" {
 		return updateNeeded, false, errors.New(errMsg)
 	}

--- a/deploy/crds/kustomize_operatorpolicy/allowed-compliance-types.json
+++ b/deploy/crds/kustomize_operatorpolicy/allowed-compliance-types.json
@@ -1,7 +1,0 @@
-[
-    {
-        "op":"replace",
-        "path":"/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/complianceType/enum",
-        "value": ["musthave", "mustnothave"]
-    }
-]

--- a/deploy/crds/kustomize_operatorpolicy/kustomization.yaml
+++ b/deploy/crds/kustomize_operatorpolicy/kustomization.yaml
@@ -2,13 +2,6 @@ resources:
 - policy.open-cluster-management.io_operatorpolicies.yaml
 
 patches:
-# The OperatorPolicy currently only supports "musthave"
-- path: allowed-compliance-types.json
-  target:
-    group: apiextensions.k8s.io
-    version: v1
-    kind: CustomResourceDefinition
-    name: operatorpolicies.policy.open-cluster-management.io
 - path: template-label.json
   target:
     group: apiextensions.k8s.io

--- a/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -80,18 +80,11 @@ spec:
                 type: object
               complianceType:
                 description: |-
-                  ComplianceType describes how objects on the cluster should be compared with the object definition
-                  of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
-                  `MustNotHave`.
+                  ComplianceType specifies the desired state of the operator on the cluster. If set to
+                  `musthave`, the policy is compliant when the operator is found. If set to `mustnothave`,
+                  the policy is compliant when the operator is not found.
                 enum:
-                - MustHave
-                - Musthave
                 - musthave
-                - MustOnlyHave
-                - Mustonlyhave
-                - mustonlyhave
-                - MustNotHave
-                - Mustnothave
                 - mustnothave
                 type: string
               operatorGroup:

--- a/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -82,9 +82,9 @@ spec:
                 type: object
               complianceType:
                 description: |-
-                  ComplianceType describes how objects on the cluster should be compared with the object definition
-                  of the configuration policy. The supported options are `MustHave`, `MustOnlyHave`, or
-                  `MustNotHave`.
+                  ComplianceType specifies the desired state of the operator on the cluster. If set to
+                  `musthave`, the policy is compliant when the operator is found. If set to `mustnothave`,
+                  the policy is compliant when the operator is not found.
                 enum:
                 - musthave
                 - mustnothave

--- a/test/e2e/case8_status_check_test.go
+++ b/test/e2e/case8_status_check_test.go
@@ -101,10 +101,10 @@ var _ = Describe("Test pod obj template handling", func() {
 		})
 		AfterAll(func() {
 			policies := []string{
-				case8ConfigPolicyNamePod,
 				case8ConfigPolicyNameCheck,
 				case8ConfigPolicyNameCheckFail,
 				case8ConfigPolicyNameEnforceFail,
+				case8ConfigPolicyNamePod,
 			}
 
 			deleteConfigPolicies(policies)


### PR DESCRIPTION
I've tried to make each of the commits understandable on their own, but the major reorganization in the big function was difficult to read no matter how I split it up.

There are two commits with changes beyond just refactoring:
- [Assume dry run is always supported](https://github.com/open-cluster-management-io/config-policy-controller/commit/3873da64679935346a1a6ca9dc25b438b0c5e9ab)
- [Cache empty selectors and errors in NS reconciler](https://github.com/open-cluster-management-io/config-policy-controller/commit/feec0d09c271a2450ad3be8b9513d20c7de83260)

I would be happy to walk through any changes if it would help.