### PR TITLE
Watch correct openshift templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
 	github.com/stolostron/go-template-utils/v6 v6.4.0
-	github.com/stolostron/kubernetes-dependency-watches v0.10.0
+	github.com/stolostron/kubernetes-dependency-watches v0.10.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/mod v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRD
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
 github.com/stolostron/go-template-utils/v6 v6.4.0 h1:FKEK8rNi2VGhuEXY6gROfO6VBJ0myGqjfwfnRsLkpuY=
 github.com/stolostron/go-template-utils/v6 v6.4.0/go.mod h1:4+HWMKPMBDDekJlPve3zkuWdE0hcwgnKKOap2GoHjNY=
-github.com/stolostron/kubernetes-dependency-watches v0.10.0 h1:brg9FCZUvd1gnm5wmsv/InfErcPUvYcZsK/LWNRr+wg=
-github.com/stolostron/kubernetes-dependency-watches v0.10.0/go.mod h1:j1DBv/3JjwDX3bT/oKB4YvSwJ6DEVcrUpEzKbFLM0QM=
+github.com/stolostron/kubernetes-dependency-watches v0.10.1 h1:c3lfy7gylDm/xwk5VapTIz90kdYyfx/ecUWOqNKjAPc=
+github.com/stolostron/kubernetes-dependency-watches v0.10.1/go.mod h1:shQSsNdVovtqbmnjs2aWLrNnvXBat7hFEKiPkKRAt/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -639,6 +639,7 @@ func addSupportedResources(clientset *clientsetfake.Clientset) {
 			Version:      parentpolicyv1.GroupVersion.Version,
 			Namespaced:   true,
 			Kind:         parentpolicyv1.Kind,
+			Verbs:        mappings.DefaultVerbs,
 		}, {
 			Name:         "configurationpolicies",
 			SingularName: "configurationpolicy",
@@ -646,6 +647,7 @@ func addSupportedResources(clientset *clientsetfake.Clientset) {
 			Version:      policyv1.GroupVersion.Version,
 			Namespaced:   true,
 			Kind:         "ConfigurationPolicy",
+			Verbs:        mappings.DefaultVerbs,
 		}},
 	})
 }

--- a/pkg/dryrun/testdata/test_unwatchable_mappings/input_resource.yaml
+++ b/pkg/dryrun/testdata/test_unwatchable_mappings/input_resource.yaml
@@ -1,0 +1,6 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: something
+spec:
+  foo: bar

--- a/pkg/dryrun/testdata/test_unwatchable_mappings/mappings.yaml
+++ b/pkg/dryrun/testdata/test_unwatchable_mappings/mappings.yaml
@@ -1,0 +1,14 @@
+- group: template.openshift.io
+  kind: Template
+  plural: processedtemplates
+  scope: namespace
+  singular: processedtemplate
+  verbs:
+  - create
+  version: v1
+- group: template.openshift.io
+  kind: Template
+  plural: templates
+  scope: namespace
+  singular: template
+  version: v1

--- a/pkg/dryrun/testdata/test_unwatchable_mappings/output.txt
+++ b/pkg/dryrun/testdata/test_unwatchable_mappings/output.txt
@@ -1,0 +1,5 @@
+# Diffs:
+template.openshift.io/v1 Template default/something:
+
+# Compliance messages:
+Compliant; notification - templates [something] found as specified in namespace default

--- a/pkg/dryrun/testdata/test_unwatchable_mappings/policy.yaml
+++ b/pkg/dryrun/testdata/test_unwatchable_mappings/policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: hello
+  namespace: default
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: template.openshift.io/v1
+        kind: Template
+        metadata:
+          name: something
+        spec:
+          foo: bar

--- a/pkg/mappings/default-mappings.yaml
+++ b/pkg/mappings/default-mappings.yaml
@@ -3,12 +3,17 @@
   plural: bindings
   scope: namespace
   singular: binding
+  verbs:
+  - create
   version: v1
 - group: ""
   kind: ComponentStatus
   plural: componentstatuses
   scope: root
   singular: componentstatus
+  verbs:
+  - get
+  - list
   version: v1
 - group: ""
   kind: ConfigMap
@@ -39,6 +44,14 @@
   plural: namespaces
   scope: root
   singular: namespace
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
   version: v1
 - group: ""
   kind: Node
@@ -159,36 +172,48 @@
   plural: selfsubjectreviews
   scope: root
   singular: selfsubjectreview
+  verbs:
+  - create
   version: v1
 - group: authentication.k8s.io
   kind: TokenReview
   plural: tokenreviews
   scope: root
   singular: tokenreview
+  verbs:
+  - create
   version: v1
 - group: authorization.k8s.io
   kind: LocalSubjectAccessReview
   plural: localsubjectaccessreviews
   scope: namespace
   singular: localsubjectaccessreview
+  verbs:
+  - create
   version: v1
 - group: authorization.k8s.io
   kind: SelfSubjectAccessReview
   plural: selfsubjectaccessreviews
   scope: root
   singular: selfsubjectaccessreview
+  verbs:
+  - create
   version: v1
 - group: authorization.k8s.io
   kind: SelfSubjectRulesReview
   plural: selfsubjectrulesreviews
   scope: root
   singular: selfsubjectrulesreview
+  verbs:
+  - create
   version: v1
 - group: authorization.k8s.io
   kind: SubjectAccessReview
   plural: subjectaccessreviews
   scope: root
   singular: subjectaccessreview
+  verbs:
+  - create
   version: v1
 - group: autoscaling
   kind: HorizontalPodAutoscaler


### PR DESCRIPTION
Chiefly, this updates the kubernetes-dependency-watches library to use verbs allowed on the API resources to only choose ones that can be watched - which fixes the ambiguous case around Openshift Templates, which was causing the config-policy-controller to use the wrong endpoint.

This also updates the mappings file format to include verbs, so that dryrun can match this behavior.

https://issues.redhat.com/browse/ACM-18827