### PR TITLE
Handle CSV approvals with unconventional package names

### DIFF
--- a/test/resources/unit/mtc-oadp-installplan.yaml
+++ b/test/resources/unit/mtc-oadp-installplan.yaml
@@ -1,0 +1,18 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: install-mtc-oadp
+  namespace: openshift-adp
+spec:
+  approval: Manual
+  approved: false
+  clusterServiceVersionNames:
+  - mtc-operator.v1.8.9
+  - oadp-operator.v1.5.0
+  generation: 1
+status:
+  bundleLookups:
+  - identifier: oadp-operator.v1.5.0
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"oadp.openshift.io","kind":"CloudStorage","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"redhat-oadp-operator","version":"1.5.0"}}]}'
+  - identifier: mtc-operator.v1.8.9
+    properties: '{"properties":[{"type":"olm.gvk","value":{"group":"migration.openshift.io","kind":"DirectImageMigration","version":"v1alpha1"}},{"type":"olm.package","value":{"packageName":"mtc-operator","version":"1.8.9"}},{"type":"olm.package.required","value":{"packageName":"redhat-oadp-operator","versionRange":">=1.2.3"}}]}' 


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-20500

When an operator policy enforces automatic upgrades, dependency CSVs should be automatically approved. In some cases, CSVs do not match the name format of `<package name>.v<version>` and could not be approved.

The PR looks up the CSV name for each dependency package by reading the install plan.