### PR TITLE
Add sprig functions to customMessage templating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module open-cluster-management.io/config-policy-controller
 go 1.22.0
 
 require (
+	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
@@ -14,7 +15,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v6 v6.1.1
+	github.com/stolostron/go-template-utils/v6 v6.2.0
 	github.com/stolostron/kubernetes-dependency-watches v0.9.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/mod v0.17.0
@@ -34,7 +35,6 @@ require (
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AV
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v6 v6.1.1 h1:Fm68U6vSSOihgiUYsRdI5P3Xj8APxZIJyeAvCH/39Sc=
-github.com/stolostron/go-template-utils/v6 v6.1.1/go.mod h1:tMHdfS/X/Fn7lliavT3q/yK0oI0mvxp+g9qXXSReuk0=
+github.com/stolostron/go-template-utils/v6 v6.2.0 h1:BzkG1fLWXpvtPscukyEsMvgE2u+gOsE+7+Bu9MKdwxg=
+github.com/stolostron/go-template-utils/v6 v6.2.0/go.mod h1:gEWq/Ws+835v56yHflmUyhza3fuLTT8q/Av0kUfPsvU=
 github.com/stolostron/kubernetes-dependency-watches v0.9.1 h1:54FSEdcE+3MECfmW7nvMToy0vBbufwCzXfEHty9G8Ho=
 github.com/stolostron/kubernetes-dependency-watches v0.9.1/go.mod h1:BpDgquBjEbNM9dQYlLndGBX+FoaXDUJQ6eR3j1NA+Kk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This helps with consistency between the customMessage templates and the other templating we have in policies.