### PR TITLE
Add the skipObject template function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v6 v6.3.0
+	github.com/stolostron/go-template-utils/v6 v6.4.0
 	github.com/stolostron/kubernetes-dependency-watches v0.10.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AV
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v6 v6.3.0 h1:ptbIZcJqcWtT8baOrQyoqVFGj1PKQqyJzA9m+mcAHx8=
-github.com/stolostron/go-template-utils/v6 v6.3.0/go.mod h1:4+HWMKPMBDDekJlPve3zkuWdE0hcwgnKKOap2GoHjNY=
+github.com/stolostron/go-template-utils/v6 v6.4.0 h1:FKEK8rNi2VGhuEXY6gROfO6VBJ0myGqjfwfnRsLkpuY=
+github.com/stolostron/go-template-utils/v6 v6.4.0/go.mod h1:4+HWMKPMBDDekJlPve3zkuWdE0hcwgnKKOap2GoHjNY=
 github.com/stolostron/kubernetes-dependency-watches v0.10.0 h1:brg9FCZUvd1gnm5wmsv/InfErcPUvYcZsK/LWNRr+wg=
 github.com/stolostron/kubernetes-dependency-watches v0.10.0/go.mod h1:j1DBv/3JjwDX3bT/oKB4YvSwJ6DEVcrUpEzKbFLM0QM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/test/e2e/case42_resource_selection_test.go
+++ b/test/e2e/case42_resource_selection_test.go
@@ -26,8 +26,7 @@ var _ = Describe("Test results of resource selection", Ordered, func() {
 		policyName = "case42-selector-results-e2e"
 
 		filterErrMsgFmt = "Error parsing provided objectSelector in the object-template at index [0]: %s"
-		noMatchesMsg    = "object of kind FakeAPI has no name specified from " +
-			"the policy objectSelector nor the object metadata"
+		noMatchesMsg    = "No objects of kind FakeAPI were matched from the policy objectSelector"
 	)
 
 	// Test setup for resource selection policy tests:
@@ -61,7 +60,7 @@ var _ = Describe("Test results of resource selection", Ordered, func() {
 	})
 
 	DescribeTable("ObjectSelector matching all is specified", func(patch string) {
-		By("Verifying policy is noncompliant and returns no objects")
+		By("Verifying policy is compliant and returns no objects")
 		utils.Kubectl("patch", "--namespace=managed", "configurationpolicy", policyName, "--type=json",
 			fmt.Sprintf(objectSelectorPatchFmt, `{"matchLabels":{"selects":"nothing"}}`),
 		)

--- a/test/resources/case13_templatization/case13_objectname_var_all_skipped.yaml
+++ b/test/resources/case13_templatization/case13_objectname_var_all_skipped.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: case13-objectname-var
+  name: case13-objectname-var-all-skipped
 spec:
   remediationAction: enforce
   namespaceSelector:
@@ -17,7 +17,7 @@ spec:
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ if eq .ObjectName "case13-e2e-objectname-var1" }}{{ skipObject }}{{ else }}{{ .ObjectName }}{{ end }}'
+          name: '{{ if true }}{{ skipObject }}{{ end }}'
           namespace: "{{ .ObjectNamespace }}"
           labels:
             case13: passed


### PR DESCRIPTION
When a user wants further filtering based on the object name, they can call the `skipObject` template function to skip it from being considered for evaluation.

When all objects are skipped or there's no match from the object selector, the policy is considered compliant.

Relates:
https://issues.redhat.com/browse/ACM-15937