### PR TITLE
Set `UnknownCompliancy` to an empty string

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -318,7 +318,7 @@ type ComplianceState string
 const (
 	Compliant         ComplianceState = "Compliant"
 	NonCompliant      ComplianceState = "NonCompliant"
-	UnknownCompliancy ComplianceState = "UnknownCompliancy"
+	UnknownCompliancy ComplianceState = ""
 	Terminating       ComplianceState = "Terminating"
 )
 

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -3307,7 +3307,7 @@ func (r *ConfigurationPolicyReconciler) sendComplianceEvent(instance *policyv1.C
 // defaultComplianceMessage looks through the policy's Compliance and CompliancyDetails and formats
 // a message that can be used for compliance events recognized by the framework.
 func defaultComplianceMessage(plc *policyv1.ConfigurationPolicy) string {
-	if plc.Status.ComplianceState == "" || plc.Status.ComplianceState == policyv1.UnknownCompliancy {
+	if plc.Status.ComplianceState == policyv1.UnknownCompliancy {
 		return "ComplianceState is still unknown"
 	}
 

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -1223,7 +1223,7 @@ var noExistingCSVObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: string(policyv1.UnknownCompliancy),
+	Compliant: "UnknownCompliancy",
 	Reason:    "No relevant ClusterServiceVersion found",
 }
 
@@ -1239,7 +1239,7 @@ var noExistingCRDObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: string(policyv1.UnknownCompliancy),
+	Compliant: "UnknownCompliancy",
 	Reason:    "No relevant CustomResourceDefinitions found",
 }
 
@@ -1285,7 +1285,7 @@ var noExistingDeploymentObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: string(policyv1.UnknownCompliancy),
+	Compliant: "UnknownCompliancy",
 	Reason:    "No relevant deployments found",
 }
 

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -1223,13 +1223,13 @@ var noExistingCSVObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: "UnknownCompliancy",
+	Compliant: "Inapplicable",
 	Reason:    "No relevant ClusterServiceVersion found",
 }
 
 // noExistingCRDObj is a RelatedObject for CustomResourceDefinitions,
 // with Reason 'No relevant CustomResourceDefinitions found'. It is considered
-// UnknownCompliancy because the lack of a CRD does not imply Compliance
+// Inapplicable because the lack of a CRD does not imply Compliance
 // or NonCompliance.
 var noExistingCRDObj = policyv1.RelatedObject{
 	Object: policyv1.ObjectResource{
@@ -1239,7 +1239,7 @@ var noExistingCRDObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: "UnknownCompliancy",
+	Compliant: "Inapplicable",
 	Reason:    "No relevant CustomResourceDefinitions found",
 }
 
@@ -1275,7 +1275,7 @@ func existingDeploymentObj(
 
 // noExistingDeploymentObj is a Compliant RelatedObject for Deployments,
 // with Reason 'No relevant Deployments found'. It is considered
-// UnknownCompliancy because the lack of a Deployment does not imply
+// Inapplicable because the lack of a Deployment does not imply
 // Compliance or NonCompliance.
 var noExistingDeploymentObj = policyv1.RelatedObject{
 	Object: policyv1.ObjectResource{
@@ -1285,7 +1285,7 @@ var noExistingDeploymentObj = policyv1.RelatedObject{
 			Name: "-",
 		},
 	},
-	Compliant: "UnknownCompliancy",
+	Compliant: "Inapplicable",
 	Reason:    "No relevant deployments found",
 }
 

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -1548,7 +1548,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "",
+					Compliant: "Inapplicable",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -1901,7 +1901,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "",
+					Compliant: "Inapplicable",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -2606,7 +2606,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "",
+					Compliant: "Inapplicable",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -2780,7 +2780,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "",
+					Compliant: "Inapplicable",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -1548,7 +1548,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "UnknownCompliancy",
+					Compliant: "",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -1901,7 +1901,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "UnknownCompliancy",
+					Compliant: "",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -2606,7 +2606,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "UnknownCompliancy",
+					Compliant: "",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{
@@ -2780,7 +2780,7 @@ var _ = Describe("Testing OperatorPolicy", Ordered, Label("supports-hosted"), fu
 							Name: "-",
 						},
 					},
-					Compliant: "UnknownCompliancy",
+					Compliant: "",
 					Reason:    "No relevant CustomResourceDefinitions found",
 				}},
 				metav1.Condition{


### PR DESCRIPTION
The framework-addon controller looks for an empty string. Plus, this aligns with the enum.

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>