### PR TITLE
Consolidate status metric

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -302,8 +302,8 @@ func (r *ConfigurationPolicyReconciler) Reconcile(ctx context.Context, request c
 	duration := time.Now().UTC().Sub(before)
 	seconds := float64(duration) / float64(time.Second)
 
-	configPolicyStatusGauge.WithLabelValues(
-		policy.Name, policy.Namespace,
+	policyStatusGauge.WithLabelValues(
+		"ConfigurationPolicy", policy.Name, policy.Namespace, string(policy.Spec.Severity),
 	).Set(
 		getStatusValue(policy.Status.ComplianceState),
 	)

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -301,8 +301,8 @@ func (r *OperatorPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	operatorPolicyStatusGauge.WithLabelValues(
-		policy.Name, policy.Namespace,
+	policyStatusGauge.WithLabelValues(
+		"OperatorPolicy", policy.Name, policy.Namespace, string(policy.Spec.Severity),
 	).Set(
 		getStatusValue(policy.Status.ComplianceState),
 	)

--- a/test/e2e/case28_metric_test.go
+++ b/test/e2e/case28_metric_test.go
@@ -58,20 +58,20 @@ var _ = Describe("Test config policy metrics", Ordered, func() {
 		By("Checking metric endpoint for configuration policy status")
 		Eventually(
 			metricCheck, defaultTimeoutSeconds, 1,
-		).WithArguments("configurationpolicy_governance_info", "policy", policyName).Should(BeNumerically("==", 1))
+		).WithArguments("cluster_policy_governance_info", "policy", policyName).Should(BeNumerically("==", 1))
 
 		By("Enforcing the policy")
 		utils.EnforceConfigurationPolicy(policyName, testNamespace)
 		Eventually(
 			metricCheck, defaultTimeoutSeconds, 1,
-		).WithArguments("configurationpolicy_governance_info", "policy", policyName).Should(BeNumerically("==", 0))
+		).WithArguments("cluster_policy_governance_info", "policy", policyName).Should(BeNumerically("==", 0))
 	})
 
 	It("should report status for the operatorpolicy", func() {
 		By("Checking metric endpoint for operator policy status")
 		Eventually(
 			metricCheck, defaultTimeoutSeconds, 1,
-		).WithArguments("operatorpolicy_governance_info", "policy", operatorPolicyName).Should(BeNumerically("==", 1))
+		).WithArguments("cluster_policy_governance_info", "policy", operatorPolicyName).Should(BeNumerically("==", 1))
 	})
 
 	AfterAll(func() {
@@ -82,8 +82,7 @@ var _ = Describe("Test config policy metrics", Ordered, func() {
 		for metricName, label := range map[string]string{
 			"config_policy_evaluation_total":         "name",
 			"config_policy_evaluation_seconds_total": "name",
-			"configurationpolicy_governance_info":    "policy",
-			"operatorpolicy_governance_info":         "policy",
+			"cluster_policy_governance_info":         "policy",
 		} {
 			Eventually(
 				utils.GetMetrics, defaultTimeoutSeconds, 1,


### PR DESCRIPTION
Rather than a metric for each kind, consolidate to a single `cluster_policy_governance_info` metric

ref: https://issues.redhat.com/browse/ACM-17519