### PR TITLE
feat: enable logging output for `dryrun`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ kubeconfig_*
 kind_kubeconfig.yaml
 report.json
 report_*.json
+report_*.xml
 gosec.json
 
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,8 @@ kind-deploy-controller-dev-normal: kind-deploy-controller
 .PHONY: kind-deploy-controller-dev-addon
 kind-deploy-controller-dev-addon:
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
-	kubectl annotate -n $(subst -hosted,,$(KIND_NAMESPACE)) --overwrite managedclusteraddon config-policy-controller\
+	kubectl get managedclusteraddons -A
+	kubectl annotate -n $(subst klusterlet-,,$(KIND_NAMESPACE)) --overwrite managedclusteraddon config-policy-controller \
 		addon.open-cluster-management.io/values='{"global":{"imagePullPolicy": "Never", "imageOverrides":{"config_policy_controller": "$(REGISTRY)/$(IMG):$(TAG)"}}}'
 
 # Specify KIND_VERSION to indicate the version tag of the KinD image

--- a/pkg/dryrun/cmd.go
+++ b/pkg/dryrun/cmd.go
@@ -18,6 +18,7 @@ type DryRunner struct {
 	statusPath    string
 	desiredStatus string
 	mappingsPath  string
+	log           bool
 	logPath       string
 	noColors      bool
 	fullDiffs     bool
@@ -48,6 +49,21 @@ func (d *DryRunner) GetCmd() *cobra.Command {
 	if err := cmd.MarkFlagRequired("policy"); err != nil {
 		panic(err)
 	}
+
+	cmd.Flags().BoolVar(
+		&d.log,
+		"log",
+		false,
+		"Print the controller logs to the console. Use --log-path to save to a file.",
+	)
+
+	cmd.Flags().StringVar(
+		&d.logPath,
+		"log-path",
+		"",
+		"The path to which to save the controller logs. It implies --log=true. "+
+			"It will append to the file if it exists, otherwise it will create it.",
+	)
 
 	cmd.Flags().StringVar(
 		&d.messagesPath,

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -59,7 +59,7 @@ func (d *DryRunner) dryRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to read input policy: %w", err)
 	}
 
-	if err := d.setupLogs(); err != nil {
+	if err := d.setupLogs(cmd); err != nil {
 		return fmt.Errorf("unable to setup the logging configuration: %w", err)
 	}
 
@@ -386,8 +386,16 @@ func (d *DryRunner) applyInputResources(
 
 // setupLogs configures klog and the controller-runtime logger to send logs to the
 // path defined in the configuration. If that option is empty, logs will be discarded.
-func (d *DryRunner) setupLogs() error {
-	if d.logPath == "" {
+func (d *DryRunner) setupLogs(cmd *cobra.Command) error {
+	if cmd.Flags().Changed("log") && d.logPath != "" && !d.log {
+		return errors.New("error: log-path cannot be set when log is false")
+	}
+
+	if d.logPath != "" {
+		d.log = true
+	}
+
+	if !d.log {
 		klog.SetLogger(logr.Discard())
 		runtime.SetLogger(logr.Discard())
 
@@ -397,9 +405,14 @@ func (d *DryRunner) setupLogs() error {
 	z := zaputil.NewFlagConfig()
 	cfg := z.GetConfig()
 
-	cfg.Level = zap.NewAtomicLevelAt(zapcore.Level(-1))
+	cfg.Level = zap.NewAtomicLevelAt(zapcore.Level(-2))
 	cfg.Encoding = "console"
-	cfg.OutputPaths = []string{d.logPath}
+
+	if d.logPath == "" {
+		cfg.OutputPaths = []string{os.Stdout.Name()}
+	} else {
+		cfg.OutputPaths = []string{d.logPath}
+	}
 
 	ctrlZap, err := cfg.Build()
 	if err != nil {
@@ -410,6 +423,11 @@ func (d *DryRunner) setupLogs() error {
 
 	runtime.SetLogger(logger)
 	klog.SetLogger(logger)
+
+	if d.logPath != "" {
+		logger.Info(fmt.Sprintf("\n=== Executing configuration policy dryrun ===\n"+
+			"policy path: %s\n==", d.policyPath))
+	}
 
 	return nil
 }


### PR DESCRIPTION
Leverage the unused (?) `logPath` struct field to optionally output logs.

Sample log output:
```
2026-03-18T13:13:58.832-0400	info	dryrun/dryrun.go:428	
=== Executing configuration policy dryrun ===
policy path: test/dryrun/ns_selector/ns_default/policy.yaml
==
2026-03-18T13:13:58.863-0400	info	client/client.go:265	Starting the dynamic watcher
2026-03-18T13:13:58.865-0400	debug	controllers/configurationpolicy_controller.go:453	The policy's status.lastEvaluated field is not set. Will evaluate it now.
2026-03-18T13:13:58.865-0400	debug	controllers/configurationpolicy_controller.go:930	Processing object templates
...
```