### PR TITLE
fix: Properly handle `objectSelector` with `namespaceSelector`

### DIFF
--- a/test/dryrun/context_vars/context_vars_test.go
+++ b/test/dryrun/context_vars/context_vars_test.go
@@ -31,6 +31,8 @@ var (
 	objNsTemplatedEmpty embed.FS
 	//go:embed objectns_templated_no_nsselector
 	objNsTemplatedNoNsSelector embed.FS
+	//go:embed objectname_nsselector
+	objNameNsSelector embed.FS
 
 	testCases = map[string]embed.FS{
 		"Test Object: available for namespaced objects":                    objNamespaced,
@@ -43,6 +45,7 @@ var (
 		"Test ObjectNamespace: unavailable for cluster-scoped objects":     objNsClusterScoped,
 		"Test ObjectNamespace: noncompliant for empty templated namespace": objNsTemplatedEmpty,
 		"Test ObjectNamespace: available for templated namespace":          objNsTemplatedNoNsSelector,
+		"Test ObjectName: correctly handle namespaceSelector":              objNameNsSelector,
 	}
 )
 

--- a/test/dryrun/context_vars/objectname_nsselector/input.yaml
+++ b/test/dryrun/context_vars/objectname_nsselector/input.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mega-mart
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mega-mart-2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mega-mart-3
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inventory
+  namespace: mega-mart
+data: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nininventory
+  namespace: mega-mart
+data: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inventory
+  namespace: mega-mart-2
+data: 
+  things: original-stuff
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inventory-2
+  namespace: mega-mart-2
+data:
+  things: stuff

--- a/test/dryrun/context_vars/objectname_nsselector/output.txt
+++ b/test/dryrun/context_vars/objectname_nsselector/output.txt
@@ -1,0 +1,40 @@
+# Diffs:
+v1 ConfigMap mega-mart/inventory:
+--- mega-mart/inventory : existing
++++ mega-mart/inventory : updated
+@@ -1,7 +1,8 @@
+ apiVersion: v1
+-data: {}
++data:
++  hocus: pocus
+ kind: ConfigMap
+ metadata:
+   name: inventory
+   namespace: mega-mart
+ 
+v1 ConfigMap mega-mart-2/inventory:
+--- mega-mart-2/inventory : existing
++++ mega-mart-2/inventory : updated
+@@ -1,7 +1,8 @@
+ apiVersion: v1
+ data:
++  hocus: pocus
+   things: original-stuff
+ kind: ConfigMap
+ metadata:
+   name: inventory
+   namespace: mega-mart-2
+v1 ConfigMap mega-mart-2/inventory-2:
+--- mega-mart-2/inventory-2 : existing
++++ mega-mart-2/inventory-2 : updated
+@@ -1,7 +1,8 @@
+ apiVersion: v1
+ data:
++  hocus: pocus
+   things: stuff
+ kind: ConfigMap
+ metadata:
+   name: inventory-2
+   namespace: mega-mart-2
+# Compliance messages:
+NonCompliant; violation - configmaps [inventory-2] found but not as specified in namespace mega-mart-2; configmaps [inventory] found but not as specified in namespaces: mega-mart, mega-mart-2

--- a/test/dryrun/context_vars/objectname_nsselector/policy.yaml
+++ b/test/dryrun/context_vars/objectname_nsselector/policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-object-var-templated-name
+spec:
+  remediationAction: inform
+  namespaceSelector:
+    include: ["*"]
+  object-templates:
+    - complianceType: musthave
+      recordDiff: InStatus
+      objectSelector: {}
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: '{{ not (hasPrefix "inv" .ObjectName) | skipObject }}'
+        data: '{{ set .Object.data "hocus" "pocus" | toJSON | toLiteral }}'


### PR DESCRIPTION
The `relevantNsNames` variable is a map to a map. However, in Golang a map is a pointer, so setting one `relevantNsNames[ns]` resulted in setting all of the namespaces to the same value. This instead instantiates a new value each time.

Followup to
- https://github.com/open-cluster-management-io/config-policy-controller/pull/361

ref: https://issues.redhat.com/browse/ACM-22676
