### PR TITLE
Account for nil annotations in uninstall

### DIFF
--- a/pkg/triggeruninstall/triggeruninstall.go
+++ b/pkg/triggeruninstall/triggeruninstall.go
@@ -49,6 +49,10 @@ func TriggerUninstall(
 		}
 
 		annotations := deployment.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
 		annotations[common.UninstallingAnnotation] = time.Now().Format(time.RFC3339)
 		deployment.SetAnnotations(annotations)
 
@@ -98,6 +102,10 @@ func TriggerUninstall(
 					cleanedUp = false
 
 					annos := configPolicy.GetAnnotations()
+					if annos == nil {
+						annos = map[string]string{}
+					}
+
 					annos[common.UninstallingAnnotation] = time.Now().Format(time.RFC3339)
 
 					updatedPolicy := configPolicy.DeepCopy()


### PR DESCRIPTION
`.GetAnnotations()` can return a `nil` map, which can not be written to without panicking. These cases are now addressed in the triggeruninstall code.

Refs:
 - https://issues.redhat.com/browse/ACM-17562