### PR TITLE
Update gitignore with broader kubeconfig matching pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ test/crds/test-policy.yaml
 !vbh/.build-harness-vendorized
 !vbh/build-harness
 !vbh/build-harness-extensions 
-kubeconfig_managed*
+kubeconfig_*
 kind_kubeconfig.yaml
 report.json
 report_*.json


### PR DESCRIPTION
If kubeconfigs are copied between repos during e2e testing with local kind clusters, the gitignore will miss any `kubeconfig_hub_e2e` files originally generated from the governance policy addon controller repo. 

Match kubeconfig pattern found in the GRC addon controller's gitignore:
https://github.com/open-cluster-management-io/governance-policy-framework-addon/blob/9c0264853aaeb1ad4f04a1f4f92b25bfe478a359/.gitignore#L90