### PR TITLE
fix: Record the diff for enforce

### DIFF
--- a/test/dryrun/diff/diff_test.go
+++ b/test/dryrun/diff/diff_test.go
@@ -10,35 +10,26 @@ import (
 	"open-cluster-management.io/config-policy-controller/test/dryrun"
 )
 
-//go:embed truncated/*
-var truncated embed.FS
+var (
+	//go:embed truncated
+	truncated embed.FS
+	//go:embed secret_obj_temp
+	secretObjTemp embed.FS
+	//go:embed from_secret_obj_temp_raw
+	fromSecretObjTempRaw embed.FS
+	//go:embed from_secret_obj_temp
+	fromSecretObjTemp embed.FS
 
-// Status comparing should match
-func TestTruncated(t *testing.T) {
-	t.Run("Test Diff generation that is truncated",
-		dryrun.Run(truncated))
-}
+	testCases = map[string]embed.FS{
+		"Diff is truncated":                                    truncated,
+		"No diff when configuring a Secret":                    secretObjTemp,
+		"No diff when using fromSecret (object-templates-raw)": fromSecretObjTempRaw,
+		"No diff when using fromSecret (object-templates)":     fromSecretObjTemp,
+	}
+)
 
-//go:embed secret_obj_temp/*
-var secretObjTemp embed.FS
-
-func TestSecretObjTemp(t *testing.T) {
-	t.Run("Test does not automatically generate a diff when configuring a Secret",
-		dryrun.Run(secretObjTemp))
-}
-
-//go:embed from_secret_obj_temp_raw/*
-var fromSecretObjTempRaw embed.FS
-
-func TestFromSecretObjTempRaw(t *testing.T) {
-	t.Run("Test does not automatically generate a diff when using fromSecret (object-templates-raw)",
-		dryrun.Run(fromSecretObjTempRaw))
-}
-
-//go:embed from_secret_obj_temp/*
-var fromSecretObjTemp embed.FS
-
-func TestFromSecretObjTemp(t *testing.T) {
-	t.Run("Test does not automatically generate a diff when using fromSecret (object-templates)",
-		dryrun.Run(fromSecretObjTemp))
+func TestContextVariables(t *testing.T) {
+	for name, testFiles := range testCases {
+		t.Run("Test Diff: "+name, dryrun.Run(testFiles))
+	}
 }

--- a/test/resources/case39_diff_generation/case39-create-cfgmap-policy.yaml
+++ b/test/resources/case39_diff_generation/case39-create-cfgmap-policy.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   remediationAction: enforce
   namespaceSelector:
-    exclude: ["kube-*"]
     include: ["default"]
   object-templates:
     - complianceType: musthave

--- a/test/resources/case39_diff_generation/case39-status-cfgmap-policy.yaml
+++ b/test/resources/case39_diff_generation/case39-status-cfgmap-policy.yaml
@@ -8,11 +8,11 @@ spec:
     include: ["default"]
   object-templates:
     - complianceType: musthave
-      recordDiff: Log
+      recordDiff: InStatus
       objectDefinition:
         apiVersion: v1
         kind: ConfigMap
         metadata:
           name: case39-map
         data:
-          fieldToUpdate: "2"
+          fieldToUpdate: "3"


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-19111

Investigating this, the console (to be confirmed) appears to have conditionals around only displaying the diff link with `remediationAction: inform` and on violations. It seems we can persist the diff in that case. When flipping from `enforce` to `inform`, the diff is cleared if the objects match. I think this flow makes sense (persist for `enforce` to show the historical diff but don't persist for `inform`).