### PR TITLE
fix: Allow templated namespace without nsSelector

### DIFF
--- a/test/dryrun/context_vars/context_vars_test.go
+++ b/test/dryrun/context_vars/context_vars_test.go
@@ -27,16 +27,22 @@ var (
 	objUnnamedDef embed.FS
 	//go:embed objectns_cluster_scoped
 	objNsClusterScoped embed.FS
+	//go:embed objectns_templated_empty
+	objNsTemplatedEmpty embed.FS
+	//go:embed objectns_templated_no_nsselector
+	objNsTemplatedNoNsSelector embed.FS
 
 	testCases = map[string]embed.FS{
-		"Test Object: available for namespaced objects":                objNamespaced,
-		"Test Object: available for complex objects":                   objPod,
-		"Test Object: nil for objects that don't exist":                objPodNsSelector,
-		"Test Object: nil but succeeds with default function":          objPodDefaultFunc,
-		"Test Object: available for cluster-scoped objects":            objClusterScoped,
-		"Test Object: nil when namespace is templated":                 objTmplNs,
-		"Test Object: unavailable for unnamed objects":                 objUnnamedDef,
-		"Test ObjectNamespace: unavailable for cluster-scoped objects": objNsClusterScoped,
+		"Test Object: available for namespaced objects":                    objNamespaced,
+		"Test Object: available for complex objects":                       objPod,
+		"Test Object: nil for objects that don't exist":                    objPodNsSelector,
+		"Test Object: nil but succeeds with default function":              objPodDefaultFunc,
+		"Test Object: available for cluster-scoped objects":                objClusterScoped,
+		"Test Object: nil when namespace is templated":                     objTmplNs,
+		"Test Object: unavailable for unnamed objects":                     objUnnamedDef,
+		"Test ObjectNamespace: unavailable for cluster-scoped objects":     objNsClusterScoped,
+		"Test ObjectNamespace: noncompliant for empty templated namespace": objNsTemplatedEmpty,
+		"Test ObjectNamespace: available for templated namespace":          objNsTemplatedNoNsSelector,
 	}
 )
 

--- a/test/dryrun/context_vars/objectns_templated_empty/input.yaml
+++ b/test/dryrun/context_vars/objectns_templated_empty/input.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-other-namespace
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: templated-ns-configmap
+  namespace: my-namespace
+data:
+  this: thing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-extra
+  namespace: my-namespace
+data:
+  this: thing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-other-ns
+  namespace: my-other-namespace
+data:
+  this: thing

--- a/test/dryrun/context_vars/objectns_templated_empty/output.txt
+++ b/test/dryrun/context_vars/objectns_templated_empty/output.txt
@@ -1,0 +1,3 @@
+# Diffs:
+# Compliance messages:
+NonCompliant; violation - namespaced object templated-ns-configmap of kind ConfigMap has no namespace specified after template resolution

--- a/test/dryrun/context_vars/objectns_templated_empty/policy.yaml
+++ b/test/dryrun/context_vars/objectns_templated_empty/policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-object-var-templated-name
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      recordDiff: InStatus
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: templated-ns-configmap
+          namespace: '{{ "" }}'
+        data:
+          this: thing

--- a/test/dryrun/context_vars/objectns_templated_no_nsselector/input.yaml
+++ b/test/dryrun/context_vars/objectns_templated_no_nsselector/input.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-other-namespace
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: templated-ns-configmap
+  namespace: my-namespace
+data:
+  this: thing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-extra
+  namespace: my-namespace
+data:
+  this: thing
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-other-ns
+  namespace: my-other-namespace
+data:
+  this: thing

--- a/test/dryrun/context_vars/objectns_templated_no_nsselector/output.txt
+++ b/test/dryrun/context_vars/objectns_templated_no_nsselector/output.txt
@@ -1,0 +1,5 @@
+# Diffs:
+v1 ConfigMap my-namespace/templated-ns-configmap:
+
+# Compliance messages:
+Compliant; notification - configmaps [templated-ns-configmap] found as specified in namespace my-namespace

--- a/test/dryrun/context_vars/objectns_templated_no_nsselector/policy.yaml
+++ b/test/dryrun/context_vars/objectns_templated_no_nsselector/policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-object-var-templated-name
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      recordDiff: InStatus
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: templated-ns-configmap
+          namespace: '{{ "my-namespace" }}'
+        data:
+          this: thing


### PR DESCRIPTION
When a `namespaceSelector` was not provided and a namespace was templated, the controller considered this invalid and didn't attempt to resolve the template, returning errors about a missing namespace.

ref: https://issues.redhat.com/browse/ACM-21804
