### PR TITLE
Fix mustnothave on unnamed templates with ObjectSelector

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1937,7 +1937,7 @@ func (r *ConfigurationPolicyReconciler) handleObjects(
 		log.V(1).Info(
 			"The object template does not specify a name. Will search for matching objects in the namespace.",
 		)
-		objNames, allResourceNames = r.getNamesOfKind(policy, desiredObj, scopedGVR, objectT.ComplianceType)
+		objNames, allResourceNames = r.getMatchingNames(policy, desiredObj, scopedGVR, objectT.ComplianceType)
 
 		// we do not support enforce on unnamed templates
 		if !remediation.IsInform() {
@@ -2326,10 +2326,10 @@ func buildNameList(
 	return kindNameList
 }
 
-// getNamesOfKind returns an array with names of all of the resources found
-// matching the GVK specified.
-// allResourceList includes names that are under the same namespace and kind.
-func (r *ConfigurationPolicyReconciler) getNamesOfKind(
+// getMatchingNames returns two slices: the second contains the names of all resources
+// which match the given GVR and the object selector on the template (if present). The
+// first slice additionally filters by the other fields in the object template.
+func (r *ConfigurationPolicyReconciler) getMatchingNames(
 	plc *policyv1.ConfigurationPolicy,
 	desiredObj *unstructured.Unstructured,
 	scopedGVR depclient.ScopedGVR,

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -704,20 +704,26 @@ func generateMessageWithReason(sortedObjectNamesStrs []string,
 		// If it is namespaced, include the namespaces that were checked. A namespace of "" indicates
 		// cluster scoped. This length check is not necessary but is added for additional safety in case the logic
 		// above is changed.
-		nsList := []string{}
+		nsSet := map[string]struct{}{}
 
 		for _, nsName := range objectNameStrsToNsNames[namesStr] {
 			ns, _, _ := strings.Cut(nsName, "/")
 			if ns != "" {
-				nsList = append(nsList, ns)
+				nsSet[ns] = struct{}{}
 			}
 		}
 
-		if len(nsList) > 0 {
-			if len(objectNameStrsToNsNames[namesStr]) > 1 {
+		if len(nsSet) > 0 {
+			if len(nsSet) > 1 {
 				msgTemplate += " in namespaces: "
 			} else {
 				msgTemplate += " in namespace "
+			}
+
+			nsList := make([]string, 0, len(nsSet))
+
+			for ns := range nsSet {
+				nsList = append(nsList, ns)
 			}
 
 			sort.Strings(nsList)

--- a/test/dryrun/multiple/multiple_mustnothave/desired_status.yaml
+++ b/test/dryrun/multiple/multiple_mustnothave/desired_status.yaml
@@ -1,0 +1,24 @@
+compliancyDetails:
+- Compliant: NonCompliant
+  Validity: {}
+  conditions:
+  - message: ingresses [one, two] found in namespace default
+    reason: K8s has a `must not have` object
+compliant: NonCompliant
+relatedObjects:
+- compliant: NonCompliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: one
+      namespace: default
+  reason: Resource found but should not exist
+- compliant: NonCompliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: two
+      namespace: default
+  reason: Resource found but should not exist

--- a/test/dryrun/multiple/multiple_mustnothave/input.yaml
+++ b/test/dryrun/multiple/multiple_mustnothave/input.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: one
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: test
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: two
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: three
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 801

--- a/test/dryrun/multiple/multiple_mustnothave/output.txt
+++ b/test/dryrun/multiple/multiple_mustnothave/output.txt
@@ -1,0 +1,16 @@
+# Status compare:
+[32m.compliancyDetails[0] matches[0m
+[32m.compliancyDetails matches[0m
+[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
+[32m.relatedObjects[0] matches[0m
+[32m.relatedObjects[1] matches[0m
+[32m.relatedObjects matches[0m
+[32m[1m Expected status matches the actual status [0m[0m
+
+# Diffs:
+networking.k8s.io/v1 Ingress default/one:
+
+networking.k8s.io/v1 Ingress default/two:
+
+# Compliance messages:
+NonCompliant; violation - ingresses [one, two] found in namespace default

--- a/test/dryrun/multiple/multiple_mustnothave/policy.yaml
+++ b/test/dryrun/multiple/multiple_mustnothave/policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: test-policy-1
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: mustnothave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          namespace: default
+          name: '{{ .ObjectName }}'
+        spec:
+          ingressClassName: test
+      objectSelector:
+        matchExpressions:
+          - key: test.dev/foo
+            operator: Exists

--- a/test/dryrun/multiple/multiple_test.go
+++ b/test/dryrun/multiple/multiple_test.go
@@ -37,3 +37,14 @@ var multipleObjTemp embed.FS
 func TestMultipleObjTemp(t *testing.T) {
 	t.Run("Test multiple object template", dryrun.Run(multipleObjTemp, "multiple_obj_template"))
 }
+
+//go:embed multiple_mustnothave/*
+var multipleMustNotHave embed.FS
+
+func TestMultipleMustNotHave(t *testing.T) {
+	// This test verifies that the mustnothave policy flags both objects which match the
+	// object selector, even though one of them has other fields that doesn't match what
+	// is defined in the policy.
+	t.Run("Test objectSelector with mustnothave and a templated name",
+		dryrun.Run(multipleMustNotHave, "multiple_mustnothave"))
+}

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/desired_status.yaml
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/desired_status.yaml
@@ -1,0 +1,26 @@
+relatedObjects:
+- compliant: Compliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: good-ingress
+      namespace: default
+  reason: Resource found as expected
+- compliant: NonCompliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: wrong-1-ingress
+      namespace: default
+  reason: Resource found but does not match
+- compliant: NonCompliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: wrong-2-ingress
+      namespace: default
+  reason: Resource found but does not match
+compliant: NonCompliant

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_bad.yaml
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_bad.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: wrong-1-ingress
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: wrong-2-ingress
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 801

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_good.yaml
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_good.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: good-ingress
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: test
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_ns.yaml
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_ns.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+spec: {}

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_unmatched.yaml
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/input_unmatched.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: wrong-3-ingress
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: good-ingress-2
+spec:
+  ingressClassName: test
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 801

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/output.txt
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/output.txt
@@ -1,0 +1,45 @@
+# Status compare:
+[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
+[32m.relatedObjects[0] matches[0m
+[32m.relatedObjects[1] matches[0m
+[32m.relatedObjects[2] matches[0m
+[32m.relatedObjects matches[0m
+[32m[1m Expected status matches the actual status [0m[0m
+
+# Diffs:
+networking.k8s.io/v1 Ingress default/good-ingress:
+
+networking.k8s.io/v1 Ingress default/wrong-1-ingress:
+--- default/wrong-1-ingress : existing
++++ default/wrong-1-ingress : updated
+@@ -4,11 +4,11 @@
+   labels:
+     test.dev/foo: ismatch
+   name: wrong-1-ingress
+   namespace: default
+ spec:
+-  ingressClassName: wrong-name
++  ingressClassName: test
+   rules:
+   - http:
+       paths:
+       - backend:
+           service:
+networking.k8s.io/v1 Ingress default/wrong-2-ingress:
+--- default/wrong-2-ingress : existing
++++ default/wrong-2-ingress : updated
+@@ -4,11 +4,11 @@
+   labels:
+     test.dev/foo: ismatch
+   name: wrong-2-ingress
+   namespace: default
+ spec:
+-  ingressClassName: wrong-name
++  ingressClassName: test
+   rules:
+   - http:
+       paths:
+       - backend:
+           service:
+# Compliance messages:
+NonCompliant; violation - ingresses [wrong-1-ingress, wrong-2-ingress] found but not as specified in namespace default

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/policy.yaml
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: test-policy-1
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          namespace: default
+        spec:
+          ingressClassName: test
+      objectSelector:
+        matchExpressions:
+          - key: test.dev/foo
+            operator: Exists

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/desired_status.yaml
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/desired_status.yaml
@@ -1,0 +1,23 @@
+compliancyDetails:
+- Compliant: NonCompliant
+  conditions:
+  - message: ingresses [wrong-1-ingress, wrong-2-ingress] found in namespace
+      default
+relatedObjects:
+- compliant: NonCompliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: wrong-1-ingress
+      namespace: default
+  reason: Resource found but should not exist
+- compliant: NonCompliant
+  object:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: wrong-2-ingress
+      namespace: default
+  reason: Resource found but should not exist
+compliant: NonCompliant

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_bad.yaml
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_bad.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: wrong-1-ingress
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: wrong-2-ingress
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 801

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_good.yaml
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_good.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: good-ingress
+  labels:
+    test.dev/foo: ismatch
+spec:
+  ingressClassName: test
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_ns.yaml
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_ns.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+spec: {}

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_unmatched.yaml
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/input_unmatched.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: wrong-3-ingress
+spec:
+  ingressClassName: wrong-name
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: good-ingress-2
+spec:
+  ingressClassName: test
+  rules:
+    - http: 
+       paths: 
+         - path: /testpath
+           pathType: Prefix
+           backend:
+            service:
+              name: test
+              port:
+                number: 801

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/output.txt
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/output.txt
@@ -1,0 +1,16 @@
+# Status compare:
+[32m.compliancyDetails[0] matches[0m
+[32m.compliancyDetails matches[0m
+[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
+[32m.relatedObjects[0] matches[0m
+[32m.relatedObjects[1] matches[0m
+[32m.relatedObjects matches[0m
+[32m[1m Expected status matches the actual status [0m[0m
+
+# Diffs:
+networking.k8s.io/v1 Ingress default/wrong-1-ingress:
+
+networking.k8s.io/v1 Ingress default/wrong-2-ingress:
+
+# Compliance messages:
+NonCompliant; violation - ingresses [wrong-1-ingress, wrong-2-ingress] found in namespace default

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/policy.yaml
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: test-policy-1
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: mustnothave
+      objectDefinition:
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          namespace: default
+        spec:
+          ingressClassName: wrong-name
+      objectSelector:
+        matchExpressions:
+          - key: test.dev/foo
+            operator: Exists

--- a/test/dryrun/no_name/with_object_selector/no_name_obj_sel_test.go
+++ b/test/dryrun/no_name/with_object_selector/no_name_obj_sel_test.go
@@ -1,0 +1,24 @@
+package dryruntest
+
+import (
+	"embed"
+	"testing"
+
+	"open-cluster-management.io/config-policy-controller/test/dryrun"
+)
+
+//go:embed musthave_mixed_noncompliant/*
+var musthaveMixedNoncompliant embed.FS
+
+func TestMusthaveMixedNonCompliant(t *testing.T) {
+	t.Run("Test only selected and incorrect objects are marked as violations",
+		dryrun.Run(musthaveMixedNoncompliant, "musthave_mixed_noncompliant"))
+}
+
+//go:embed mustnothave_mixed_noncompliant/*
+var mustnothaveMixedNoncompliant embed.FS
+
+func TestMustnothaveMixedNonCompliant(t *testing.T) {
+	t.Run("Test only selected and matched objects are marked as violations",
+		dryrun.Run(mustnothaveMixedNoncompliant, "mustnothave_mixed_noncompliant"))
+}

--- a/test/resources/case42_resource_selector/case42_mnh_policy.yaml
+++ b/test/resources/case42_resource_selector/case42_mnh_policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case42-selector-mnh-e2e
+spec:
+  evaluationInterval:
+    compliant: watch
+    noncompliant: watch
+  remediationAction: inform
+  object-templates:
+    - complianceType: mustnothave
+      objectSelector:
+        matchExpressions:
+          - key: case42
+            operator: Exists
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          namespace: case42-e2e-4
+        data:
+          test: match

--- a/test/resources/case42_resource_selector/case42_mnh_prereq.yaml
+++ b/test/resources/case42_resource_selector/case42_mnh_prereq.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: case42-e2e-4
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    case42: present
+  name: case42-4-e2e-match-1
+data:
+  test: match
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    case42: present
+  name: case42-4-e2e-match-2
+data:
+  test: match
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case42-4-e2e-no-match-1
+data:
+  test: match
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    case42: present
+  name: case42-4-e2e-no-match-2
+data:
+  test: does-not-match


### PR DESCRIPTION
When a mustnothave policy specifies a named object, then the policy will
always want that resource to be missing from the cluster, regardless of
the other fields in the object template or the actual resource. However,
for unnamed templates, the policy will check to see if other fields
match.

Previously, the way ObjectSelector sets names on templates while
processing them internally was causing mustnothave policies to mark
*all* objects matching the selector as undesired, disregarding any other
fields.

Now, the ObjectSelector and the other fields defined in the template are
both considered when marking objects as undesired by a mustnothave
policy.

Refs:
 - https://issues.redhat.com/browse/ACM-15772

Also includes a small refactor which disambiguates a function.