### PR TITLE
Use `--server-side` for `null` test

### DIFF
--- a/test/crds/securitycontextconstraints.security.openshift.io_crd.yaml
+++ b/test/crds/securitycontextconstraints.security.openshift.io_crd.yaml
@@ -1,12 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: "2020-07-01T18:12:53Z"
-  generation: 1
   name: securitycontextconstraints.security.openshift.io
-  resourceVersion: "306"
-  selfLink: /apis/apiextensions.k8s.io/v1/customresourcedefinitions/securitycontextconstraints.security.openshift.io
-  uid: 6c41f1bb-278d-4414-8c1d-82de7c2d5135
 spec:
   conversion:
     strategy: None
@@ -325,22 +320,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: SecurityContextConstraints
-    listKind: SecurityContextConstraintsList
-    plural: securitycontextconstraints
-    singular: securitycontextconstraints
-  conditions:
-  - lastTransitionTime: "2020-07-01T18:12:53Z"
-    message: no conflicts found
-    reason: NoConflicts
-    status: "True"
-    type: NamesAccepted
-  - lastTransitionTime: "2020-07-01T18:12:53Z"
-    message: the initial names have been accepted
-    reason: InitialNamesAccepted
-    status: "True"
-    type: Established
-  storedVersions:
-  - v1


### PR DESCRIPTION
In K8s v1.31, `kubectl create` and `kubectl apply` client-side both treat `null` as removing the field, which breaks our test that is trying to test when the field is actually set to `null`. Using `kubectl apply --server-side` fixes it.

> In the client-side apply on create, defining the null value as "delete the key associated with this value". [SIG API Machinery, CLI and Testing]

ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md

Also refactor to get more informative results, including:
- Moving the variables to be function-scoped
- Returning a diff rather than a boolean