### PR TITLE
Add observedGeneration to OperatorPolicy status

### DIFF
--- a/api/v1beta1/operatorpolicy_types.go
+++ b/api/v1beta1/operatorpolicy_types.go
@@ -199,6 +199,10 @@ type OperatorPolicyStatus struct {
 	// ComplianceState reports the most recent compliance state of the operator policy.
 	ComplianceState policyv1.ComplianceState `json:"compliant,omitempty"`
 
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions includes historic details on the condition of the operator policy.
 	//
 	//+listType=map

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -57,7 +57,7 @@ func updateStatus(
 	if condChanged {
 		updatedComplianceCondition := calculateComplianceCondition(policy)
 
-		compCondIdx, _ := policy.Status.GetCondition(updatedComplianceCondition.Type)
+		compCondIdx, _ := policy.Status.GetCondition(compliantConditionType)
 		if compCondIdx == -1 {
 			policy.Status.Conditions = append(policy.Status.Conditions, updatedComplianceCondition)
 		} else {
@@ -148,7 +148,12 @@ func updateStatus(
 		}
 	}
 
-	return condChanged || relObjsChanged
+	genUpdated := policy.ObjectMeta.Generation != policy.Status.ObservedGeneration
+	if genUpdated {
+		policy.Status.ObservedGeneration = policy.ObjectMeta.Generation
+	}
+
+	return condChanged || relObjsChanged || genUpdated
 }
 
 func conditionChanged(updatedCondition, existingCondition metav1.Condition) bool {

--- a/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -303,6 +303,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               overlappingPolicies:
                 description: |-
                   The list of overlapping OperatorPolicies (as name.namespace) which all manage the same

--- a/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -305,6 +305,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               overlappingPolicies:
                 description: |-
                   The list of overlapping OperatorPolicies (as name.namespace) which all manage the same

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -118,6 +118,8 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 			err = json.Unmarshal(policyJSON, &policy)
 			g.Expect(err).NotTo(HaveOccurred())
 
+			g.Expect(policy.Status.ObservedGeneration).To(Equal(unstructPolicy.GetGeneration()))
+
 			if wantNonCompliant {
 				g.Expect(policy.Status.ComplianceState).To(Equal(policyv1.NonCompliant))
 			}


### PR DESCRIPTION
This can be useful to know if the controller has updated the status based on any updates tothe policy yet. It matches a common field used in core kubernetes objects.

Refs:
 - https://issues.redhat.com/browse/ACM-12804