### PR TITLE
Fix dryrun default namespaceSelector issue

### DIFF
--- a/test/dryrun/diff/from_secret_obj_temp/input_ns.yaml
+++ b/test/dryrun/diff/from_secret_obj_temp/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/diff/from_secret_obj_temp_raw/input_ns.yaml
+++ b/test/dryrun/diff/from_secret_obj_temp_raw/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/diff/secret_obj_temp/input_ns.yaml
+++ b/test/dryrun/diff/secret_obj_temp/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/diff/truncated/desired_status.yaml
+++ b/test/dryrun/diff/truncated/desired_status.yaml
@@ -6,10 +6,10 @@ relatedObjects:
     kind: Namespace
   properties:
     diff: |-
-      # Truncated: showing 50/66 diff lines:
+      # Truncated: showing 50/65 diff lines:
       --- default : existing
       +++ default : updated
-      @@ -1,6 +1,62 @@
+      @@ -1,5 +1,61 @@
        apiVersion: v1
        kind: Namespace
        metadata:

--- a/test/dryrun/diff/truncated/input.yaml
+++ b/test/dryrun/diff/truncated/input.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/diff/truncated/output.txt
+++ b/test/dryrun/diff/truncated/output.txt
@@ -6,10 +6,10 @@
 
 # Diffs:
 v1 Namespace default:
-# Truncated: showing 50/66 diff lines:
+# Truncated: showing 50/65 diff lines:
 --- default : existing
 +++ default : updated
-@@ -1,6 +1,62 @@
+@@ -1,5 +1,61 @@
  apiVersion: v1
  kind: Namespace
  metadata:

--- a/test/dryrun/kind_field/pod_annotation_match/input_ns.yaml
+++ b/test/dryrun/kind_field/pod_annotation_match/input_ns.yaml
@@ -1,11 +1,5 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: default
-spec: {}
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: managed
 spec: {}

--- a/test/dryrun/multiple/multiple_obj_combo/input_ns_1.yaml
+++ b/test/dryrun/multiple/multiple_obj_combo/input_ns_1.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/no_name/compliant_related_obj/input_ns.yaml
+++ b/test/dryrun/no_name/compliant_related_obj/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/no_name/mustnothave_compliant_related_obj/input_ns.yaml
+++ b/test/dryrun/no_name/mustnothave_compliant_related_obj/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/no_name/mustnothave_compliant_related_obj_1/input_ns.yaml
+++ b/test/dryrun/no_name/mustnothave_compliant_related_obj_1/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/no_name/mustnothave_noncompliant_related_obj_1/input_ns.yaml
+++ b/test/dryrun/no_name/mustnothave_noncompliant_related_obj_1/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/no_name/noncompliant_related_obj/input_ns.yaml
+++ b/test/dryrun/no_name/noncompliant_related_obj/input_ns.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: default
-spec: {}

--- a/test/dryrun/ns_selector/ns_default/desired_status.yaml
+++ b/test/dryrun/ns_selector/ns_default/desired_status.yaml
@@ -1,0 +1,1 @@
+compliant: Compliant

--- a/test/dryrun/ns_selector/ns_default/input.yaml
+++ b/test/dryrun/ns_selector/ns_default/input.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sample-nginx-pod
+spec:
+  containers:
+    - image: nginx:1.18.0
+      name: nginx
+      ports:
+        - containerPort: 80

--- a/test/dryrun/ns_selector/ns_default/output.txt
+++ b/test/dryrun/ns_selector/ns_default/output.txt
@@ -1,0 +1,9 @@
+# Status compare:
+[32m.compliant: 'Compliant' does match 'Compliant'[0m
+[32m[1m Expected status matches the actual status [0m[0m
+
+# Diffs:
+v1 Pod default/sample-nginx-pod:
+
+# Compliance messages:
+Compliant; notification - pods [sample-nginx-pod] found as specified in namespace default

--- a/test/dryrun/ns_selector/ns_default/policy.yaml
+++ b/test/dryrun/ns_selector/ns_default/policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-example
+spec:
+  remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+  severity: low
+  namespaceSelector:
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod # nginx pod must exist
+        metadata:
+          name: sample-nginx-pod
+        spec:
+          containers:
+            - image: nginx:1.18.0
+              name: nginx
+              ports:
+                - containerPort: 80

--- a/test/dryrun/ns_selector/ns_selector_test.go
+++ b/test/dryrun/ns_selector/ns_selector_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package dryruntest
+
+import (
+	"embed"
+	"testing"
+
+	"open-cluster-management.io/config-policy-controller/test/dryrun"
+)
+
+//go:embed ns_default/*
+var nsDefault embed.FS
+
+func TestNsDefault(t *testing.T) {
+	t.Run("Test compliant with namespaceSelector",
+		dryrun.Run(nsDefault, "ns_default"))
+}


### PR DESCRIPTION
- Add the "default" namespace if the input resources do not have a namespace.
- Add "default" namespace in dryrun 
Ref: https://issues.redhat.com/browse/ACM-18064
Signed-off-by: yiraeChristineKim <yikim@redhat.com>