### PR TITLE
Approve package dependencies if the top-level CSV is approved

### DIFF
--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -1705,7 +1705,7 @@ func (r *OperatorPolicyReconciler) musthaveInstallPlan(
 		), nil
 	}
 
-	remainingCSVsToApprove, err := r.getRemainingCSVApprovals(ctx, policy, sub, ipCSVs)
+	remainingCSVsToApprove, err := r.getRemainingCSVApprovals(ctx, policy, sub, &latestInstallPlan)
 	if err != nil {
 		return false, fmt.Errorf("error finding the InstallPlan approvals: %w", err)
 	}
@@ -1742,19 +1742,16 @@ func (r *OperatorPolicyReconciler) getRemainingCSVApprovals(
 	ctx context.Context,
 	currentPolicy *policyv1beta1.OperatorPolicy,
 	currentSub *operatorv1alpha1.Subscription,
-	csvNames []string,
+	installPlan *operatorv1alpha1.InstallPlan,
 ) ([]string, error) {
+	csvNames := installPlan.Spec.ClusterServiceVersionNames
+
 	requiredCSVs := sets.New(csvNames...)
-	approvedCSVs := sets.New[string]()
-
 	// First try the current OperatorPolicy without checking others.
-	approvedCSV := r.getApprovedCSV(currentPolicy, currentSub, csvNames)
-	if approvedCSV != "" {
-		approvedCSVs.Insert(approvedCSV)
+	approvedCSVs := getApprovedCSVs(currentPolicy, currentSub, installPlan)
 
-		if requiredCSVs.Equal(approvedCSVs) {
-			return nil, nil
-		}
+	if approvedCSVs.IsSuperset(requiredCSVs) {
+		return nil, nil
 	}
 
 	watcher := opPolIdentifier(currentPolicy.Namespace, currentPolicy.Name)
@@ -1811,10 +1808,7 @@ func (r *OperatorPolicyReconciler) getRemainingCSVApprovals(
 			continue
 		}
 
-		approvedCSV := r.getApprovedCSV(&policy, &subTyped, csvNames)
-		if approvedCSV != "" {
-			approvedCSVs.Insert(approvedCSV)
-		}
+		approvedCSVs = approvedCSVs.Union(getApprovedCSVs(&policy, &subTyped, installPlan))
 	}
 
 	unapprovedCSVs := requiredCSVs.Difference(approvedCSVs).UnsortedList()
@@ -1824,14 +1818,14 @@ func (r *OperatorPolicyReconciler) getRemainingCSVApprovals(
 	return unapprovedCSVs, nil
 }
 
-// getApprovedCSV returns the CSV in the passed in csvNames that can be approved. If no approval can take place, an
-// empty string is returned.
-func (r *OperatorPolicyReconciler) getApprovedCSV(
-	policy *policyv1beta1.OperatorPolicy, sub *operatorv1alpha1.Subscription, csvNames []string,
-) string {
+// getApprovedCSVs returns the CSVs in the passed in subscription that can be approved. If no approval can take place,
+// an empty list is returned.
+func getApprovedCSVs(
+	policy *policyv1beta1.OperatorPolicy, sub *operatorv1alpha1.Subscription, installPlan *operatorv1alpha1.InstallPlan,
+) sets.Set[string] {
 	// Only enforce policies can approve InstallPlans
 	if !policy.Spec.RemediationAction.IsEnforce() {
-		return ""
+		return nil
 	}
 
 	initialInstall := sub.Status.InstalledCSV == ""
@@ -1840,33 +1834,128 @@ func (r *OperatorPolicyReconciler) getApprovedCSV(
 	// If the operator is already installed and isn't configured for automatic upgrades, then it can't approve
 	// InstallPlans.
 	if !autoUpgrade && !initialInstall {
-		return ""
+		return nil
 	}
 
-	allowedCSVs := make([]policyv1.NonEmptyString, 0, len(policy.Spec.Versions)+1)
-	allowedCSVs = append(allowedCSVs, policy.Spec.Versions...)
+	subscriptionCSV := sub.Status.CurrentCSV
 
-	if sub.Spec.StartingCSV != "" {
-		allowedCSVs = append(allowedCSVs, policyv1.NonEmptyString(sub.Spec.StartingCSV))
+	if subscriptionCSV == "" {
+		return nil
 	}
 
-	// All versions for the operator are allowed if no version is specified
+	approvedSubCSV := false
+
 	if len(policy.Spec.Versions) == 0 {
-		// currentCSV is the CSV related to the latest InstallPlan
-		if sub.Status.CurrentCSV != "" {
-			return sub.Status.CurrentCSV
-		}
+		approvedSubCSV = true
 	} else {
+		allowedCSVs := make([]policyv1.NonEmptyString, 0, len(policy.Spec.Versions)+1)
+		allowedCSVs = append(allowedCSVs, policy.Spec.Versions...)
+
+		if sub.Spec != nil && sub.Spec.StartingCSV != "" {
+			allowedCSVs = append(allowedCSVs, policyv1.NonEmptyString(sub.Spec.StartingCSV))
+		}
+
 		for _, allowedCSV := range allowedCSVs {
-			for _, csvName := range csvNames {
-				if string(allowedCSV) == csvName {
-					return csvName
-				}
+			if string(allowedCSV) == subscriptionCSV {
+				approvedSubCSV = true
+
+				break
 			}
 		}
 	}
 
-	return ""
+	if !approvedSubCSV {
+		return nil
+	}
+
+	packageDependencies := getBundleDependencies(installPlan, subscriptionCSV, "")
+
+	approvedCSVs := sets.Set[string]{}
+	approvedCSVs.Insert(subscriptionCSV)
+
+	// Approve all CSVs that are dependencies of the subscription CSV.
+	for _, packageDependency := range packageDependencies.UnsortedList() {
+		for _, csvName := range installPlan.Spec.ClusterServiceVersionNames {
+			if strings.HasPrefix(csvName, packageDependency+".v") {
+				approvedCSVs.Insert(csvName)
+			}
+		}
+	}
+
+	return approvedCSVs
+}
+
+// getBundleDependencies recursively gets the dependencies from a target CSV or package name. If the package name is
+// provided instead of the target CSV, then it assumes the CSVs are in the format of `<package>.v<version>`. The
+// returned set is of package names and not the CSV (i.e. no version in it).
+func getBundleDependencies(
+	installPlan *operatorv1alpha1.InstallPlan, targetCSV string, packageName string,
+) sets.Set[string] {
+	packageDependencies := sets.Set[string]{}
+
+	if targetCSV == "" && packageName == "" {
+		return packageDependencies
+	}
+
+	for i, bundle := range installPlan.Status.BundleLookups {
+		if targetCSV != "" && bundle.Identifier != targetCSV {
+			continue
+		}
+
+		if packageName != "" && !strings.HasPrefix(bundle.Identifier, packageName+".v") {
+			continue
+		}
+
+		if bundle.Properties == "" {
+			break
+		}
+
+		props := map[string]interface{}{}
+
+		err := json.Unmarshal([]byte(bundle.Properties), &props)
+		if err != nil {
+			log.Error(
+				err,
+				"The bundle properties on the InstallPlan are invalid. Will skip check for operator dependencies.",
+				"path", fmt.Sprintf("status.bundleLookups[%d]", i),
+				"installPlan", installPlan.Name,
+				"namespace", installPlan.Namespace,
+			)
+
+			break
+		}
+
+		propsList, ok := props["properties"].([]interface{})
+		if !ok {
+			break
+		}
+
+		for _, prop := range propsList {
+			propMap, ok := prop.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			if propMap["type"] != "olm.package.required" {
+				continue
+			}
+
+			propValue, ok := propMap["value"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			depPackageName, ok := propValue["packageName"].(string)
+			if !ok || depPackageName == "" {
+				continue
+			}
+
+			packageDependencies.Insert(depPackageName)
+			packageDependencies = packageDependencies.Union(getBundleDependencies(installPlan, "", depPackageName))
+		}
+	}
+
+	return packageDependencies
 }
 
 func (r *OperatorPolicyReconciler) mustnothaveInstallPlan(

--- a/test/resources/unit/odf-installplan.yaml
+++ b/test/resources/unit/odf-installplan.yaml
@@ -1,0 +1,107 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  creationTimestamp: "2024-10-17T14:57:31Z"
+  generateName: install-
+  generation: 1
+  labels:
+    operators.coreos.com/odf-operator.openshift-storage: ""
+  name: install-dxrlr
+  namespace: openshift-storage
+  ownerReferences:
+  - apiVersion: operators.coreos.com/v1alpha1
+    blockOwnerDeletion: false
+    controller: false
+    kind: Subscription
+    name: odf-operator
+    uid: 19d57638-2589-425e-8dc0-e67a97c0dcd6
+  resourceVersion: "184549"
+  uid: 910f5d87-7997-40d8-b381-409934d6126a
+spec:
+  approval: Manual
+  approved: false
+  clusterServiceVersionNames:
+  - ocs-operator.v4.16.3-rhodf
+  - ocs-client-operator.v4.16.3-rhodf
+  - odf-operator.v4.16.3-rhodf
+  - odf-prometheus-operator.v4.16.3-rhodf
+  - mcg-operator.v4.16.3-rhodf
+  - odf-csi-addons-operator.v4.16.3-rhodf
+  - recipe.v4.16.3-rhodf
+  - rook-ceph-operator.v4.16.3-rhodf
+  generation: 1
+status:
+  bundleLookups:
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: ocs-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/ocs-operator-bundle@sha256:1bbc151acb46edd4c042acd66d028eaa6b514204ad79c8be708d89f07c9f9e81
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"OCSInitialization","version":"v1"}},{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"StorageCluster","version":"v1"}},{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"StorageConsumer","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"StorageProfile","version":"v1"}},{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"StorageRequest","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"ocs-operator","version":"4.16.3-rhodf"}},{"type":"olm.package.required","value":{"packageName":"rook-ceph-operator","versionRange":"\u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"rook-ceph-operator","versionRange":"\u003c=4.16.3"}}]}'
+    replaces: ocs-operator.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: ocs-client-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/ocs-client-operator-bundle@sha256:123523041fe4092a36fd41cc6203802d903188642bde1a40f22515a5715fff81
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"StorageClaim","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"ocs.openshift.io","kind":"StorageClient","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"ocs-client-operator","version":"4.16.3-rhodf"}},{"type":"olm.package.required","value":{"packageName":"odf-csi-addons-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"odf-csi-addons-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}}]}'
+    replaces: ocs-client-operator.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: odf-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/odf-operator-bundle@sha256:e5c49afe79002be166f7b51421d712069ad6fe67c54743c8a991afd97f9f30f6
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"odf.openshift.io","kind":"StorageSystem","version":"v1alpha1"}},{"type":"olm.maxOpenShiftVersion","value":"4.17"},{"type":"olm.package","value":{"packageName":"odf-operator","version":"4.16.3-rhodf"}},{"type":"olm.package.required","value":{"packageName":"mcg-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"ocs-client-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"ocs-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"odf-csi-addons-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"odf-prometheus-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"recipe","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"mcg-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"ocs-client-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"ocs-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"odf-csi-addons-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"odf-prometheus-operator","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}},{"type":"olm.package.required","value":{"packageName":"recipe","versionRange":"\u003e=4.9.0
+      \u003c=4.16.3"}}]}'
+    replaces: odf-operator.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: odf-prometheus-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/odf-prometheus-operator-bundle@sha256:5ddcb5b3ff0a69c80857e5185dcfd9e397ba0ad1272e66cd98acd729996d006a
+    properties: '{"properties":[{"type":"olm.package","value":{"packageName":"odf-prometheus-operator","version":"4.16.3-rhodf"}}]}'
+    replaces: odf-prometheus-operator.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: mcg-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/mcg-operator-bundle@sha256:5dc780b845bf22a5ed8350a0c8783d1fb8a0fef4ce2e1c3265db82fd236ea3e1
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"noobaa.io","kind":"BackingStore","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"noobaa.io","kind":"BucketClass","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"noobaa.io","kind":"NamespaceStore","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"noobaa.io","kind":"NooBaa","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"noobaa.io","kind":"NooBaaAccount","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"objectbucket.io","kind":"ObjectBucket","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"objectbucket.io","kind":"ObjectBucketClaim","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"mcg-operator","version":"4.16.3-rhodf"}}]}'
+    replaces: mcg-operator.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: odf-csi-addons-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/odf-csi-addons-operator-bundle@sha256:8721c6de61a7ee31e1312856e5887a36be7b1ce930fcba24b720097d286be6f6
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"csiaddons.openshift.io","kind":"CSIAddonsNode","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"csiaddons.openshift.io","kind":"NetworkFence","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"csiaddons.openshift.io","kind":"ReclaimSpaceCronJob","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"csiaddons.openshift.io","kind":"ReclaimSpaceJob","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"replication.storage.openshift.io","kind":"VolumeReplication","version":"v1alpha1"}},{"type":"olm.gvk","value":{"group":"replication.storage.openshift.io","kind":"VolumeReplicationClass","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"odf-csi-addons-operator","version":"4.16.3-rhodf"}}]}'
+    replaces: odf-csi-addons-operator.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: recipe.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/odr-recipe-operator-bundle@sha256:f221b43415c44080b49785f4a35447dc529e0d27c17a76057df6b80992ac5388
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"ramendr.openshift.io","kind":"Recipe","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"recipe","version":"4.16.3-rhodf"}}]}'
+    replaces: recipe.v4.16.2-rhodf
+  - catalogSourceRef:
+      name: redhat-operators
+      namespace: openshift-marketplace
+    identifier: rook-ceph-operator.v4.16.3-rhodf
+    path: registry.redhat.io/odf4/rook-ceph-operator-bundle@sha256:d97b31272d77f0b0552844cc58749b772d71bef73d40bd2bf7befdad86d139e4
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephBlockPool","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephBlockPoolRadosNamespace","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephBucketNotification","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephBucketTopic","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephCOSIDriver","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephClient","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephCluster","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephFilesystem","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephFilesystemMirror","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephFilesystemSubVolumeGroup","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephNFS","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephObjectRealm","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephObjectStore","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephObjectStoreUser","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephObjectZone","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephObjectZoneGroup","version":"v1"}},{"type":"olm.gvk","value":{"group":"ceph.rook.io","kind":"CephRBDMirror","version":"v1"}},{"type":"olm.package","value":{"packageName":"rook-ceph-operator","version":"4.16.3-rhodf"}}]}'
+    replaces: rook-ceph-operator.v4.16.2-rhodf
+  catalogSources:
+  - redhat-operators
+  phase: RequiresApproval


### PR DESCRIPTION
This handles InstallPlans that have multiple CSVs listed in them due to package dependencies.

Relates:
https://issues.redhat.com/browse/ACM-14540