### PR TITLE
Fix order of deleting ConfigPolicies in test

### DIFF
--- a/test/e2e/case8_status_check_test.go
+++ b/test/e2e/case8_status_check_test.go
@@ -101,10 +101,10 @@ var _ = Describe("Test pod obj template handling", func() {
 		})
 		AfterAll(func() {
 			policies := []string{
-				case8ConfigPolicyNamePod,
 				case8ConfigPolicyNameCheck,
 				case8ConfigPolicyNameCheckFail,
 				case8ConfigPolicyNameEnforceFail,
+				case8ConfigPolicyNamePod,
 			}
 
 			deleteConfigPolicies(policies)


### PR DESCRIPTION
This was causing some flaky test failures. The enforced policy was sometimes recreating the 'policy-pod-to-check' config policy after it was deleted.

Commit migrated from:
- #276 