### PR TITLE
feat: detect new minor operator version on another channel

### DIFF
--- a/api/v1beta1/operatorpolicy_types.go
+++ b/api/v1beta1/operatorpolicy_types.go
@@ -141,6 +141,12 @@ type ComplianceConfig struct {
 	//
 	// +kubebuilder:default=Compliant
 	DeprecationsPresent ComplianceConfigAction `json:"deprecationsPresent,omitempty"`
+	// MinorChannelUpgradeAvailable specifies how the availability of a newer minor version channel
+	// should affect overall policy compliance when spec.UpgradeApproval is Automatic. The default
+	// value is `Compliant`.
+	//
+	// +kubebuilder:default=Compliant
+	MinorChannelUpgradeAvailable ComplianceConfigAction `json:"minorChannelUpgradeAvailable,omitempty"`
 }
 
 // OperatorPolicySpec defines the desired state of a particular operator on the cluster.

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -396,7 +396,7 @@ func (r *OperatorPolicyReconciler) handleResources(ctx context.Context, policy *
 		return earlyComplianceEvents, condChanged || changed, err
 	}
 
-	desiredSub, desiredOG, changed, err := r.buildResources(ctx, policy)
+	desiredSub, desiredOG, packageManifest, changed, err := r.buildResources(ctx, policy)
 	condChanged = condChanged || changed
 
 	if err != nil {
@@ -449,7 +449,14 @@ func (r *OperatorPolicyReconciler) handleResources(ctx context.Context, policy *
 		return earlyComplianceEvents, condChanged, err
 	}
 
-	err = r.updateDeprecationStatus(ctx, policy, subscription, csv)
+	err = r.updateDeprecationStatus(ctx, policy, subscription, csv, packageManifest)
+	if err != nil {
+		return earlyComplianceEvents, condChanged, err
+	}
+
+	changed, err = r.updateMinorChannelUpgradeStatus(policy, subscription, packageManifest)
+	condChanged = condChanged || changed
+
 	if err != nil {
 		return earlyComplianceEvents, condChanged, err
 	}
@@ -489,12 +496,13 @@ func (r *OperatorPolicyReconciler) handleResources(ctx context.Context, policy *
 // checks if the policy's spec is valid. It returns:
 //   - the built Subscription
 //   - the built OperatorGroup
+//   - the PackageManifest
 //   - whether the status has changed
 //   - an error if an API call failed
 //
 // The built objects can be used to find relevant objects for a 'mustnothave' policy.
 func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *policyv1beta1.OperatorPolicy) (
-	*operatorv1alpha1.Subscription, *operatorv1.OperatorGroup, bool, error,
+	*operatorv1alpha1.Subscription, *operatorv1.OperatorGroup, *unstructured.Unstructured, bool, error,
 ) {
 	opLog := ctrl.LoggerFrom(ctx)
 	disableTemplates := false
@@ -514,14 +522,14 @@ func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *p
 		if err != nil {
 			newError := fmt.Errorf("unable to create template resolver: %w", err)
 
-			return nil, nil, updateStatus(policy, validationCond([]error{newError})), nil
+			return nil, nil, nil, updateStatus(policy, validationCond([]error{newError})), nil
 		}
 
 		err = resolveVersionsTemplates(policy, tmplResolver)
 		if err != nil {
 			newError := fmt.Errorf("unable to create template resolver: %w", err)
 
-			return nil, nil, updateStatus(policy, validationCond([]error{newError})), nil
+			return nil, nil, nil, updateStatus(policy, validationCond([]error{newError})), nil
 		}
 	} else {
 		opLog.V(1).Info("Templates disabled by annotation")
@@ -532,30 +540,37 @@ func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *p
 	var returnedErr error
 
 	sub, subErr := buildSubscription(policy, tmplResolver)
-	if subErr == nil {
-		err := r.applySubscriptionDefaults(ctx, policy, sub)
-		if err != nil {
-			// If it's a PackageManifest API error, then that means it should be returned for the Reconcile method
-			// to requeue the request. This is to workaround the PackageManifest API not supporting watches.
-			if errors.Is(err, ErrPackageManifest) {
-				returnedErr = err
-			}
-
-			return nil, nil, updateStatus(policy, validationCond([]error{err})), returnedErr
-		}
-
-		if sub != nil && sub.Namespace == "" {
-			if r.DefaultNamespace != "" {
-				sub.Namespace = r.DefaultNamespace
-			} else {
-				newError := errors.New("namespace is required in spec.subscription")
-
-				return sub, nil, updateStatus(policy, validationCond([]error{newError})), nil
-			}
-		}
-	} else {
+	if subErr != nil {
 		// Invalid subscription spec - mark status and return without an API error
-		return sub, nil, updateStatus(policy, validationCond([]error{subErr})), nil
+		return sub, nil, nil, updateStatus(policy, validationCond([]error{subErr})), nil
+	}
+
+	packageManifest, err := r.getPackageManifest(ctx, sub.Spec.Package)
+	if err != nil {
+		returnedErr = fmt.Errorf("%wfailed to get the PackageManifest", ErrPackageManifest)
+
+		// If it's a PackageManifest API error, then that means it should be returned for the Reconcile method
+		// to requeue the request. This is to workaround the PackageManifest API not supporting watches.
+		return nil, nil, nil, updateStatus(policy, validationCond([]error{err})), returnedErr
+	}
+
+	err = r.applySubscriptionDefaults(ctx, policy, sub, packageManifest)
+	if err != nil {
+		if errors.Is(err, ErrPackageManifest) {
+			returnedErr = err
+		}
+
+		return nil, nil, nil, updateStatus(policy, validationCond([]error{err})), returnedErr
+	}
+
+	if sub != nil && sub.Namespace == "" {
+		if r.DefaultNamespace != "" {
+			sub.Namespace = r.DefaultNamespace
+		} else {
+			newError := errors.New("namespace is required in spec.subscription")
+
+			return sub, nil, nil, updateStatus(policy, validationCond([]error{newError})), nil
+		}
 	}
 
 	opGroupNS := r.DefaultNamespace
@@ -566,20 +581,20 @@ func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *p
 	opGroup, ogErr := buildOperatorGroup(policy, opGroupNS, tmplResolver)
 	if ogErr != nil {
 		// OperatorGroup spec invalid - mark status, don't requeue
-		return sub, nil, updateStatus(policy, validationCond([]error{ogErr})), nil
+		return sub, nil, nil, updateStatus(policy, validationCond([]error{ogErr})), nil
 	}
 
 	watcher := opPolIdentifier(policy.Namespace, policy.Name)
 
 	gotNamespace, err := r.DynamicWatcher.Get(watcher, namespaceGVK, "", opGroupNS)
 	if err != nil {
-		return sub, opGroup, false, fmt.Errorf("error getting operator namespace: %w", err)
+		return sub, opGroup, packageManifest, false, fmt.Errorf("error getting operator namespace: %w", err)
 	}
 
 	if gotNamespace == nil && policy.Spec.ComplianceType.IsMustHave() {
 		newError := fmt.Errorf("the operator namespace ('%v') does not exist", opGroupNS)
 
-		return sub, opGroup, updateStatus(policy, validationCond([]error{newError})), nil
+		return sub, opGroup, packageManifest, updateStatus(policy, validationCond([]error{newError})), nil
 	}
 
 	changed, overlapErr, apiErr := r.checkSubOverlap(ctx, policy, sub)
@@ -591,12 +606,12 @@ func (r *OperatorPolicyReconciler) buildResources(ctx context.Context, policy *p
 		// When an overlap is detected, the generated subscription and operatorgroup
 		// will be considered to be invalid to prevent creations/updates.
 		// sub and opgroup should be nil to prevent creation/update.
-		return nil, nil, updateStatus(policy, validationCond([]error{overlapErr})), returnedErr
+		return nil, nil, nil, updateStatus(policy, validationCond([]error{overlapErr})), returnedErr
 	}
 
 	changed = updateStatus(policy, validationCond([]error{})) || changed
 
-	return sub, opGroup, changed, returnedErr
+	return sub, opGroup, packageManifest, changed, returnedErr
 }
 
 func (r *OperatorPolicyReconciler) checkSubOverlap(
@@ -677,7 +692,10 @@ func (r *OperatorPolicyReconciler) checkSubOverlap(
 // utilizing the PackageManifest API. If the PackageManifest can not be found, and a subscription already exists for the
 // operator, then information from the found subscription will be used.
 func (r *OperatorPolicyReconciler) applySubscriptionDefaults(
-	ctx context.Context, policy *policyv1beta1.OperatorPolicy, subscription *operatorv1alpha1.Subscription,
+	ctx context.Context,
+	policy *policyv1beta1.OperatorPolicy,
+	subscription *operatorv1alpha1.Subscription,
+	packageManifest *unstructured.Unstructured,
 ) error {
 	opLog := ctrl.LoggerFrom(ctx)
 	subSpec := subscription.Spec
@@ -691,27 +709,13 @@ func (r *OperatorPolicyReconciler) applySubscriptionDefaults(
 
 	opLog.V(1).Info("Determining defaults for the subscription based on the PackageManifest")
 
-	// PackageManifests come from an API server and not a Kubernetes resource, so the DynamicWatcher can't be used since
-	// it utilizes watches. The namespace doesn't have any meaning but is required.
-	packageManifest, err := r.DynamicClient.Resource(packageManifestGVR).Namespace("default").Get(
-		ctx, subSpec.Package, metav1.GetOptions{},
-	)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			if !r.usingExistingSubIfFound(policy, subscription) {
-				return fmt.Errorf(
-					"%wthe subscription defaults could not be determined because the PackageManifest was not found",
-					ErrPackageManifest,
-				)
-			}
-
+	if packageManifest == nil {
+		if r.usingExistingSubIfFound(policy, subscription) {
 			return nil
 		}
 
-		opLog.Error(err, "Failed to get the PackageManifest", "name", subSpec.Package)
-
 		return fmt.Errorf(
-			"%wthe subscription defaults could not be determined because the PackageManifest API returned an error",
+			"%wthe subscription defaults could not be determined because the PackageManifest was not found",
 			ErrPackageManifest,
 		)
 	}
@@ -1528,6 +1532,7 @@ func (r *OperatorPolicyReconciler) updateDeprecationStatus(ctx context.Context,
 	policy *policyv1beta1.OperatorPolicy,
 	desiredSub *operatorv1alpha1.Subscription,
 	csv *operatorv1alpha1.ClusterServiceVersion,
+	packageManifest *unstructured.Unstructured,
 ) error {
 	opLog := ctrl.LoggerFrom(ctx)
 
@@ -1536,25 +1541,17 @@ func (r *OperatorPolicyReconciler) updateDeprecationStatus(ctx context.Context,
 		return nil
 	}
 
-	packageManifest, err := r.DynamicClient.Resource(packageManifestGVR).Namespace("default").Get(
-		ctx, desiredSub.Spec.Package, metav1.GetOptions{},
-	)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			// Handle the case where 'packageManifest' is null in other functions
-			opLog.Info("PackageManifest not found; skipping DeprecationStatus check",
-				"PackageManifestName", desiredSub.Spec.Package)
+	if packageManifest == nil {
+		opLog.Info("PackageManifest not found; skipping DeprecationStatus check",
+			"PackageManifestName", desiredSub.Spec.Package)
 
-			return nil
-		}
-
-		return fmt.Errorf("failed to get the PackageManifest %q %w", desiredSub.Spec.Package, err)
+		return nil
 	}
 
 	// Extract package name
 	packageName, ok, err := unstructured.NestedString(packageManifest.Object, "status", "packageName")
 	if err != nil || !ok {
-		return fmt.Errorf("failed to get packageName in the pakcageManifest %q %w", desiredSub.Spec.Package, err)
+		return fmt.Errorf("failed to get packageName in the packageManifest %q %w", desiredSub.Spec.Package, err)
 	}
 
 	// Check if the package is deprecated
@@ -1566,15 +1563,9 @@ func (r *OperatorPolicyReconciler) updateDeprecationStatus(ctx context.Context,
 	}
 
 	// Check the selected channel is deprecated
-	selectedChannelName := desiredSub.Spec.Channel
-	if selectedChannelName == "" {
-		defaultChannel, ok, err := unstructured.NestedString(packageManifest.Object, "status", "defaultChannel")
-		if err != nil || !ok {
-			return fmt.Errorf("failed to retrieve default channel in PackageManifest %q: %w",
-				desiredSub.Spec.Package, err)
-		}
-
-		selectedChannelName = defaultChannel
+	selectedChannelName, err := r.getSelectedChannelName(packageManifest, desiredSub)
+	if err != nil {
+		return err
 	}
 
 	// Extract channels
@@ -1645,6 +1636,56 @@ func (r *OperatorPolicyReconciler) updateDeprecationStatus(ctx context.Context,
 	})
 
 	return nil
+}
+
+// updateMinorChannelUpgradeStatus checks if a newer minor version channel is available for the operator
+// when using automatic install plan approval, and updates the condition
+func (r *OperatorPolicyReconciler) updateMinorChannelUpgradeStatus(
+	policy *policyv1beta1.OperatorPolicy,
+	desiredSub *operatorv1alpha1.Subscription,
+	packageManifest *unstructured.Unstructured,
+) (bool, error) {
+	isManualUpgradeApproval := policy.Spec.UpgradeApproval != "Automatic"
+	resourcesNotFound := desiredSub == nil || packageManifest == nil
+
+	if !policy.Spec.ComplianceType.IsMustHave() || isManualUpgradeApproval || resourcesNotFound {
+		changed := updateStatus(policy, minorChannelOKCond("Skipped", "skipping check for minor channel upgrades"))
+
+		return changed, nil
+	}
+
+	selectedChannelName, err := r.getSelectedChannelName(packageManifest, desiredSub)
+	if err != nil {
+		return false, err
+	}
+
+	channels, ok, err := unstructured.NestedSlice(packageManifest.Object, "status", "channels")
+	if err != nil || !ok {
+		return false, fmt.Errorf("failed to retrieve channels in PackageManifest %q: %w", desiredSub.Spec.Package, err)
+	}
+
+	nextChannelNames, found := getNextMinorChannel(channels, selectedChannelName)
+	if !found {
+		changed := updateStatus(
+			policy, minorChannelOKCond("Recommended", "the subscription is on the recommended channel"))
+
+		return changed, nil
+	}
+
+	status := metav1.ConditionTrue
+	if policy.Spec.ComplianceConfig.MinorChannelUpgradeAvailable == policyv1beta1.NonCompliant {
+		status = metav1.ConditionFalse
+	}
+
+	changed := updateStatus(policy, metav1.Condition{
+		Type:   minorChannelConditionType,
+		Status: status,
+		Reason: "UpgradeAvailable",
+		Message: "a newer version of the operator is available in channel(s): " +
+			strings.Join(nextChannelNames, ", "),
+	})
+
+	return changed, nil
 }
 
 func (r *OperatorPolicyReconciler) considerResolutionFailed(
@@ -3007,6 +3048,117 @@ func (r *OperatorPolicyReconciler) mergeObjects(
 	}
 
 	return updateNeeded, false, nil
+}
+
+// getPackageManifest will get the PackageManifest from the API server
+func (r *OperatorPolicyReconciler) getPackageManifest(
+	ctx context.Context, packageName string,
+) (*unstructured.Unstructured, error) {
+	opLog := ctrl.LoggerFrom(ctx)
+
+	// PackageManifests come from an API server and not a Kubernetes resource, so the DynamicWatcher can't be used since
+	// it utilizes watches. The namespace doesn't have any meaning but is required.
+	packageManifest, err := r.DynamicClient.Resource(packageManifestGVR).Namespace("default").Get(
+		ctx, packageName, metav1.GetOptions{},
+	)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			opLog.Info("PackageManifest not found, proceeding without it",
+				"name", packageName)
+
+			return nil, nil
+		}
+
+		opLog.Error(err, "Failed to get the PackageManifest", "name", packageName)
+
+		return nil, err
+	}
+
+	return packageManifest, nil
+}
+
+func (r *OperatorPolicyReconciler) getSelectedChannelName(
+	packageManifest *unstructured.Unstructured, desiredSub *operatorv1alpha1.Subscription,
+) (string, error) {
+	selectedChannelName := desiredSub.Spec.Channel
+	if selectedChannelName == "" {
+		defaultChannel, ok, err := unstructured.NestedString(packageManifest.Object, "status", "defaultChannel")
+		if err != nil || !ok {
+			return "", errors.New(
+				"the default channel could not be determined because the PackageManifest didn't specify one")
+		}
+
+		selectedChannelName = defaultChannel
+	}
+
+	return selectedChannelName, nil
+}
+
+// getNextMinorChannel checks if there are newer minor channels available,
+// assuming channel naming patterns similar to unit tests
+// Returns the newer channel name if found, along with a boolean indicating success.
+func getNextMinorChannel(channels []interface{}, selectedChannelName string) ([]string, bool) {
+	if selectedChannelName == "" || len(channels) == 0 {
+		return nil, false
+	}
+
+	// find the version numbers in the selected channel name using regex
+	pattern := `^([a-zA-Z-]*)(\d+)\.(\d+)(\.x)?$`
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(selectedChannelName)
+
+	if matches == nil {
+		return nil, false
+	}
+
+	prefix := matches[1] // e.g., "my-operator-v", "openshift-virt-"
+	majorVersion := matches[2]
+	minorVersion := matches[3]
+	suffix := matches[4] // ".x" or ""
+
+	selectedMinorVersion, err := strconv.Atoi(minorVersion)
+	if err != nil {
+		return nil, false
+	}
+
+	nextChannelPattern := fmt.Sprintf(`^%s%s\.(\d+)%s$`, prefix, majorVersion, suffix)
+
+	nextRe, err := regexp.Compile(nextChannelPattern)
+	if err != nil {
+		return nil, false
+	}
+
+	nextChannelNames := make([]string, 0, len(channels))
+
+	for _, channel := range channels {
+		channelMap, ok := channel.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, ok := channelMap["name"].(string)
+		if !ok {
+			continue
+		}
+
+		matches := nextRe.FindStringSubmatch(name)
+		if matches == nil {
+			continue
+		}
+
+		nextMinorVersion, _ := strconv.Atoi(matches[1])
+		if nextMinorVersion > selectedMinorVersion {
+			nextChannelNames = append(nextChannelNames, name)
+		}
+	}
+
+	if len(nextChannelNames) == 0 {
+		return nil, false
+	}
+
+	slices.Sort(nextChannelNames)
+
+	return nextChannelNames, true
 }
 
 // subLabelSelector returns a selector that matches a label that OLM adds to resources

--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -10,6 +10,7 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -22,7 +23,9 @@ import (
 func TestBuildResources_SubscriptionErrorUpdatesStatus(t *testing.T) {
 	t.Parallel()
 
-	r := &OperatorPolicyReconciler{}
+	r := &OperatorPolicyReconciler{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	}
 
 	policy := &policyv1beta1.OperatorPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -49,7 +52,7 @@ func TestBuildResources_SubscriptionErrorUpdatesStatus(t *testing.T) {
 		},
 	}
 
-	_, _, changed, returnedErr := r.buildResources(t.Context(), policy)
+	_, _, _, changed, returnedErr := r.buildResources(t.Context(), policy) //nolint:dogsled
 	assert.True(t, changed, "expected status to be updated")
 	assert.NoError(t, returnedErr)
 
@@ -62,7 +65,9 @@ func TestBuildResources_SubscriptionErrorUpdatesStatus(t *testing.T) {
 func TestBuildResources_subInstallPlanApprovalErrorUpdatesStatus(t *testing.T) {
 	t.Parallel()
 
-	r := &OperatorPolicyReconciler{}
+	r := &OperatorPolicyReconciler{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	}
 
 	policy := &policyv1beta1.OperatorPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -90,7 +95,7 @@ func TestBuildResources_subInstallPlanApprovalErrorUpdatesStatus(t *testing.T) {
 		},
 	}
 
-	_, _, changed, returnedErr := r.buildResources(t.Context(), policy)
+	_, _, _, changed, returnedErr := r.buildResources(t.Context(), policy) //nolint:dogsled
 	assert.True(t, changed, "expected status to be updated")
 	assert.NoError(t, returnedErr)
 
@@ -134,7 +139,7 @@ func TestBuildResources_SubDefaultsPkgManifestNotFoundUpdatesStatusAndReturnsErr
 		},
 	}
 
-	sub, opGroup, changed, returnedErr := r.buildResources(t.Context(), policy)
+	sub, opGroup, packageManifest, changed, returnedErr := r.buildResources(t.Context(), policy)
 	assert.True(t, changed, "expected status to be updated")
 	assert.ErrorIs(t, returnedErr, ErrPackageManifest, "expected returned error to wrap ErrPackageManifest")
 
@@ -146,12 +151,26 @@ func TestBuildResources_SubDefaultsPkgManifestNotFoundUpdatesStatusAndReturnsErr
 		cond.Message)
 	assert.Nil(t, sub, "expected subscription to be nil")
 	assert.Nil(t, opGroup, "expected operator group to be nil")
+	assert.Nil(t, packageManifest, "expected package manifest to be nil")
 }
 
 func TestBuildResources_OperatorGroupErrorUpdatesStatus(t *testing.T) {
 	t.Parallel()
 
-	r := &OperatorPolicyReconciler{}
+	packageManifest := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "packages.operators.coreos.com/v1",
+			"kind":       "PackageManifest",
+			"metadata": map[string]interface{}{
+				"name":      "my-operator",
+				"namespace": "default",
+			},
+		},
+	}
+
+	r := &OperatorPolicyReconciler{
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), packageManifest),
+	}
 
 	policy := &policyv1beta1.OperatorPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -182,7 +201,7 @@ func TestBuildResources_OperatorGroupErrorUpdatesStatus(t *testing.T) {
 		},
 	}
 
-	_, _, changed, returnedErr := r.buildResources(t.Context(), policy)
+	_, _, _, changed, returnedErr := r.buildResources(t.Context(), policy) //nolint:dogsled
 	assert.True(t, changed, "expected status to be updated")
 	assert.NoError(t, returnedErr)
 
@@ -195,9 +214,7 @@ func TestBuildResources_OperatorGroupErrorUpdatesStatus(t *testing.T) {
 func TestBuildResources_TemplateResolverCreationErrorUpdatesStatus(t *testing.T) {
 	t.Parallel()
 
-	r := &OperatorPolicyReconciler{
-		DynamicWatcher: nil,
-	}
+	r := &OperatorPolicyReconciler{}
 
 	policy := &policyv1beta1.OperatorPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -223,11 +240,12 @@ func TestBuildResources_TemplateResolverCreationErrorUpdatesStatus(t *testing.T)
 		},
 	}
 
-	sub, opGroup, changed, returnedErr := r.buildResources(t.Context(), policy)
+	sub, opGroup, packageManifest, changed, returnedErr := r.buildResources(t.Context(), policy)
 	assert.True(t, changed, "expected status to be updated")
 	assert.NoError(t, returnedErr)
 	assert.Nil(t, sub, "expected subscription to be nil on early return")
 	assert.Nil(t, opGroup, "expected operator group to be nil on early return")
+	assert.Nil(t, packageManifest, "expected package manifest to be nil on early return")
 
 	_, cond := policy.Status.GetCondition(validPolicyConditionType)
 	assert.Equal(t, metav1.ConditionFalse, cond.Status)
@@ -699,5 +717,334 @@ func TestCanonicalizeVersions(t *testing.T) {
 
 	if !reflect.DeepEqual(policy.Spec.Versions, expected) {
 		t.Fatalf("Expected %v canonicalized versions, got %v", expected, policy.Spec.Versions)
+	}
+}
+
+func TestUpdateMinorChannelUpgradeStatus_PackageManifestNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := &OperatorPolicyReconciler{
+		// Use a fake dynamic client without any objects so PackageManifest GET returns NotFound
+		DynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	}
+
+	policy := &policyv1beta1.OperatorPolicy{
+		Spec: policyv1beta1.OperatorPolicySpec{
+			Severity:          "low",
+			RemediationAction: "inform",
+			ComplianceType:    "musthave",
+			UpgradeApproval:   "Automatic",
+			ComplianceConfig: policyv1beta1.ComplianceConfig{
+				MinorChannelUpgradeAvailable: "NonCompliant",
+			},
+		},
+	}
+
+	sub := &operatorv1alpha1.Subscription{
+		Spec: &operatorv1alpha1.SubscriptionSpec{
+			Package: "my-operator",
+			Channel: "stable",
+		},
+	}
+
+	changed, err := r.updateMinorChannelUpgradeStatus(policy, sub, nil)
+	assert.True(t, changed)
+	assert.NoError(t, err)
+
+	_, cond := policy.Status.GetCondition(minorChannelConditionType)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, "Skipped", cond.Reason)
+	assert.Equal(t, "skipping check for minor channel upgrades", cond.Message)
+}
+
+func TestUpdateMinorChannelUpgradeStatus_InstallPlanApprovalNotAutomatic(t *testing.T) {
+	t.Parallel()
+
+	r := &OperatorPolicyReconciler{}
+
+	policy := &policyv1beta1.OperatorPolicy{
+		Spec: policyv1beta1.OperatorPolicySpec{
+			Severity:          "low",
+			RemediationAction: "inform",
+			ComplianceType:    "musthave",
+			UpgradeApproval:   "None",
+			ComplianceConfig: policyv1beta1.ComplianceConfig{
+				MinorChannelUpgradeAvailable: "NonCompliant",
+			},
+		},
+	}
+
+	sub := &operatorv1alpha1.Subscription{
+		Spec: &operatorv1alpha1.SubscriptionSpec{
+			Package: "my-operator",
+			Channel: "stable",
+		},
+	}
+
+	pkgManifest := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"channels": []interface{}{
+					map[string]interface{}{"name": "stable"},
+				},
+			},
+		},
+	}
+
+	changed, err := r.updateMinorChannelUpgradeStatus(policy, sub, pkgManifest)
+	assert.True(t, changed)
+	assert.NoError(t, err)
+
+	_, cond := policy.Status.GetCondition(minorChannelConditionType)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, "Skipped", cond.Reason)
+	assert.Equal(t, "skipping check for minor channel upgrades", cond.Message)
+}
+
+func TestGetNewMinorChannel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		selectedChannel string
+		channels        []interface{}
+		expectedNames   []string
+		expectedFound   bool
+	}{
+		{
+			name:            "empty selected channel",
+			selectedChannel: "",
+			channels: []interface{}{
+				map[string]interface{}{"name": "fake-operatorv1.2"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "nil channel",
+			selectedChannel: "fake-operatorv1.3",
+			channels: []interface{}{
+				nil,
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "malformed channel name key",
+			selectedChannel: "fake-operatorv1.3",
+			channels: []interface{}{
+				map[string]interface{}{"notName": "fake-operatorv1.3"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "nil channels list",
+			selectedChannel: "fake-operatorv1.3",
+			channels:        nil,
+			expectedNames:   nil,
+			expectedFound:   false,
+		},
+		{
+			name:            "no newer channel available",
+			selectedChannel: "fake-operatorv1.3",
+			channels: []interface{}{
+				map[string]interface{}{"name": "fake-operatorv1.2"},
+				map[string]interface{}{"name": "fake-operatorv1.3"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "different channel prefix",
+			selectedChannel: "fake-operator-stablev1.3",
+			channels: []interface{}{
+				map[string]interface{}{"name": "fake-operator-stablev1.3"},
+				map[string]interface{}{"name": "fake-operator-fastv1.4"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "no minor version",
+			selectedChannel: "stable-pg-v13",
+			channels: []interface{}{
+				map[string]interface{}{"name": "stable-pg-v13"},
+				map[string]interface{}{"name": "stable-pg-v14"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "major version only",
+			selectedChannel: "stable-2.x",
+			channels: []interface{}{
+				map[string]interface{}{"name": "stable-2.x"},
+				map[string]interface{}{"name": "stable-3.x"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "bad minor version",
+			selectedChannel: "v1.bad.x",
+			channels: []interface{}{
+				map[string]interface{}{"name": "v1.1.x"},
+				map[string]interface{}{"name": "v1.2.x"},
+			},
+			expectedNames: nil,
+			expectedFound: false,
+		},
+		{
+			name:            "happy path: v2026.30 to v2026.40",
+			selectedChannel: "Fake-Operatorv2026.30",
+			channels: []interface{}{
+				map[string]interface{}{"name": "Fake-Operatorv2026.30"},
+				map[string]interface{}{"name": "Fake-Operatorv2026.40"},
+				map[string]interface{}{"name": "Fake-Operatorv2026.50"},
+			},
+			expectedNames: []string{"Fake-Operatorv2026.40", "Fake-Operatorv2026.50"},
+			expectedFound: true,
+		},
+		{
+			name:            "happy path: unsorted -1.2 to -1.3",
+			selectedChannel: "openshift-virt-1.2",
+			channels: []interface{}{
+				map[string]interface{}{"name": "openshift-virt-1.2"},
+				map[string]interface{}{"name": "openshift-virt-1.4"},
+				map[string]interface{}{"name": "openshift-virt-1.3"},
+			},
+			expectedNames: []string{"openshift-virt-1.3", "openshift-virt-1.4"},
+			expectedFound: true,
+		},
+		{
+			name:            "happy path: version only",
+			selectedChannel: "1.1.x",
+			channels: []interface{}{
+				map[string]interface{}{"name": "1.1.x"},
+				map[string]interface{}{"name": "1.2.x"},
+			},
+			expectedNames: []string{"1.2.x"},
+			expectedFound: true,
+		},
+		{
+			name:            "happy path: version with v prefix",
+			selectedChannel: "v1.1.x",
+			channels: []interface{}{
+				map[string]interface{}{"name": "v1.1.x"},
+				map[string]interface{}{"name": "v1.2.x"},
+			},
+			expectedNames: []string{"v1.2.x"},
+			expectedFound: true,
+		},
+		{
+			name:            "happy path: x.y version only",
+			selectedChannel: "3.17",
+			channels: []interface{}{
+				map[string]interface{}{"name": "3.17"},
+				map[string]interface{}{"name": "3.18"},
+			},
+			expectedNames: []string{"3.18"},
+			expectedFound: true,
+		},
+		{
+			name:            "happy path: x.y version only",
+			selectedChannel: "3.17",
+			channels: []interface{}{
+				map[string]interface{}{"name": "3.17"},
+				map[string]interface{}{"name": "3.18"},
+			},
+			expectedNames: []string{"3.18"},
+			expectedFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualNames, actualFound := getNextMinorChannel(tt.channels, tt.selectedChannel)
+
+			assert.Equal(t, tt.expectedFound, actualFound)
+			assert.Equal(t, tt.expectedNames, actualNames)
+		})
+	}
+}
+
+func TestGetSelectedChannelName(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		packageManifest  map[string]interface{}
+		expectedChannel  string
+		expectedError    bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "success with default channel",
+			packageManifest: map[string]interface{}{
+				"apiVersion": "packages.operators.coreos.com/v1",
+				"kind":       "PackageManifest",
+				"metadata": map[string]interface{}{
+					"name":      "my-operator",
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"defaultChannel": "stable",
+				},
+			},
+			expectedChannel: "stable",
+			expectedError:   false,
+		},
+		{
+			name: "error when defaultChannel is missing",
+			packageManifest: map[string]interface{}{
+				"apiVersion": "packages.operators.coreos.com/v1",
+				"kind":       "PackageManifest",
+				"metadata": map[string]interface{}{
+					"name":      "my-operator",
+					"namespace": "default",
+				},
+				"status": map[string]interface{}{
+					"notADefaultChannel": "stable",
+				},
+			},
+			expectedError: true,
+			expectedErrorMsg: "the default channel could not be determined " +
+				"because the PackageManifest didn't specify one",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			subscription := &operatorv1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-operator",
+					Namespace: "default",
+				},
+				Spec: &operatorv1alpha1.SubscriptionSpec{
+					Package: "my-operator",
+					Channel: "", // select default channel
+				},
+			}
+
+			packageManifest := &unstructured.Unstructured{
+				Object: tc.packageManifest,
+			}
+
+			r := &OperatorPolicyReconciler{}
+			channelName, err := r.getSelectedChannelName(packageManifest, subscription)
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedErrorMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedChannel, channelName)
+			}
+		})
 	}
 }

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -307,6 +307,19 @@ func calculateComplianceCondition(policy *policyv1beta1.OperatorPolicy) metav1.C
 		}
 	}
 
+	if !policy.Spec.ComplianceType.IsMustNotHave() &&
+		policy.Spec.ComplianceConfig.MinorChannelUpgradeAvailable == "NonCompliant" {
+		idx, cond = policy.Status.GetCondition(minorChannelConditionType)
+		if idx != -1 {
+			if cond.Status != metav1.ConditionTrue {
+				messages = append(messages, cond.Message)
+				foundNonCompliant = true
+			}
+		} else {
+			foundNonCompliant = true
+		}
+	}
+
 	message := strings.Join(messages, ", ")
 
 	prefix := "Compliant"
@@ -402,16 +415,17 @@ func (r *OperatorPolicyReconciler) emitComplianceEvent(
 }
 
 const (
-	compliantConditionType   = "Compliant"
-	validPolicyConditionType = "ValidPolicySpec"
-	opGroupConditionType     = "OperatorGroupCompliant"
-	subConditionType         = "SubscriptionCompliant"
-	csvConditionType         = "ClusterServiceVersionCompliant"
-	crdConditionType         = "CustomResourceDefinitionCompliant"
-	deploymentConditionType  = "DeploymentCompliant"
-	catalogSrcConditionType  = "CatalogSourcesUnhealthy"
-	installPlanConditionType = "InstallPlanCompliant"
-	deprecationType          = "NoDeprecations"
+	compliantConditionType    = "Compliant"
+	validPolicyConditionType  = "ValidPolicySpec"
+	opGroupConditionType      = "OperatorGroupCompliant"
+	subConditionType          = "SubscriptionCompliant"
+	csvConditionType          = "ClusterServiceVersionCompliant"
+	crdConditionType          = "CustomResourceDefinitionCompliant"
+	deploymentConditionType   = "DeploymentCompliant"
+	catalogSrcConditionType   = "CatalogSourcesUnhealthy"
+	installPlanConditionType  = "InstallPlanCompliant"
+	deprecationType           = "NoDeprecations"
+	minorChannelConditionType = "MinorChannelUpgradeAvailable"
 )
 
 func condType(kind string) string {
@@ -597,6 +611,17 @@ func updatedCond(kind string) metav1.Condition {
 		Status:  metav1.ConditionTrue,
 		Reason:  kind + "Updated",
 		Message: "the " + kind + " was updated to match the policy",
+	}
+}
+
+// minorChannelOKCond returns a Compliant condition indicating
+// the selected channel has no recommended minor version updates
+func minorChannelOKCond(reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:    minorChannelConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
 	}
 }
 

--- a/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/kustomize_operatorpolicy/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -79,6 +79,16 @@ spec:
                     - Compliant
                     - NonCompliant
                     type: string
+                  minorChannelUpgradeAvailable:
+                    default: Compliant
+                    description: |-
+                      MinorChannelUpgradeAvailable specifies how the availability of a newer minor version channel
+                      should affect overall policy compliance when spec.UpgradeApproval is Automatic. The default
+                      value is `Compliant`.
+                    enum:
+                    - Compliant
+                    - NonCompliant
+                    type: string
                   upgradesAvailable:
                     default: Compliant
                     description: |-

--- a/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_operatorpolicies.yaml
@@ -81,6 +81,16 @@ spec:
                     - Compliant
                     - NonCompliant
                     type: string
+                  minorChannelUpgradeAvailable:
+                    default: Compliant
+                    description: |-
+                      MinorChannelUpgradeAvailable specifies how the availability of a newer minor version channel
+                      should affect overall policy compliance when spec.UpgradeApproval is Automatic. The default
+                      value is `Compliant`.
+                    enum:
+                    - Compliant
+                    - NonCompliant
+                    type: string
                   upgradesAvailable:
                     default: Compliant
                     description: |-

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -1358,8 +1358,9 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 
 	Describe("Testing InstallPlan approval and status behavior", Ordered, func() {
 		const (
-			opPolYAML = "../resources/case38_operator_install/operator-policy-manual-upgrades.yaml"
-			subName   = "strimzi-kafka-operator"
+			opPolYAML           = "../resources/case38_operator_install/operator-policy-manual-upgrades.yaml"
+			subName             = "strimzi-kafka-operator"
+			desiredMinorVersion = 50
 		)
 		var (
 			opPolTestNS           string
@@ -1453,7 +1454,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			)
 		})
 		It("Should report an available install when informing", func(ctx SpecContext) {
-			goodVersion := "strimzi-cluster-operator.v0.36.0"
+			goodVersion := "strimzi-cluster-operator.v0.50.0"
 			Eventually(func(ctx SpecContext) int {
 				utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
 					`[{"op": "replace", "path": "/spec/subscription/startingCSV", "value": "`+goodVersion+`"},`+
@@ -1484,7 +1485,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 					Type:   "InstallPlanCompliant",
 					Status: metav1.ConditionTrue,
 					Reason: "InstallPlanRequiresApproval",
-					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.36.0] is available" +
+					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.50.0] is available" +
 						" for approval",
 				},
 				"an InstallPlan to update .* is available for approval",
@@ -1514,7 +1515,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 					Type:    "InstallPlanCompliant",
 					Status:  metav1.ConditionFalse,
 					Reason:  "InstallPlanRequiresApproval",
-					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.36.0] is available for approval",
+					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.50.0] is available for approval",
 				},
 				"an InstallPlan to update .* is available for approval",
 			)
@@ -1574,15 +1575,15 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 					Type:   "InstallPlanCompliant",
 					Status: metav1.ConditionFalse,
 					Reason: "InstallPlanRequiresApproval",
-					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.36.1] is available for " +
-						"approval but approval for [strimzi-cluster-operator.v0.36.1] is required",
+					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.50.1] is available for " +
+						"approval but approval for [strimzi-cluster-operator.v0.50.1] is required",
 				},
-				"the InstallPlan.*36.0.*was approved",
+				"the InstallPlan.*50.0.*was approved",
 			)
 		})
 		It("Should not approve an upgrade while upgradeApproval is None", func() {
 			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
-				`[{"op": "add", "path": "/spec/versions/-", "value": "strimzi-cluster-operator.v0.36.1"},`+
+				`[{"op": "add", "path": "/spec/versions/-", "value": "strimzi-cluster-operator.v0.50.1"},`+
 					`{"op": "replace", "path": "/spec/upgradeApproval", "value": "None"}]`)
 			check(
 				opPolName,
@@ -1603,9 +1604,9 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 					Type:    "InstallPlanCompliant",
 					Status:  metav1.ConditionFalse,
 					Reason:  "InstallPlanRequiresApproval",
-					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.36.1] is available for approval",
+					Message: "an InstallPlan to update to [strimzi-cluster-operator.v0.50.1] is available for approval",
 				},
-				"an InstallPlan.*36.*is available for approval",
+				"an InstallPlan.*50.*is available for approval",
 			)
 		})
 		It("Should approve the upgrade when upgradeApproval is changed to Automatic", func(ctx SpecContext) {
@@ -1641,7 +1642,83 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 					Reason:  "NoInstallPlansRequiringApproval",
 					Message: "no InstallPlans requiring approval were found",
 				},
-				"the InstallPlan.*36.*was approved",
+				"the InstallPlan.*50.*was approved",
+			)
+		})
+
+		It("Should update status when a newer minor version channel is available", func() {
+			By("Fetching the latest channel names")
+			pm := utils.GetWithTimeout(
+				targetK8sDynamic, gvrPackageManifest, "strimzi-kafka-operator", testNamespace, true, eventuallyTimeout)
+			Expect(pm).ToNot(BeNil())
+			channels, _, err := unstructured.NestedSlice(pm.Object, "status", "channels")
+			Expect(err).NotTo(HaveOccurred())
+
+			pattern := regexp.MustCompile(`^strimzi-0\.(\d+)\.x$`)
+			var laterChannels []string
+			for _, ch := range channels {
+				chMap, ok := ch.(map[string]interface{})
+				Expect(ok).To(BeTrue())
+
+				chName, ok := chMap["name"].(string)
+				Expect(ok).To(BeTrue())
+
+				if matches := pattern.FindStringSubmatch(chName); matches != nil {
+					if minor, _ := strconv.Atoi(matches[1]); minor > desiredMinorVersion {
+						laterChannels = append(laterChannels, chName)
+					}
+				}
+			}
+
+			Expect(laterChannels).NotTo(BeEmpty(), "expected at least one newer Strimzi minor channel")
+			slices.Sort(laterChannels)
+
+			expectedCond := metav1.Condition{
+				Type:   "MinorChannelUpgradeAvailable",
+				Status: metav1.ConditionTrue,
+				Reason: "UpgradeAvailable",
+				Message: "a newer version of the operator is available in channel(s): " +
+					strings.Join(laterChannels, ", "),
+			}
+
+			By("Checking the newer channel names are reported")
+			check(
+				opPolName,
+				true,
+				[]policyv1.RelatedObject{},
+				expectedCond,
+				"",
+			)
+
+			By("Patching the complianceConfig to NonCompliant when a newer minor version channel is available")
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
+				`[{"op": "replace",
+				"path": "/spec/complianceConfig/minorChannelUpgradeAvailable",
+				"value": "NonCompliant"}]`)
+
+			expectedNonCompliantCond := expectedCond
+			expectedNonCompliantCond.Status = metav1.ConditionFalse
+
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{},
+				expectedNonCompliantCond,
+				"",
+			)
+
+			By("Should be Compliant when minorChannelUpgradeAvailable config changes to Compliant")
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
+				`[{"op": "replace",
+			"path": "/spec/complianceConfig/minorChannelUpgradeAvailable",
+			"value": "Compliant"}]`)
+
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{},
+				expectedCond,
+				"",
 			)
 		})
 	})
@@ -4416,6 +4493,56 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 				g.Expect(sel).NotTo(HaveKey("matchLabels"))
 				g.Expect(sel).To(HaveKey("matchExpressions"))
 			}, olmWaitTimeout, 5).Should(Succeed())
+		})
+	})
+
+	Describe("Test complianceConfig options", func() {
+		const (
+			opPolYAML = "../resources/case38_operator_install/operator-policy-with-group-and-config.yaml"
+		)
+		var (
+			opPolName        string
+			parentPolicyName string
+		)
+
+		BeforeEach(func() {
+			opPolName = "oppol-with-group-and-config" + getTestSuffix()
+			parentPolicyName = getParentPolicyName()
+
+			preFunc()
+			setupPolicy(opPolYAML, opPolName, parentPolicyName)
+		})
+
+		It("Should be Compliant when there are no new minor version channels available", func() {
+			By("Enabling install plan approval by matching node selector to kind cluster ")
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p", "["+
+				`{"op": "replace", "path": "/spec/subscription/config/nodeSelector",`+
+				` "value": {"node-role.kubernetes.io/control-plane": ""}}`+
+				"]")
+
+			By("Enabling automatic upgrade approval")
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
+				`[{"op": "replace", "path": "/spec/upgradeApproval", "value": "Automatic"}]`)
+
+			By("Patching complianceConfig to NonCompliant")
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
+				`[{"op": "replace",
+				"path": "/spec/complianceConfig/minorChannelUpgradeAvailable",
+				"value": "NonCompliant"}]`)
+
+			By("Verifying the status is still Compliant")
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{},
+				metav1.Condition{
+					Type:    "MinorChannelUpgradeAvailable",
+					Status:  metav1.ConditionTrue,
+					Reason:  "Recommended",
+					Message: "the subscription is on the recommended channel",
+				},
+				"",
+			)
 		})
 	})
 })

--- a/test/resources/case38_operator_install/deprecation/all.yaml
+++ b/test/resources/case38_operator_install/deprecation/all.yaml
@@ -21,7 +21,7 @@ spec:
       - operator-policy-testns
   subscription:
     name: deprecation-operator
-    namespace: grc-dep
+    namespace: operator-policy-testns
     channel: alpha
     source: grc-mock-source
     sourceNamespace: olm

--- a/test/resources/case38_operator_install/deprecation/channel.yaml
+++ b/test/resources/case38_operator_install/deprecation/channel.yaml
@@ -21,7 +21,7 @@ spec:
       - operator-policy-testns
   subscription:
     name: dep-channel-operator
-    namespace: grc-dep
+    namespace: operator-policy-testns
     channel: alpha
     source: grc-mock-source
     sourceNamespace: olm

--- a/test/resources/case38_operator_install/operator-policy-manual-upgrades.yaml
+++ b/test/resources/case38_operator_install/operator-policy-manual-upgrades.yaml
@@ -20,12 +20,12 @@ spec:
     targetNamespaces:
       - operator-policy-testns
   subscription:
-    channel: strimzi-0.36.x
+    channel: strimzi-0.50.x
     name: strimzi-kafka-operator
     namespace: operator-policy-testns
     source: operatorhubio-catalog
     sourceNamespace: olm
     startingCSV: strimzi-cluster-operator.v0.0.0.1337 # shouldn't match a real version
   versions:
-    - strimzi-cluster-operator.v0.36.0
+    - strimzi-cluster-operator.v0.50.0
   upgradeApproval: None


### PR DESCRIPTION
Added `spec.ComplianceConfig.MinorChannelUpgradeAvailable` to check if a newer minor version of the operator exists on a different channel. `MinorChannelUpgradeAvailable` only affects compliance when `InstallPlanApproval` is `Automatic` and the operator channels include the minor version number in the channel names.

Moved duplicate code to fetch packagemanifest and channels into helpers.

ref: https://issues.redhat.com/browse/ACM-30371

Channel name parsing assisted by Cursor/Claude 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compliance option to detect recommended newer minor release channels and a corresponding status condition; CRD schema updated with the new field (default: Compliant).

* **Behavior**
  * Policy status now reports a minor-channel upgrade condition when automatic upgrades and the new setting are applicable; checks are skipped if channel data is unavailable.

* **Tests**
  * Added and expanded unit and e2e tests covering channel selection, minor-channel detection, status transitions, and updated test fixtures/versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->