### PR TITLE
Provide the ObjectNamespace template variable

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -568,7 +568,7 @@ status:
 		t.Error(err)
 	}
 
-	desiredObj := unstructured.Unstructured{Object: policyObjDef}
+	desiredObj := &unstructured.Unstructured{Object: policyObjDef}
 	existingObjOrderOne := unstructured.Unstructured{Object: orderOneObj}
 	existingObjOrderTwo := unstructured.Unstructured{Object: orderTwoObj}
 
@@ -1057,7 +1057,7 @@ secrets:
 	compType := policyv1.MustOnlyHave
 	mdCompType := policyv1.MustOnlyHave
 
-	throwSpecViolation, _, updateNeeded, statusMismatch := handleKeys(desiredObj, &existingObj,
+	throwSpecViolation, _, updateNeeded, statusMismatch := handleKeys(&desiredObj, &existingObj,
 		&existingObjCopy, compType, mdCompType)
 
 	assert.False(t, throwSpecViolation)
@@ -1524,7 +1524,7 @@ func TestShouldHandleSingleKeyFalse(t *testing.T) {
 		unstruct.Object = test.input
 		unstructObj.Object = test.fromAPI
 		key := test.expectResult.key
-		_, update, _, skip = handleSingleKey(key, unstruct, &unstructObj, "musthave", true)
+		_, update, _, skip = handleSingleKey(key, &unstruct, &unstructObj, "musthave", true)
 		assert.Equal(t, update, test.expectResult.expect)
 		assert.False(t, skip)
 	}

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -359,7 +359,7 @@ func filterUnwantedAnnotations(input map[string]interface{}) map[string]interfac
 }
 
 // formatTemplate returns the value of the input key in a manner that the controller can use for comparisons.
-func formatTemplate(unstruct unstructured.Unstructured, key string) (obj interface{}) {
+func formatTemplate(unstruct *unstructured.Unstructured, key string) (obj interface{}) {
 	if key == "metadata" {
 		metadata, ok := unstruct.Object[key].(map[string]interface{})
 		if !ok {

--- a/controllers/metric.go
+++ b/controllers/metric.go
@@ -25,22 +25,6 @@ var (
 		},
 		[]string{"name"},
 	)
-	plcTempsProcessSecondsCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "config_policy_templates_process_seconds_total",
-			Help: "The total seconds taken while processing the configuration policy templates. Use this alongside " +
-				"config_policy_templates_process_total.",
-		},
-		[]string{"name"},
-	)
-	plcTempsProcessCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "config_policy_templates_process_total",
-			Help: "The total number of processes of the configuration policy templates. Use this alongside " +
-				"config_policy_templates_process_seconds_total.",
-		},
-		[]string{"name"},
-	)
 	compareObjSecondsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "compare_objects_seconds_total",
@@ -85,8 +69,6 @@ func init() {
 	// Register custom metrics with the global Prometheus registry
 	metrics.Registry.MustRegister(policyEvalSecondsCounter)
 	metrics.Registry.MustRegister(policyEvalCounter)
-	metrics.Registry.MustRegister(plcTempsProcessSecondsCounter)
-	metrics.Registry.MustRegister(plcTempsProcessCounter)
 	metrics.Registry.MustRegister(compareObjSecondsCounter)
 	metrics.Registry.MustRegister(compareObjEvalCounter)
 	// Error metrics may already be registered by template sync
@@ -107,8 +89,6 @@ func removeConfigPolicyMetrics(request ctrl.Request) {
 	// If a metric has an error while deleting, that means the policy was never evaluated so it can be ignored.
 	_ = policyEvalSecondsCounter.DeleteLabelValues(request.Name)
 	_ = policyEvalCounter.DeleteLabelValues(request.Name)
-	_ = plcTempsProcessSecondsCounter.DeleteLabelValues(request.Name)
-	_ = plcTempsProcessCounter.DeleteLabelValues(request.Name)
 	_ = compareObjEvalCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
 	_ = compareObjSecondsCounter.DeletePartialMatch(prometheus.Labels{"config_policy_name": request.Name})
 	_ = policyUserErrorsCounter.DeletePartialMatch(prometheus.Labels{"template": request.Name})

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -2533,7 +2533,7 @@ func (r *OperatorPolicyReconciler) mergeObjects(
 	existing *unstructured.Unstructured,
 	complianceType policyv1.ComplianceType,
 ) (updateNeeded, updateIsForbidden bool, err error) {
-	desiredObj := unstructured.Unstructured{Object: desired}
+	desiredObj := &unstructured.Unstructured{Object: desired}
 
 	// Use a copy since some values can be directly assigned to mergedObj in handleSingleKey.
 	existingObjectCopy := existing.DeepCopy()

--- a/test/e2e/case35_no_apiversion_test.go
+++ b/test/e2e/case35_no_apiversion_test.go
@@ -25,8 +25,10 @@ var _ = Describe("Test a policy with an objectDefinition that is missing apiVers
 
 		By("Checking there is a NonCompliant event on the policy")
 		Eventually(func() interface{} {
-			return utils.GetMatchingEvents(clientManaged, testNamespace,
-				policyName, cfgPlcName, "^NonCompliant;.*missing apiVersion", defaultTimeoutSeconds)
+			return utils.GetMatchingEvents(
+				clientManaged, testNamespace, policyName, cfgPlcName,
+				"^NonCompliant;.*kind and apiVersion fields are required", defaultTimeoutSeconds,
+			)
 		}, defaultTimeoutSeconds, 5).ShouldNot(BeEmpty())
 
 		By("Checking there are no Compliant events on the policy")

--- a/test/e2e/case5_multi_test.go
+++ b/test/e2e/case5_multi_test.go
@@ -148,22 +148,14 @@ var _ = Describe("Test multiple obj template handling", Ordered, func() {
 			utils.Kubectl("apply", "-f", case5MultiEnforceErrYaml)
 
 			By("Kind missing")
-			kindErrMsg := "Decoding error, please check your policy file! Aborting handling the " +
-				"object template at index [0] in policy `policy-multi-namespace-enforce-kind-missing` with " +
-				"error = `Object 'Kind' is missing in '{\"apiVersion\":\"v1\",\"metadata\":" +
-				"{\"name\":\"case5-multi-namespace-enforce-kind-missing-pod\"}," +
-				"\"spec\":{\"containers\":[{\"image\":\"nginx:1.7.9\",\"imagePullPolicy\":\"Never\",\"name\":" +
-				"\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}'`"
+			kindErrMsg := "The kind and apiVersion fields are required on the object template at index 0 in policy " +
+				"policy-multi-namespace-enforce-kind-missing"
 			utils.DoConfigPolicyMessageTest(clientManagedDynamic, gvrConfigPolicy, testNamespace,
 				case5KindMissPlcName, 0, defaultTimeoutSeconds, kindErrMsg)
 
 			By("Kind and Name missing")
-			kindNameErrMsg := "Decoding error, please check your policy file! Aborting handling the " +
-				"object template at index [0] in policy `policy-multi-namespace-enforce-both-missing` " +
-				"with error = `Object 'Kind' is missing in " +
-				"'{\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"\"},\"spec\":{\"containers\":" +
-				"[{\"image\":\"nginx:1.7.9\",\"imagePullPolicy\":\"Never\"," +
-				"\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}'`"
+			kindNameErrMsg := "The kind and apiVersion fields are required on the object template at index 0 in " +
+				"policy policy-multi-namespace-enforce-both-missing"
 			utils.DoConfigPolicyMessageTest(clientManagedDynamic, gvrConfigPolicy, testNamespace,
 				case5KindNameMissPlcName, 0, defaultTimeoutSeconds, kindNameErrMsg)
 

--- a/test/resources/case13_templatization/case13_invalid_ns.yaml
+++ b/test/resources/case13_templatization/case13_invalid_ns.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case13-invalid-ns
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    include:
+    - default
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case13-invalid-ns
+          namespace: '{{ .ObjectNamespace }}-some-random-suffix'

--- a/test/resources/case13_templatization/case13_object_variables.yaml
+++ b/test/resources/case13_templatization/case13_object_variables.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case13-object-variables
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    include:
+    - default
+    - case13-e2e-object-variables
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case13-e2e-object-variables
+          namespace: '{{ .ObjectNamespace }}'
+          labels:
+            case13: passed
+            namespace: '{{ .ObjectNamespace }}'

--- a/test/resources/case13_templatization/case13_object_variables_prereqs.yaml
+++ b/test/resources/case13_templatization/case13_object_variables_prereqs.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: case13-e2e-object-variables
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case13-e2e-object-variables
+  namespace: case13-e2e-object-variables
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case13-e2e-object-variables
+  namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case13-e2e-object-variables2
+  namespace: case13-e2e-object-variables

--- a/test/resources/case13_templatization/case13_wrong_args.yaml
+++ b/test/resources/case13_templatization/case13_wrong_args.yaml
@@ -3,7 +3,7 @@ kind: ConfigurationPolicy
 metadata:
   name: case13-policy-pod-create-wrong-args
 spec:
-  remediationAction: enforce
+  remediationAction: inform
   namespaceSelector:
     exclude: ["kube-*"]
     include: ["default"]
@@ -20,3 +20,9 @@ spec:
               name: nginx
               ports:
                 - containerPort: 80
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: default

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -190,7 +190,17 @@ func GetComplianceState(managedPlc *unstructured.Unstructured) (result interface
 // GetStatusMessage parses status field to get message
 func GetStatusMessage(managedPlc *unstructured.Unstructured) (result interface{}) {
 	if managedPlc.Object["status"] != nil {
-		detail := managedPlc.Object["status"].(map[string]interface{})["compliancyDetails"].([]interface{})[0]
+		status, ok := managedPlc.Object["status"].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		complianceDetails, ok := status["compliancyDetails"].([]interface{})
+		if !ok || len(complianceDetails) == 0 {
+			return nil
+		}
+
+		detail := complianceDetails[0]
 
 		return detail.(map[string]interface{})["conditions"].([]interface{})[0].(map[string]interface{})["message"]
 	}


### PR DESCRIPTION
A user can now leverage the ObjectNamespace template variable to have a ConfigurationPolicy inform or enforce on a named object for all namespaces in the namespace selector.

As part of this, the code had to be refactored to resolve templates per object template rather than resolve all templates up front. This has the side effect of allowing some object templates to still be evaluated while another object template failed template resolution.

This made it so that the templating metrics no longer apply since there can be multiple calls to resolve templates per policy in different parts of the code.

Relates:
https://issues.redhat.com/browse/ACM-15392