### PR TITLE
Modify metrics options to account for deprecation of kube-rbac-proxy

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,8 +253,9 @@ func main() {
 
 	// Configure secure metrics
 	if opts.secureMetrics {
-		metricsOptions.SecureServing = true
 		metricsOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+		metricsOptions.SecureServing = true
+		metricsOptions.CertDir = "/var/run/metrics-cert"
 	}
 
 	// Set default manager options
@@ -715,8 +716,8 @@ func parseOpts(flags *pflag.FlagSet, args []string) *ctrlOpts {
 	flags.BoolVar(
 		&opts.secureMetrics,
 		"secure-metrics",
-		true,
-		"Enable secure metrics endpoint",
+		false,
+		"Enable secure metrics endpoint with certificates at /var/run/metrics-cert",
 	)
 
 	flags.StringVar(

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,6 @@ func TestRunMain(t *testing.T) {
 		// Speed up the tests by not throttling the policy evaluations
 		"--evaluation-backoff=1",
 		"--enable-operator-policy=true",
-		"--secure-metrics=false",
 	)
 
 	main()


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-8346