### PR TITLE
Adjust `--no-colors` behaviors

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -21,7 +21,7 @@ import (
 	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/go-logr/logr"
 	gocmp "github.com/google/go-cmp/cmp"
-	templates "github.com/stolostron/go-template-utils/v6/pkg/templates"
+	templates "github.com/stolostron/go-template-utils/v7/pkg/templates"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"

--- a/controllers/encryption.go
+++ b/controllers/encryption.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/stolostron/go-template-utils/v6/pkg/templates"
+	"github.com/stolostron/go-template-utils/v7/pkg/templates"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/controllers/hubtemplates.go
+++ b/controllers/hubtemplates.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	templates "github.com/stolostron/go-template-utils/v6/pkg/templates"
+	templates "github.com/stolostron/go-template-utils/v7/pkg/templates"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -18,7 +18,7 @@ import (
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	templates "github.com/stolostron/go-template-utils/v6/pkg/templates"
+	templates "github.com/stolostron/go-template-utils/v7/pkg/templates"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v6 v6.4.0
+	github.com/stolostron/go-template-utils/v7 v7.0.0
 	github.com/stolostron/kubernetes-dependency-watches v0.10.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AV
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v6 v6.4.0 h1:FKEK8rNi2VGhuEXY6gROfO6VBJ0myGqjfwfnRsLkpuY=
-github.com/stolostron/go-template-utils/v6 v6.4.0/go.mod h1:4+HWMKPMBDDekJlPve3zkuWdE0hcwgnKKOap2GoHjNY=
+github.com/stolostron/go-template-utils/v7 v7.0.0 h1:RWh7TEL5Sid7A35IX9X0FYeB5xkb9UWcpf9kN+WoXv4=
+github.com/stolostron/go-template-utils/v7 v7.0.0/go.mod h1:HaqIrebtjJKsBMByzHbTbDc5AaXSZrUozbhXRmsDaHY=
 github.com/stolostron/kubernetes-dependency-watches v0.10.1 h1:c3lfy7gylDm/xwk5VapTIz90kdYyfx/ecUWOqNKjAPc=
 github.com/stolostron/kubernetes-dependency-watches v0.10.1/go.mod h1:shQSsNdVovtqbmnjs2aWLrNnvXBat7hFEKiPkKRAt/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/dryrun/dryrun_utils.go
+++ b/pkg/dryrun/dryrun_utils.go
@@ -33,6 +33,10 @@ func applyColor(input, color string, noColors bool) string {
 	return color + input + Reset
 }
 
+func boldColor(input string, noColors bool) string {
+	return applyColor(input, Bold, noColors)
+}
+
 func successColor(input string, noColors bool) string {
 	return applyColor(input, Green, noColors)
 }
@@ -55,9 +59,9 @@ func compareStatus(cmd *cobra.Command,
 	isStatusMatch := compareStatusObj(cmd, true, "", inputStatus, resultStatus, noColor)
 
 	if isStatusMatch {
-		cmd.Println(successColor("\033[1m Expected status matches the actual status \033[0m", noColor))
+		cmd.Println(successColor(boldColor(" Expected status matches the actual status ", noColor), noColor))
 	} else {
-		cmd.Println(errorColor("\033[1m Expected status does not match the actual status \033[0m", noColor))
+		cmd.Println(errorColor(boldColor(" Expected status does not match the actual status ", noColor), noColor))
 	}
 }
 

--- a/pkg/dryrun/dryrun_utils.go
+++ b/pkg/dryrun/dryrun_utils.go
@@ -59,9 +59,9 @@ func compareStatus(cmd *cobra.Command,
 	isStatusMatch := compareStatusObj(cmd, true, "", inputStatus, resultStatus, noColor)
 
 	if isStatusMatch {
-		cmd.Println(successColor(boldColor(" Expected status matches the actual status ", noColor), noColor))
+		cmd.Println(successColor(boldColor(" Expected status matches the actual status", noColor), noColor))
 	} else {
-		cmd.Println(errorColor(boldColor(" Expected status does not match the actual status ", noColor), noColor))
+		cmd.Println(errorColor(boldColor(" Expected status does not match the actual status", noColor), noColor))
 	}
 }
 

--- a/pkg/dryrun/testdata/test_desired_status/output.txt
+++ b/pkg/dryrun/testdata/test_desired_status/output.txt
@@ -4,7 +4,7 @@
 [31m.compliant: 'Compliant' does not match 'NonCompliant'[0m
 [32m.relatedObjects[0] matches[0m
 [32m.relatedObjects matches[0m
-[31m[1m Expected status does not match the actual status [0m[0m
+[31m[1m Expected status does not match the actual status[0m[0m
 
 # Diffs:
 v1 Pod default/nginx-pod-e2e:

--- a/pkg/dryrun/utils_testdata/test_array_match/output.txt
+++ b/pkg/dryrun/utils_testdata/test_array_match/output.txt
@@ -3,4 +3,4 @@
 [32m.compliancyDetails matches[0m
 [32m.compliant: 'Compliant' does match 'Compliant'[0m
 [32m.lastEvaluatedGeneration: '1' does match '1'[0m
-[32m[1m Expected status matches the actual status [0m[0m
+[32m[1m Expected status matches the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_array_no_match/output.txt
+++ b/pkg/dryrun/utils_testdata/test_array_no_match/output.txt
@@ -3,4 +3,4 @@
 [31m.compliancyDetails does not match the elements[0m
 [31m.relatedObjects[0] does not match any elements[0m
 [31m.relatedObjects does not match the elements[0m
-[31m[1m Expected status does not match the actual status [0m[0m
+[31m[1m Expected status does not match the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_array_user_input_error/output.txt
+++ b/pkg/dryrun/utils_testdata/test_array_user_input_error/output.txt
@@ -1,4 +1,4 @@
 # Status compare:
 [31mThe input status field '.compliancyDetails' is not the right type - expected '[]interface {}'[0m
 [33mskip lastEvaluatedGeneration, .lastEvaluatedGeneration is not array,[0m
-[31m[1m Expected status does not match the actual status [0m[0m
+[31m[1m Expected status does not match the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_multiple_array_input/output.txt
+++ b/pkg/dryrun/utils_testdata/test_multiple_array_input/output.txt
@@ -2,4 +2,4 @@
 [32m.compliant: 'Compliant' does match 'Compliant'[0m
 [31m.relatedObjects[0] does not match any elements[0m
 [31m.relatedObjects does not match the elements[0m
-[31m[1m Expected status does not match the actual status [0m[0m
+[31m[1m Expected status does not match the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_multiple_relobj_compliant/output.txt
+++ b/pkg/dryrun/utils_testdata/test_multiple_relobj_compliant/output.txt
@@ -3,4 +3,4 @@
 [32m.relatedObjects[0] matches[0m
 [32m.relatedObjects[1] matches[0m
 [32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+[32m[1m Expected status matches the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_no_color/output.txt
+++ b/pkg/dryrun/utils_testdata/test_no_color/output.txt
@@ -1,3 +1,3 @@
 # Status compare:
 .compliant: 'NonCompliant' does not match 'Compliant'
- Expected status does not match the actual status 
+ Expected status does not match the actual status

--- a/pkg/dryrun/utils_testdata/test_no_color/output.txt
+++ b/pkg/dryrun/utils_testdata/test_no_color/output.txt
@@ -1,3 +1,3 @@
 # Status compare:
 .compliant: 'NonCompliant' does not match 'Compliant'
-[1m Expected status does not match the actual status [0m
+ Expected status does not match the actual status 

--- a/pkg/dryrun/utils_testdata/test_one_match/output.txt
+++ b/pkg/dryrun/utils_testdata/test_one_match/output.txt
@@ -2,4 +2,4 @@
 [32m.compliant: 'Compliant' does match 'Compliant'[0m
 [32m.relatedObjects[0] matches[0m
 [32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+[32m[1m Expected status matches the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_simple/output.txt
+++ b/pkg/dryrun/utils_testdata/test_simple/output.txt
@@ -1,3 +1,3 @@
 # Status compare:
 [31m.compliant: 'NonCompliant' does not match 'Compliant'[0m
-[31m[1m Expected status does not match the actual status [0m[0m
+[31m[1m Expected status does not match the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_string_array_match/output.txt
+++ b/pkg/dryrun/utils_testdata/test_string_array_match/output.txt
@@ -1,4 +1,4 @@
 # Status compare:
 [32m.relatedObjects[0] matches[0m
 [32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+[32m[1m Expected status matches the actual status[0m[0m

--- a/pkg/dryrun/utils_testdata/test_string_array_not_match/output.txt
+++ b/pkg/dryrun/utils_testdata/test_string_array_not_match/output.txt
@@ -1,4 +1,4 @@
 # Status compare:
 [31m.relatedObjects[0] does not match any elements[0m
 [31m.relatedObjects does not match the elements[0m
-[31m[1m Expected status does not match the actual status [0m[0m
+[31m[1m Expected status does not match the actual status[0m[0m

--- a/test/dryrun/diff/from_secret_obj_temp/output.txt
+++ b/test/dryrun/diff/from_secret_obj_temp/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 v1 Namespace default:

--- a/test/dryrun/diff/from_secret_obj_temp_raw/output.txt
+++ b/test/dryrun/diff/from_secret_obj_temp_raw/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 v1 Namespace default:

--- a/test/dryrun/diff/secret_obj_temp/output.txt
+++ b/test/dryrun/diff/secret_obj_temp/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 v1 Secret default/case39-secret:

--- a/test/dryrun/diff/truncated/output.txt
+++ b/test/dryrun/diff/truncated/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 v1 Namespace default:
@@ -13,52 +13,52 @@ v1 Namespace default:
  apiVersion: v1
  kind: Namespace
  metadata:
-[32m+  annotations:[0m
-[32m+    message1: message[0m
-[32m+    message2: message[0m
-[32m+    message3: message[0m
-[32m+    message4: message[0m
-[32m+    message5: message[0m
-[32m+    message6: message[0m
-[32m+    message7: message[0m
-[32m+    message8: message[0m
-[32m+    message9: message[0m
-[32m+    message10: message[0m
-[32m+    message11: message[0m
-[32m+    message12: message[0m
-[32m+    message13: message[0m
-[32m+    message14: message[0m
-[32m+    message15: message[0m
-[32m+    message16: message[0m
-[32m+    message17: message[0m
-[32m+    message18: message[0m
-[32m+    message19: message[0m
-[32m+    message20: message[0m
-[32m+    message21: message[0m
-[32m+    message22: message[0m
-[32m+    message23: message[0m
-[32m+    message24: message[0m
-[32m+    message25: message[0m
-[32m+    message26: message[0m
-[32m+    message27: message[0m
-[32m+    message28: message[0m
-[32m+    message29: message[0m
-[32m+    message30: message[0m
-[32m+    message31: message[0m
-[32m+    message32: message[0m
-[32m+    message33: message[0m
-[32m+    message34: message[0m
-[32m+    message35: message[0m
-[32m+    message36: message[0m
-[32m+    message37: message[0m
-[32m+    message38: message[0m
-[32m+    message39: message[0m
-[32m+    message40: message[0m
-[32m+    message41: message[0m
-[32m+    message42: message[0m
-[32m+    message43: message[0m
-[32m+    message44: message[0m
-[32m+    message45: message[0m
-[32m+    message46: message[0m
++  annotations:
++    message1: message
++    message2: message
++    message3: message
++    message4: message
++    message5: message
++    message6: message
++    message7: message
++    message8: message
++    message9: message
++    message10: message
++    message11: message
++    message12: message
++    message13: message
++    message14: message
++    message15: message
++    message16: message
++    message17: message
++    message18: message
++    message19: message
++    message20: message
++    message21: message
++    message22: message
++    message23: message
++    message24: message
++    message25: message
++    message26: message
++    message27: message
++    message28: message
++    message29: message
++    message30: message
++    message31: message
++    message32: message
++    message33: message
++    message34: message
++    message35: message
++    message36: message
++    message37: message
++    message38: message
++    message39: message
++    message40: message
++    message41: message
++    message42: message
++    message43: message
++    message44: message
++    message45: message
++    message46: message
 # Compliance messages:
 NonCompliant; violation - namespaces [default] found but not as specified

--- a/test/dryrun/multiple/multiple_mustnothave/output.txt
+++ b/test/dryrun/multiple/multiple_mustnothave/output.txt
@@ -1,11 +1,11 @@
 # Status compare:
-[32m.compliancyDetails[0] matches[0m
-[32m.compliancyDetails matches[0m
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects[1] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliancyDetails[0] matches
+.compliancyDetails matches
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects[1] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/one:

--- a/test/dryrun/no_name/compliant_related_obj/output.txt
+++ b/test/dryrun/no_name/compliant_related_obj/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'Compliant' does match 'Compliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'Compliant' does match 'Compliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/good-ingress:

--- a/test/dryrun/no_name/mustnothave_compliant_related_obj/output.txt
+++ b/test/dryrun/no_name/mustnothave_compliant_related_obj/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'Compliant' does match 'Compliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'Compliant' does match 'Compliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/-:

--- a/test/dryrun/no_name/mustnothave_compliant_related_obj_1/output.txt
+++ b/test/dryrun/no_name/mustnothave_compliant_related_obj_1/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'Compliant' does match 'Compliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'Compliant' does match 'Compliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/-:

--- a/test/dryrun/no_name/mustnothave_noncompliant_related_obj_1/output.txt
+++ b/test/dryrun/no_name/mustnothave_noncompliant_related_obj_1/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/good-ingress:

--- a/test/dryrun/no_name/noncompliant_related_obj/output.txt
+++ b/test/dryrun/no_name/noncompliant_related_obj/output.txt
@@ -1,7 +1,7 @@
 # Status compare:
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/-:

--- a/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/output.txt
+++ b/test/dryrun/no_name/with_object_selector/musthave_mixed_noncompliant/output.txt
@@ -1,10 +1,10 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects[1] matches[0m
-[32m.relatedObjects[2] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects[1] matches
+.relatedObjects[2] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/good-ingress:
@@ -18,8 +18,8 @@ networking.k8s.io/v1 Ingress default/wrong-1-ingress:
    name: wrong-1-ingress
    namespace: default
  spec:
-[31m-  ingressClassName: wrong-name[0m
-[32m+  ingressClassName: test[0m
+-  ingressClassName: wrong-name
++  ingressClassName: test
    rules:
    - http:
        paths:
@@ -34,8 +34,8 @@ networking.k8s.io/v1 Ingress default/wrong-2-ingress:
    name: wrong-2-ingress
    namespace: default
  spec:
-[31m-  ingressClassName: wrong-name[0m
-[32m+  ingressClassName: test[0m
+-  ingressClassName: wrong-name
++  ingressClassName: test
    rules:
    - http:
        paths:

--- a/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/output.txt
+++ b/test/dryrun/no_name/with_object_selector/mustnothave_mixed_noncompliant/output.txt
@@ -1,11 +1,11 @@
 # Status compare:
-[32m.compliancyDetails[0] matches[0m
-[32m.compliancyDetails matches[0m
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects[1] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliancyDetails[0] matches
+.compliancyDetails matches
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects[1] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 Ingress default/wrong-1-ingress:

--- a/test/dryrun/no_name_clusterscope/compliant_related_obj/output.txt
+++ b/test/dryrun/no_name_clusterscope/compliant_related_obj/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'Compliant' does match 'Compliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'Compliant' does match 'Compliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 IngressClass -:

--- a/test/dryrun/no_name_clusterscope/noncompliant_related_obj/output.txt
+++ b/test/dryrun/no_name_clusterscope/noncompliant_related_obj/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 networking.k8s.io/v1 IngressClass -:

--- a/test/dryrun/no_ns/enforce_ns/output.txt
+++ b/test/dryrun/no_ns/enforce_ns/output.txt
@@ -1,8 +1,8 @@
 # Status compare:
-[32m.compliant: 'Compliant' does match 'Compliant'[0m
-[32m.relatedObjects[0] matches[0m
-[32m.relatedObjects matches[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'Compliant' does match 'Compliant'
+.relatedObjects[0] matches
+.relatedObjects matches
+ Expected status matches the actual status
 
 # Diffs:
 v1 Namespace e2etest:

--- a/test/dryrun/no_ns/ns_role/output.txt
+++ b/test/dryrun/no_ns/ns_role/output.txt
@@ -1,6 +1,6 @@
 # Status compare:
-[32m.compliant: 'NonCompliant' does match 'NonCompliant'[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'NonCompliant' does match 'NonCompliant'
+ Expected status matches the actual status
 
 # Diffs:
 # Compliance messages:

--- a/test/dryrun/ns_selector/ns_default/output.txt
+++ b/test/dryrun/ns_selector/ns_default/output.txt
@@ -1,6 +1,6 @@
 # Status compare:
-[32m.compliant: 'Compliant' does match 'Compliant'[0m
-[32m[1m Expected status matches the actual status [0m[0m
+.compliant: 'Compliant' does match 'Compliant'
+ Expected status matches the actual status
 
 # Diffs:
 v1 Pod default/sample-nginx-pod:

--- a/test/dryrun/utils.go
+++ b/test/dryrun/utils.go
@@ -31,7 +31,7 @@ func Run(testFiles embed.FS, filePath string) func(t *testing.T) {
 
 		cmd.SetOut(&testout)
 
-		args := []string{}
+		args := []string{"--no-colors"}
 
 		for _, f := range scenarioFiles {
 			if strings.HasPrefix(f.Name(), "input") {


### PR DESCRIPTION
- Bump to `go-template-utils/v7`
- Bring "Bold" under the `--no-colors` flag
- Set `--no-colors` for dryrun controller tests
- Remove the trailing space from the status check