### PR TITLE
Refactor `skipObject` to report arg types

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -1570,17 +1570,22 @@ func (r *ConfigurationPolicyReconciler) determineDesiredObjects(
 				skipObject := false
 
 				resolveOptions.CustomFunctions = map[string]interface{}{
-					"skipObject": func(skips ...bool) (empty string, err error) {
+					"skipObject": func(skips ...any) (empty string, err error) {
 						switch len(skips) {
 						case 0:
 							skipObject = true
 						case 1:
 							if !skipObject {
-								skipObject = skips[0]
+								if skip, ok := skips[0].(bool); ok {
+									skipObject = skip
+								} else {
+									err = fmt.Errorf(
+										"expected boolean but received '%v'", skips[0])
+								}
 							}
 						default:
 							err = fmt.Errorf(
-								"skipObject only accepts one optional boolean argument but received %d", len(skips))
+								"expected one optional boolean argument but received %d arguments", len(skips))
 						}
 
 						return

--- a/test/resources/case13_templatization/case13_skipobject_multi_arg.yaml
+++ b/test/resources/case13_templatization/case13_skipobject_multi_arg.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: case13-objectname-invalid-skipobject
+  name: case13-skipobject-multi-arg
 spec:
   remediationAction: enforce
   namespaceSelector:

--- a/test/resources/case13_templatization/case13_skipobject_non_bool.yaml
+++ b/test/resources/case13_templatization/case13_skipobject_non_bool.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case13-skipobject-non-bool
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    include:
+      - case13-e2e-objectname-var
+  object-templates:
+    - complianceType: musthave
+      objectSelector:
+        matchExpressions:
+          - key: case13
+            operator: Exists
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: '{{ skipObject "not a boolean" }}'
+          namespace: "{{ .ObjectNamespace }}"
+          labels:
+            case13: passed
+            name: "{{ .ObjectName }}"
+            namespace: "{{ .ObjectNamespace }}"


### PR DESCRIPTION
This also shortens the message because it appears the templating library already wraps our error with "error calling skipObject", so saying "skipObject" again in the message isn't necessary.

Followup to:
- #354 