### PR TITLE
Fix alreadyEvaluated check for dryrun

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -3162,7 +3162,10 @@ func (r *ConfigurationPolicyReconciler) alreadyEvaluated(
 
 	resultTyped := result.(cachedEvaluationResult)
 
-	return resultTyped.resourceVersion == currentObject.GetResourceVersion(), resultTyped.compliant, resultTyped.msg
+	alreadyEvaluated := resultTyped.resourceVersion != "" &&
+		resultTyped.resourceVersion == currentObject.GetResourceVersion()
+
+	return alreadyEvaluated, resultTyped.compliant, resultTyped.msg
 }
 
 func getUpdateErrorMsg(err error, kind string, name string) string {

--- a/pkg/dryrun/testdata/README.md
+++ b/pkg/dryrun/testdata/README.md
@@ -1,0 +1,6 @@
+# About these tests
+
+The test cases in `pkg/dryrun/testdata/` are meant to exercise the dryrun tool,
+and verify it behaves correctly with different kinds of inputs and that the
+output format is correct. These tests are not necessarily meant to check that
+ConfigruationPolicies are working as intended.

--- a/pkg/dryrun/testdata/test_multiple_object_templates/input_pods.yaml
+++ b/pkg/dryrun/testdata/test_multiple_object_templates/input_pods.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  namespace: default
+spec:
+  containers:
+    - image: nginx:1.7.9
+      name: nginx
+      ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  namespace: another
+spec:
+  containers:
+    - image: nginx:1.7.9
+      name: nginx
+      ports:
+        - containerPort: 8080

--- a/pkg/dryrun/testdata/test_multiple_object_templates/output.txt
+++ b/pkg/dryrun/testdata/test_multiple_object_templates/output.txt
@@ -1,0 +1,19 @@
+# Diffs:
+v1 Pod another/nginx-pod:
+
+v1 Pod default/nginx-pod:
+--- default/nginx-pod : existing
++++ default/nginx-pod : updated
+@@ -6,7 +6,8 @@
+ spec:
+   containers:
+   - image: nginx:1.7.9
+     name: nginx
+     ports:
++    - containerPort: 8080
+     - containerPort: 80
+ 
+v1 Pod nonexist/nginx-pod:
+
+# Compliance messages:
+NonCompliant; notification - pods [nginx-pod] found as specified in namespace another; violation - pods [nginx-pod] found but not as specified in namespace default; violation - pods [nginx-pod] not found in namespace nonexist

--- a/pkg/dryrun/testdata/test_multiple_object_templates/policy.yaml
+++ b/pkg/dryrun/testdata/test_multiple_object_templates/policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: example-config-policy
+  namespace: default
+spec:
+  remediationAction: enforce
+  object-templates-raw: |
+    {{range $ns := (list "another" "default" "nonexist")}}
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod
+          namespace: {{$ns}}
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 8080
+    {{end}}


### PR DESCRIPTION
It appears that the fake API server used by dryrun does not supply resource versions, so when multiple object templates were supplied in a ConfigurationPolicy to dryrun, it would incorrectly think that the later templates had already been evaluated and didn't need to be updated.

Now if the resource version is empty, it will not consider the object as already evaluated.

Refs:
 - https://issues.redhat.com/browse/ACM-15899