### PR TITLE
Remove unused serverVersion field

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -187,7 +187,6 @@ type ConfigurationPolicyReconciler struct {
 	SelectorReconciler     common.SelectorReconciler
 	// Whether custom metrics collection is enabled
 	EnableMetrics bool
-	ServerVersion string
 	// When true, the controller has detected it is being uninstalled and only basic cleanup should be performed before
 	// exiting.
 	UninstallMode bool

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	k8sversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -429,7 +428,6 @@ func main() {
 	var nsSelUpdatesSource source.TypedSource[reconcile.Request]
 	var objectTemplatesChannel source.TypedSource[reconcile.Request]
 	var dynamicWatcher depclient.DynamicWatcher
-	var serverVersion *k8sversion.Info
 	var standaloneHubCfg *rest.Config
 	var configPolHubDynamicWatcher depclient.DynamicWatcher
 	var hubClient *kubernetes.Clientset
@@ -447,14 +445,6 @@ func main() {
 		nsSelReconciler = common.NewNamespaceSelectorReconciler(nsSelMgr.GetClient(), nsSelUpdatesChan)
 		if err = nsSelReconciler.SetupWithManager(nsSelMgr); err != nil {
 			log.Error(err, "Unable to create controller", "controller", "NamespaceSelector")
-			os.Exit(1)
-		}
-
-		var serverVersionErr error
-
-		serverVersion, serverVersionErr = targetK8sClient.Discovery().ServerVersion()
-		if serverVersionErr != nil {
-			log.Error(serverVersionErr, "unable to detect the managed cluster's Kubernetes version")
 			os.Exit(1)
 		}
 
@@ -524,7 +514,6 @@ func main() {
 		SelectorReconciler:     &nsSelReconciler,
 		EnableMetrics:          opts.enableMetrics,
 		UninstallMode:          beingUninstalled,
-		ServerVersion:          serverVersion.String(),
 		EvalBackoffSeconds:     opts.evalBackoffSeconds,
 		HubDynamicWatcher:      configPolHubDynamicWatcher,
 		HubClient:              hubClient,

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -444,13 +444,6 @@ func (d *DryRunner) setupReconciler(
 	nsSelUpdatesChan := make(chan event.GenericEvent, 20)
 	nsSelReconciler := common.NewNamespaceSelectorReconciler(runtimeClient, nsSelUpdatesChan)
 
-	serverVersion := ""
-
-	versionInfo, err := clientset.Discovery().ServerVersion()
-	if err == nil {
-		serverVersion = versionInfo.String()
-	}
-
 	defaultNs := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -469,7 +462,7 @@ func (d *DryRunner) setupReconciler(
 	}
 
 	// Create default namespace for namespace selector
-	err = runtimeClient.Create(ctx, defaultNs)
+	err := runtimeClient.Create(ctx, defaultNs)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, err
 	}
@@ -486,7 +479,6 @@ func (d *DryRunner) setupReconciler(
 		SelectorReconciler:     &nsSelReconciler,
 		EnableMetrics:          false,
 		UninstallMode:          false,
-		ServerVersion:          serverVersion,
 		EvalBackoffSeconds:     5,
 		FullDiffs:              d.fullDiffs,
 	}


### PR DESCRIPTION
This field is no longer used, but could cause a panic if the target kubeconfig was removed and the container restarted (which could happen in a hosted mode scenario).

Refs:
 - https://issues.redhat.com/browse/ACM-22679