### PR TITLE
Clean policies in ocm namespace after test

### DIFF
--- a/test/e2e/case1_pod_handling_test.go
+++ b/test/e2e/case1_pod_handling_test.go
@@ -344,6 +344,15 @@ var _ = Describe("Test pod obj template handling", Ordered, func() {
 			Expect(pod).NotTo(BeNil())
 		})
 		AfterAll(func() {
+			utils.KubectlDelete("configurationpolicy", configPolicyNameInform, "-n", ocmNs)
+			utils.KubectlDelete("configurationpolicy", configPolicyNameEnforce, "-n", ocmNs)
+			_ = utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, configPolicyNameInform, ocmNs, false, defaultTimeoutSeconds,
+			)
+			_ = utils.GetWithTimeout(
+				clientManagedDynamic, gvrConfigPolicy, configPolicyNameEnforce, ocmNs, false, defaultTimeoutSeconds,
+			)
+
 			utils.KubectlDelete("ns", ocmNs)
 
 			By("Delete pods")


### PR DESCRIPTION
The namespace isn't deleted when the pod is removed, causing the policy to recreate the pod. Clean up policies before deleting the namespace.
Signed-off-by: yiraeChristineKim <yikim@redhat.com>