### PR TITLE
Populate context on a non-empty basis

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1548,13 +1548,23 @@ func (r *ConfigurationPolicyReconciler) determineDesiredObjects(
 
 				var templateContext interface{}
 
-				// If the name is empty, the policy is missing the
-				// objectSelector required to use the context variables
-				if name != "" {
+				// Only populate context variables as they are available:
+				// - Namespaced object with metadata.name or objectSelector
+				if name != "" && ns != "" {
 					templateContext = struct {
 						ObjectNamespace string
 						ObjectName      string
 					}{ObjectNamespace: ns, ObjectName: name}
+				} else if name != "" {
+					// - Cluster-scoped object with metadata.name or objectSelector
+					templateContext = struct {
+						ObjectName string
+					}{ObjectName: ns}
+				} else if ns != "" {
+					// - Unnamed namespaced object
+					templateContext = struct {
+						ObjectNamespace string
+					}{ObjectNamespace: ns}
 				}
 
 				skipObject := false


### PR DESCRIPTION
Make context available on an as-populated basis.
- ObjectName AND ObjectNamespace: Namespaced object with metadata.name or objectSelector
- Only ObjectName: Cluster-scoped object with metadata.name or objectSelector
- Only ObjectNamespace: Unnamed namespaced object

Followup to:
- #336 
- #335 