### PR TITLE
Fix: Cluster-scoped obj context variables

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1548,9 +1548,9 @@ func (r *ConfigurationPolicyReconciler) determineDesiredObjects(
 
 				var templateContext interface{}
 
-				// If both name and namespace are empty, the policy is missing the
+				// If the name is empty, the policy is missing the
 				// objectSelector required to use the context variables
-				if ns != "" && name != "" {
+				if name != "" {
 					templateContext = struct {
 						ObjectNamespace string
 						ObjectName      string

--- a/test/resources/case13_templatization/case13_objectname_var_noselector_ns.yaml
+++ b/test/resources/case13_templatization/case13_objectname_var_noselector_ns.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case13-no-selector-ns
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "{{ .ObjectName }}"
+          labels:
+            case13: passed
+            name: "{{ .ObjectName }}"
+            namespace: "{{ .ObjectNamespace }}"


### PR DESCRIPTION
Cluster-scoped objects have an empty string for the namespace in all circumstances.

Followup to:
- #335