### PR TITLE
Consolidate compliance messages

### DIFF
--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -790,8 +790,8 @@ func TestCreateStatus(t *testing.T) {
 			},
 			true,
 			"K8s `must have` object already exists",
-			"secrets [bo-peep] found as specified in namespace toy-story4; secrets [buzz] found as specified in " +
-				"namespace toy-story",
+			"secrets [buzz] found as specified in namespace toy-story; " +
+				"secrets [bo-peep] found as specified in namespace toy-story4",
 		},
 		{
 			"must have single object created",
@@ -958,6 +958,34 @@ func TestCreateStatus(t *testing.T) {
 			"K8s missing namespace",
 			"namespaced object of kind ConfigMap has no namespace specified from the policy namespaceSelector " +
 				"nor the object metadata",
+		},
+		{
+			"unnamed object multiple error",
+			"configmaps",
+			map[string]*objectTmplEvalResultWithEvent{
+				"toy-story1": {
+					result: objectTmplEvalResult{
+						objectNames: []string{"rex", "woody"},
+					},
+					event: objectTmplEvalEvent{
+						compliant: false,
+						reason:    reasonWantFoundNoMatch,
+					},
+				},
+				"toy-story2": {
+					result: objectTmplEvalResult{
+						objectNames: []string{"buzz", "potato"},
+					},
+					event: objectTmplEvalEvent{
+						compliant: false,
+						reason:    reasonWantFoundNoMatch,
+					},
+				},
+			},
+			false,
+			"K8s does not have a `must have` object",
+			"configmaps [rex, woody] found but not as specified in namespace toy-story1; " +
+				"configmaps [buzz, potato] found but not as specified in namespace toy-story2",
 		},
 		{
 			"multiple errors",

--- a/test/e2e/case13_templatization_test.go
+++ b/test/e2e/case13_templatization_test.go
@@ -600,8 +600,9 @@ var _ = Describe("Test templatization", Ordered, func() {
 
 				utils.CheckComplianceStatus(g, managedPlc, "Compliant")
 				g.Expect(utils.GetStatusMessage(managedPlc)).Should(Equal(fmt.Sprintf(
-					"configmaps [case13-e2e-objectname-var2] found as specified in namespace %[1]s; "+
-						"configmaps [case13-e2e-objectname-var3] found as specified in namespace %[1]s", e2eBaseName)))
+					"configmaps [case13-e2e-objectname-var2, case13-e2e-objectname-var3] "+
+						"found as specified in namespace %[1]s",
+					e2eBaseName)))
 
 				relatedObjects, _, _ := unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
 				g.Expect(relatedObjects).To(HaveLen(2))

--- a/test/e2e/case42_resource_selection_test.go
+++ b/test/e2e/case42_resource_selection_test.go
@@ -81,11 +81,8 @@ var _ = Describe("Test results of resource selection", Ordered, func() {
 
 			return utils.GetStatusMessage(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(
-			"fakeapis [case42-1-e2e] found as specified in namespace %[1]s; "+
-				"fakeapis [case42-2-e2e] found as specified in namespace %[1]s; "+
-				"fakeapis [case42-3-e2e] found as specified in namespace %[1]s; "+
-				"fakeapis [case42-4-e2e] found as specified in namespace %[1]s; "+
-				"fakeapis [case42-5-e2e] found as specified in namespace %[1]s", targetNs)))
+			"fakeapis [case42-1-e2e, case42-2-e2e, case42-3-e2e, case42-4-e2e, case42-5-e2e]"+
+				" found as specified in namespace %s", targetNs)))
 	},
 		Entry("Empty label selector", `{}`),
 		Entry("Empty matchLabels", `{"matchLabels":{}}`),
@@ -152,8 +149,7 @@ var _ = Describe("Test behavior of resource selection as resources change", Orde
 
 			return utils.GetStatusMessage(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(
-			"fakeapis [case42-1-e2e] found but not as specified in namespace %[1]s; "+
-				"fakeapis [case42-2-e2e] found but not as specified in namespace %[1]s", targetNs)))
+			"fakeapis [case42-1-e2e, case42-2-e2e] found but not as specified in namespace %s", targetNs)))
 	})
 
 	It("should evaluate when a matching labeled resource is added", func(ctx SpecContext) {
@@ -166,7 +162,7 @@ var _ = Describe("Test behavior of resource selection as resources change", Orde
 
 			return utils.GetStatusMessage(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(HaveSuffix(
-			fmt.Sprintf("; fakeapis [case42-3-e2e] found but not as specified in namespace %s", targetNs)))
+			fmt.Sprintf("case42-3-e2e] found but not as specified in namespace %s", targetNs)))
 	})
 
 	It("should not change when a non-matching resource is added", func(ctx SpecContext) {
@@ -190,7 +186,7 @@ var _ = Describe("Test behavior of resource selection as resources change", Orde
 
 			return utils.GetStatusMessage(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(HaveSuffix(
-			fmt.Sprintf("; fakeapis [case42-4-e2e] found but not as specified in namespace %s", targetNs)))
+			fmt.Sprintf("case42-4-e2e] found but not as specified in namespace %s", targetNs)))
 	})
 
 	It("should evaluate when a matching resource label is removed", func() {
@@ -202,7 +198,8 @@ var _ = Describe("Test behavior of resource selection as resources change", Orde
 
 			return utils.GetStatusMessage(managedPlc)
 		}, defaultTimeoutSeconds, 1).ShouldNot(ContainSubstring(
-			fmt.Sprintf("fakeapis [case42-3-e2e] found but not as specified in namespace %s", targetNs)))
+			"case42-3-e2e",
+			fmt.Sprintf("found but not as specified in namespace %s", targetNs)))
 	})
 
 	It("should become compliant when enforced", func() {
@@ -220,9 +217,7 @@ var _ = Describe("Test behavior of resource selection as resources change", Orde
 
 			return utils.GetStatusMessage(managedPlc)
 		}, defaultTimeoutSeconds, 1).Should(Equal(fmt.Sprintf(
-			"fakeapis [case42-1-e2e] found as specified in namespace %[1]s; "+
-				"fakeapis [case42-2-e2e] found as specified in namespace %[1]s; "+
-				"fakeapis [case42-4-e2e] found as specified in namespace %[1]s", targetNs)))
+			"fakeapis [case42-1-e2e, case42-2-e2e, case42-4-e2e] found as specified in namespace %s", targetNs)))
 	})
 
 	It("should ignore the objectSelector when a name is provided", func() {


### PR DESCRIPTION
Currently the compliance message is listed out for each object from the object selector. Ideally these messages would be consolidated for better consumption and readability.

Definition of Done for Engineering Story Owner (Checklist)
Status messages from the objectSelector are consolidated rather than listed out individually for each name.

Only combine messages for the same object-template (when it uses a resource selector, there can be multiple objects)

example of change:
`configmaps [rex, woody] found but not as specified in namespace toy-story1; configmaps [buzz, potato] found but not as specified in namespace toy-story2`
Ref: https://issues.redhat.com/browse/ACM-15773