### PR TITLE
Adopt existing sub when packagemanifest not found

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -53,6 +53,7 @@ var (
 	gvrOperatorGroup            schema.GroupVersionResource
 	gvrInstallPlan              schema.GroupVersionResource
 	gvrClusterServiceVersion    schema.GroupVersionResource
+	gvrPackageManifest          schema.GroupVersionResource
 	defaultImageRegistry        string
 	IsHosted                    bool
 	targetK8sClient             kubernetes.Interface
@@ -121,6 +122,11 @@ var _ = BeforeSuite(func() {
 		Group:    "operators.coreos.com",
 		Version:  "v1alpha1",
 		Resource: "clusterserviceversions",
+	}
+	gvrPackageManifest = schema.GroupVersionResource{
+		Group:    "packages.operators.coreos.com",
+		Version:  "v1",
+		Resource: "packagemanifests",
 	}
 	gvrAPIService = schema.GroupVersionResource{
 		Group:    "apiregistration.k8s.io",


### PR DESCRIPTION
Previously, if the pacakagemanifest was missing, perhaps due to the operator no longer being available in the catalog, the operator policy would be marked as invalid, and not report on the potentially helpful status of the subscription. Now the existing subscription can be used for the default values, and a more helpful status can be reported.

Refs:
 - https://issues.redhat.com/browse/ACM-14617