### PR TITLE
Update go-template-utils to v6.1.1

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 	gocmp "github.com/google/go-cmp/cmp"
-	templates "github.com/stolostron/go-template-utils/v5/pkg/templates"
+	templates "github.com/stolostron/go-template-utils/v6/pkg/templates"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1120,7 +1120,9 @@ func (r *ConfigurationPolicyReconciler) handleTemplatization(
 	var tmplResolver *templates.TemplateResolver
 
 	if usingWatch {
-		tmplResolver, err = templates.NewResolverWithDynamicWatcher(r.DynamicWatcher, templates.Config{})
+		tmplResolver, err = templates.NewResolverWithDynamicWatcher(
+			r.DynamicWatcher, templates.Config{SkipBatchManagement: true},
+		)
 		objID := plc.ObjectIdentifier()
 
 		resolveOptions.Watcher = &objID

--- a/controllers/encryption.go
+++ b/controllers/encryption.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/stolostron/go-template-utils/v5/pkg/templates"
+	"github.com/stolostron/go-template-utils/v6/pkg/templates"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -19,7 +19,7 @@ import (
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	templates "github.com/stolostron/go-template-utils/v5/pkg/templates"
+	templates "github.com/stolostron/go-template-utils/v6/pkg/templates"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -388,7 +388,9 @@ func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *p
 	if !disableTemplates {
 		var err error
 
-		tmplResolver, err = templates.NewResolverWithDynamicWatcher(r.DynamicWatcher, templates.Config{})
+		tmplResolver, err = templates.NewResolverWithDynamicWatcher(
+			r.DynamicWatcher, templates.Config{SkipBatchManagement: true},
+		)
 		if err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("unable to create template resolver: %w", err))
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v5 v5.0.0
-	github.com/stolostron/kubernetes-dependency-watches v0.8.1
+	github.com/stolostron/go-template-utils/v6 v6.1.1
+	github.com/stolostron/kubernetes-dependency-watches v0.9.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/mod v0.17.0
 	k8s.io/api v0.29.5

--- a/go.sum
+++ b/go.sum
@@ -179,10 +179,10 @@ github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AV
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v5 v5.0.0 h1:X93kI5JyHQaaeryvIZUWMDHRbXL4aqgRCw6TBZcVn+I=
-github.com/stolostron/go-template-utils/v5 v5.0.0/go.mod h1:MS/HFKsgQFOITJnuuVBmUBciagk8GJHEN0zjtidW2+8=
-github.com/stolostron/kubernetes-dependency-watches v0.8.1 h1:lm2p785iltlQe6+ImNCHR3d/Un4X42/NmRvm//9EvRc=
-github.com/stolostron/kubernetes-dependency-watches v0.8.1/go.mod h1:BpDgquBjEbNM9dQYlLndGBX+FoaXDUJQ6eR3j1NA+Kk=
+github.com/stolostron/go-template-utils/v6 v6.1.1 h1:Fm68U6vSSOihgiUYsRdI5P3Xj8APxZIJyeAvCH/39Sc=
+github.com/stolostron/go-template-utils/v6 v6.1.1/go.mod h1:tMHdfS/X/Fn7lliavT3q/yK0oI0mvxp+g9qXXSReuk0=
+github.com/stolostron/kubernetes-dependency-watches v0.9.1 h1:54FSEdcE+3MECfmW7nvMToy0vBbufwCzXfEHty9G8Ho=
+github.com/stolostron/kubernetes-dependency-watches v0.9.1/go.mod h1:BpDgquBjEbNM9dQYlLndGBX+FoaXDUJQ6eR3j1NA+Kk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
This isn't required but trying to keep the main branches of the controllers using the same version.