### PR TITLE
Use YAML to decode mappings files in dryrun tool

### DIFF
--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -449,7 +449,7 @@ func (d *DryRunner) setupReconciler(
 		}
 
 		apiMappings := []mappings.APIMapping{}
-		if err := json.NewDecoder(reader).Decode(&apiMappings); err != nil {
+		if err := yaml.NewDecoder(reader).Decode(&apiMappings); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
The dryrun tool generates the mappings as a YAML file but was reading them in as JSON.