### PR TITLE
Fix resourceVersion error for create request in dryrun

### DIFF
--- a/pkg/dryrun/testdata/test_bad_fields_creation/input_pod.yaml
+++ b/pkg/dryrun/testdata/test_bad_fields_creation/input_pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: useless-metadata-pod
+  namespace: default
+  generateName: coredns-5d78c9869d-
+  creationTimestamp: "2025-02-18T17:47:28Z"
+  resourceVersion: "441"
+  uid: b519206b-8d46-4236-928b-5a8f7f2c0209
+spec:
+  containers:
+    - image: nginx:1.7.9
+      name: engine-x
+      ports:
+        - containerPort: 8080

--- a/pkg/dryrun/testdata/test_bad_fields_creation/output.txt
+++ b/pkg/dryrun/testdata/test_bad_fields_creation/output.txt
@@ -1,0 +1,5 @@
+# Diffs:
+v1 Pod default/useless-metadata-pod:
+
+# Compliance messages:
+Compliant; notification - pods [useless-metadata-pod] found as specified in namespace default

--- a/pkg/dryrun/testdata/test_bad_fields_creation/policy.yaml
+++ b/pkg/dryrun/testdata/test_bad_fields_creation/policy.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-example
+spec:
+  remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+  severity: low
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod # nginx pod must exist
+        metadata:
+          namespace: default
+          name: useless-metadata-pod
+        spec:
+          containers:
+          - image: nginx:1.7.9
+            name: engine-x
+            ports:
+              - containerPort: 8080


### PR DESCRIPTION
selfLink, resourceVersion, generatedName, creationTimestamp, uid should be deleted in incoming resources Ref: https://issues.redhat.com/browse/ACM-18066
Signed-off-by: yiraeChristineKim <yikim@redhat.com>