### PR TITLE
Fix when context variable isn't used for metadata

### DIFF
--- a/api/v1/configurationpolicy_types.go
+++ b/api/v1/configurationpolicy_types.go
@@ -79,6 +79,11 @@ type Target struct {
 	Exclude []NonEmptyString `json:"exclude,omitempty"`
 }
 
+// IsEmpty returns whether the defined Target would always return no objects.
+func (t Target) IsEmpty() bool {
+	return t.LabelSelector == nil && len(t.Include) == 0
+}
+
 // Define String() so that the LabelSelector is dereferenced in the logs
 func (t Target) String() string {
 	fmtSelectorStr := "{include:%s,exclude:%s,matchLabels:%+v,matchExpressions:%+v}"

--- a/pkg/common/namespace_selection.go
+++ b/pkg/common/namespace_selection.go
@@ -179,7 +179,7 @@ func (r *NamespaceSelectorReconciler) Get(objNS string, objName string, t policy
 	r.lock.Unlock()
 
 	// Return no namespaces when both include and label selector are empty
-	if t.LabelSelector == nil && len(t.Include) == 0 {
+	if t.IsEmpty() {
 		log.V(2).Info("Updating selection from Reconcile for empty selector",
 			"namespace", objNS, "policy", objName)
 
@@ -306,7 +306,7 @@ func (r *NamespaceSelectorReconciler) update(namespace string, name string, sel 
 func filter(allNSList corev1.NamespaceList, t policyv1.Target) ([]string, error) {
 	// If MatchLabels and MatchExpressions are nil, the resulting label selector
 	// matches all namespaces. This is to guard against that.
-	if t.LabelSelector == nil && len(t.Include) == 0 {
+	if t.IsEmpty() {
 		return []string{}, nil
 	}
 

--- a/test/resources/case13_templatization/case13_objectname_var_outside_name.yaml
+++ b/test/resources/case13_templatization/case13_objectname_var_outside_name.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: case13-empty-name
+  name: case13-outside-name
 spec:
   remediationAction: enforce
   namespaceSelector:
@@ -17,5 +17,7 @@ spec:
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: "{{ if false }}{{ .ObjectName }}{{ end }}"
-          namespace: "{{ .ObjectNamespace }}"
+          labels:
+            case13: passed
+            object-name: '{{ if (hasSuffix "3" .ObjectName) }}{{ .ObjectName }}{{ else }}{{ skipObject }}{{ end }}'
+            object-namespace: "{{ .ObjectNamespace }}"


### PR DESCRIPTION
When the `.ObjectName` template variable was used outside `.metadata.name`, the controller complained that the name didn't match.

This also removes an errant E2E test that was testing that a template that resolved to an empty string when the `objectSelector` was in play was NonCompliant, but really an empty string would be expected there regardless so that the controller could fill in the value.