### PR TITLE
Fix mismatch status updat\ne with Root Policy

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -3133,16 +3133,6 @@ func (r *ConfigurationPolicyReconciler) addForUpdate(policy *policyv1.Configurat
 func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 	policy *policyv1.ConfigurationPolicy, sendEvent bool,
 ) error {
-	if sendEvent {
-		log.Info("Sending parent policy compliance event")
-
-		// If the compliance event can't be created, then don't update the ConfigurationPolicy
-		// status. As long as that hasn't been updated, everything will be retried next loop.
-		if err := r.sendComplianceEvent(policy); err != nil {
-			return err
-		}
-	}
-
 	log.V(2).Info(
 		"Updating configurationPolicy status", "status", policy.Status.ComplianceState, "policy", policy.GetName(),
 	)
@@ -3180,6 +3170,15 @@ func (r *ConfigurationPolicyReconciler) updatePolicyStatus(
 
 			log.Info(fmt.Sprintf("Failed to update policy status. Retrying (attempt %d/%d): %s", i, maxRetries, err))
 		} else {
+			if sendEvent {
+				log.Info("Sending parent policy compliance event")
+				// If the compliance event can't be created, then don't update the ConfigurationPolicy
+				// status. As long as that hasn't been updated, everything will be retried next loop.
+				if err := r.sendComplianceEvent(policy); err != nil {
+					return err
+				}
+			}
+			
 			break
 		}
 	}


### PR DESCRIPTION

<img width="455" alt="Screenshot 2024-10-16 at 3 32 53 PM" src="https://github.com/user-attachments/assets/730bc4c0-69d4-4826-ad4a-e7eea303e9fc">
1. Configuration status:
```
status:
  compliancyDetails:
  - Compliant: Compliant
    Validity: {}
    conditions:
    - lastTransitionTime: "2024-05-29T14:30:08Z"
      message: subscriptions [openshift-gitops-operator] found as specified in namespace
        openshift-gitops-operator
      reason: K8s `must have` object already exists
      status: "True"
      type: notification
  - Compliant: Compliant
    Validity: {}
    conditions:
    - lastTransitionTime: "2024-10-02T09:10:37Z"
      message: deployments [openshift-gitops-operator-controller-manager] found as
        specified in namespace openshift-gitops-operator
      reason: K8s `must have` object already exists
      status: "True"
      type: notification
  compliant: Compliant
  lastEvaluated: "2024-10-07T15:03:44Z"
  lastEvaluatedGeneration: 1
```

2. Policy status:
```
status:
  compliant: NonCompliant
  details:
  - compliant: NonCompliant
    history:
    - eventName: smbc-acm-policies.openshift-gitops-operator-status.17fb5be592be943b
      lastTimestamp: "2024-10-04T21:05:23Z"
      message: NonCompliant; notification - subscriptions [openshift-gitops-operator]
        found as specified in namespace openshift-gitops-operator; violation - deployments
        found but not as specified in namespace openshift-gitops-operator
```

Assume:
- The deployment became noncompliant (e.g. status didn't match anymore)
- config-policy-controller sent the compliance event and then likely failed the status update on the ConfigurationPolicy (can't confirm because of no logs): I think it fell to 
```
if k8serrors.IsConflict(err) {
		policyLog.Error(err, "Tried to re-update status before previous update could be applied, retrying next loop")
```
The Deployment status(Configuration controller watching) is changed quickly
- Next time the ConfigurationPolicy was evaluated, the deployment became compliant but because the last status still matched due to the failed status update, a compliant compliance event was not sent.

Ref: https://issues.redhat.com/browse/ACM-14822