### PR TITLE
Use JSON instead of YAML for hub templates

### DIFF
--- a/test/resources/case43_standalone_hub_templates/copy-secret-data-cfgpol.yaml
+++ b/test/resources/case43_standalone_hub_templates/copy-secret-data-cfgpol.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case43-copysecret
+  ownerReferences:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      name: case43-parent
+      uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: enforce
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          namespace: default
+          name: test
+        data: '{{hub copySecretData "ocm-standalone-template-test-src" "test" hub}}'
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          namespace: default
+          name: test-long
+        data: '{{hub copySecretData "ocm-standalone-template-test-src"
+          "long-named-secret-to-test-more" hub}}'
+          

--- a/test/resources/case43_standalone_hub_templates/hub-secret.yaml
+++ b/test/resources/case43_standalone_hub_templates/hub-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocm-standalone-template-test-src
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: ocm-standalone-template-test-src
+  name: test
+stringData:
+  tls.crt: 'certificate'
+  tls.key: 'skullkey'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: ocm-standalone-template-test-src
+  name: long-named-secret-to-test-more
+stringData:
+  tls.crt: 'certificate'
+  tls.key: 'skullkey'


### PR DESCRIPTION
For some reason, linebreaks in the YAML encoding can break the `copySecretData` template function.

Refs:
 - https://issues.redhat.com/browse/ACM-21394