### PR TITLE
Generate and save JUnit reports for all tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -17,6 +17,3 @@ coverage:
         flags:
           - unit-tests
           - e2e-tests
-
-comment:
-  behavior: new

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -44,12 +44,6 @@ jobs:
         run: |
           make test-coverage
 
-      - name: Upload Unit Test Coverage
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage_unit
-          path: coverage_unit.out
-
       - name: Bootstrap K8s KinD Cluster and Deploy Controller
         run: |
           make kind-bootstrap-cluster-dev
@@ -62,12 +56,15 @@ jobs:
           export GOPATH=$(go env GOPATH)
           KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-running-in-cluster
 
-      - name: Upload Uninstall Test Coverage
+      - name: Upload Test Info
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: coverage_e2e_uninstall
-          path: coverage_e2e_uninstall.out
-      
+          name: latest-preflight-tests
+          path: |
+            coverage_*.out
+            report_*.xml
+
       - name: Debug
         if: ${{ failure() }}
         run: |
@@ -113,12 +110,14 @@ jobs:
           export GOPATH=$(go env GOPATH)
           KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-coverage
 
-      - name: Upload E2E Test Coverage
+      - name: Upload Basic e2e Test Info
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.kind == 'latest' }}
         with:
-          name: coverage_e2e_basic
-          path: coverage_e2e_basic.out
+          name: "${{matrix.kind}}-basic-tests"
+          path: |
+            coverage_*.out
+            report_*.xml
 
       - name: Debug
         if: ${{ failure() }}
@@ -166,12 +165,14 @@ jobs:
           export GOPATH=$(go env GOPATH)
           KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-hosted-mode-coverage
 
-      - name: Upload Hosted Mode Coverage
+      - name: Upload Hosted Mode e2e Test Info
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.kind == 'latest' }}
         with:
-          name: coverage_e2e_hosted_mode
-          path: coverage_e2e_hosted_mode.out
+          name: "${{matrix.kind}}-hosted-tests"
+          path: |
+            coverage_*.out
+            report_*.xml
 
       - name: Debug
         if: ${{ failure() }}
@@ -219,12 +220,14 @@ jobs:
           export GOPATH=$(go env GOPATH)
           KUBECONFIG=${PWD}/kubeconfig_managed make e2e-test-standalone-templates-coverage
 
-      - name: Upload Hub Templates Enabled Coverage
+      - name: Upload Hub Templates e2e Report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
-        if: ${{ matrix.kind == 'latest' }}
         with:
-          name: coverage_e2e_hub_templates
-          path: coverage_e2e_hub_templates.out
+          name: "${{matrix.kind}}-hub-templates-tests"
+          path: |
+            coverage_*.out
+            report_*.xml
 
       - name: Debug
         if: ${{ failure() }}
@@ -252,10 +255,11 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Download Coverage Results
+      - name: Download Test Results
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
+          pattern: latest-*
 
       - name: Test Coverage Verification
         run: |

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ fmt:
 TEST_PKGS ?= ./api/v1 ./controllers ./pkg/common ./pkg/dryrun ./test/dryrun/...
 
 .PHONY: test
-test: envtest kubebuilder
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TESTARGS) $(TEST_PKGS)
+test: envtest kubebuilder gotestsum
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GOTESTSUM) $(GOTST_FMT) --junitfile report_unit.xml -- $(TESTARGS) $(TEST_PKGS)
 
 .PHONY: test-coverage
 test-coverage: TESTARGS = -coverpkg=./... -covermode=atomic -coverprofile=coverage_unit.out
@@ -151,7 +151,6 @@ generate-operator-yaml: manifests
 ############################################################
 # e2e test section
 ############################################################
-GINKGO = $(LOCAL_BIN)/ginkgo
 
 .PHONY: kind-bootstrap-cluster
 kind-bootstrap-cluster: kind-bootstrap-cluster-dev kind-deploy-controller
@@ -250,18 +249,22 @@ install-resources:
 
 IS_HOSTED ?= false
 E2E_PROCS = 20
+E2E_JSON = --json-report=report_e2e.json
+E2E_JUNIT = --junit-report=report_e2e.xml
 
 .PHONY: e2e-test
 e2e-test: e2e-dependencies
-	$(GINKGO) -v --procs=$(E2E_PROCS) $(E2E_TEST_ARGS) test/e2e -- -is_hosted=$(IS_HOSTED)
+	$(GINKGO) -v --procs=$(E2E_PROCS) $(E2E_TEST_ARGS) --output-dir=. $(E2E_JSON) $(E2E_JUNIT) test/e2e -- -is_hosted=$(IS_HOSTED)
 
 .PHONY: e2e-test-coverage
-e2e-test-coverage: E2E_TEST_ARGS = --json-report=report_e2e.json --label-filter='!hosted-mode && !running-in-cluster && !hub-templates-enabled' --output-dir=.
+e2e-test-coverage: E2E_TEST_ARGS = --label-filter='!hosted-mode && !running-in-cluster && !hub-templates-enabled' 
 e2e-test-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
 .PHONY: e2e-test-hosted-mode-coverage
-e2e-test-hosted-mode-coverage: E2E_TEST_ARGS = --json-report=report_e2e_hosted_mode.json --label-filter="hosted-mode || supports-hosted && !running-in-cluster" --output-dir=.
+e2e-test-hosted-mode-coverage: E2E_TEST_ARGS = --label-filter="hosted-mode || supports-hosted && !running-in-cluster"
 e2e-test-hosted-mode-coverage: COVERAGE_E2E_OUT = coverage_e2e_hosted_mode.out
+e2e-test-hosted-mode-coverage: E2E_JSON = --json-report=report_e2e_hosted_mode.json
+e2e-test-hosted-mode-coverage: E2E_JUNIT = --junit-report=report_e2e_hosted_mode.xml
 e2e-test-hosted-mode-coverage: IS_HOSTED=true
 e2e-test-hosted-mode-coverage: E2E_PROCS=2
 e2e-test-hosted-mode-coverage: export TARGET_KUBECONFIG_PATH = $(PWD)/kubeconfig_managed2
@@ -269,11 +272,15 @@ e2e-test-hosted-mode-coverage: e2e-run-instrumented e2e-test e2e-stop-instrument
 
 .PHONY: e2e-test-running-in-cluster
 e2e-test-running-in-cluster: E2E_TEST_ARGS = --label-filter="running-in-cluster" --covermode=atomic --coverprofile=coverage_e2e_uninstall.out --coverpkg=open-cluster-management.io/config-policy-controller/pkg/triggeruninstall
+e2e-test-running-in-cluster: E2E_JSON = --json-report=report_e2e_uninstall.json
+e2e-test-running-in-cluster: E2E_JUNIT = --junit-report=report_e2e_uninstall.xml
 e2e-test-running-in-cluster: e2e-test
 
 .PHONY: e2e-test-standalone-templates-coverage
-e2e-test-standalone-templates-coverage: E2E_TEST_ARGS = --json-report=report_e2e_hub_templates.json --label-filter="hub-templates-enabled" --output-dir=.
+e2e-test-standalone-templates-coverage: E2E_TEST_ARGS = --label-filter="hub-templates-enabled"
 e2e-test-standalone-templates-coverage: COVERAGE_E2E_OUT = coverage_e2e_hub_templates.out
+e2e-test-standalone-templates-coverage: E2E_JSON = --json-report=report_e2e_hub_templates.json
+e2e-test-standalone-templates-coverage: E2E_JUNIT = --junit-report=report_e2e_hub_templates.xml
 e2e-test-standalone-templates-coverage: E2E_PROCS=2
 e2e-test-standalone-templates-coverage: export HUB_TEMPLATES_KUBECONFIG_PATH = $(PWD)/kubeconfig_managed2
 e2e-test-standalone-templates-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -23,6 +23,8 @@ GOCOVMERGE_VERSION := v2.16.0
 ENVTEST_VERSION ?= $(shell go list -mod=readonly -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime 2>/dev/null | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 # Parse the Kubernetes API version from go.mod (which is v0.Y.Z) and convert to the corresponding v1.Y.Z format
 ENVTEST_K8S_VERSION := $(shell go list -mod=readonly -m -f "{{ .Version }}" k8s.io/api 2>/dev/null | awk -F'[v.]' '{printf "1.%d", $$3}')
+# https://github.com/gotestyourself/gotestsum/releases/latest
+GOTESTSUM_VERSION := v1.13.0
 
 LOCAL_BIN ?= $(error LOCAL_BIN is not set.)
 ifneq ($(findstring $(LOCAL_BIN), $(PATH)), $(LOCAL_BIN))
@@ -106,6 +108,12 @@ fmt: fmt-dependencies
 GOSEC = $(LOCAL_BIN)/gosec
 KUBEBUILDER = $(LOCAL_BIN)/kubebuilder
 ENVTEST = $(LOCAL_BIN)/setup-envtest
+GOTESTSUM = $(LOCAL_BIN)/gotestsum
+
+GOTST_FMT := --format=pkgname-and-test-fails --format-icons=text
+ifeq ($(GITHUB_ACTIONS), true)
+  GOTST_FMT := --format=github-actions
+endif
 
 .PHONY: kubebuilder
 kubebuilder:
@@ -127,6 +135,10 @@ gosec:
 .PHONY: gosec-scan
 gosec-scan: gosec
 	$(GOSEC) -fmt sonarqube -out gosec.json -stdout -exclude-dir=.go -exclude-dir=test $(GOSEC_ARGS) ./...
+
+.PHONY: gotestsum
+gotestsum:
+	$(call go-get-tool,gotest.tools/gotestsum@$(GOTESTSUM_VERSION))
 
 ############################################################
 #  E2E Test

--- a/test/dryrun/empty_test.go
+++ b/test/dryrun/empty_test.go
@@ -1,6 +1,0 @@
-// Copyright Contributors to the Open Cluster Management project
-
-package dryrun
-
-// This test file is empty, but it prevents a `go: no such tool "covdata"` error
-// when running tests on this package.

--- a/test/dryrun/noop_test.go
+++ b/test/dryrun/noop_test.go
@@ -1,0 +1,11 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package dryrun
+
+import "testing"
+
+// This test prevents a `go: no such tool "covdata"` error, and other errors that
+// can occur in the test report if no tests are executed here.
+
+func TestNoop(_ *testing.T) {
+}


### PR DESCRIPTION
Previously, we have been generating ginkgo JSON reports for only our e2e tests, but I don't believe they're used for anything specific. Now the e2e tests and the unit tests will generate JUnit XML reports, which can be used by a variety of tools. One such tool was failing when a test "suite" had no tests, so the "empty_test.go" file has been replaced by a "noop_test.go" file with a similar purpose.

The upload tasks in the workflow should run even when the tests fail, so that we can track flaky tests.

At some point in the future, some other automated process may pull the JUnit reports from the GitHub artifacts.