### PR TITLE
fix: Allow multiple object-templates to point to the same object

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -5,7 +5,9 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
@@ -2432,7 +2434,7 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 		created := false
 		uid := string(obj.existingObj.GetUID())
 
-		if evaluated, compliant, cachedMsg := r.alreadyEvaluated(obj.policy, obj.existingObj); evaluated {
+		if evaluated, compliant, cachedMsg := r.alreadyEvaluated(obj.policy, obj.existingObj, objectT); evaluated {
 			objLog.V(1).Info("Skipping object comparison since the resourceVersion hasn't changed")
 
 			for _, relatedObj := range obj.policy.Status.RelatedObjects {
@@ -3275,13 +3277,13 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	if !updateNeeded && !missingKey {
 		if !statusMismatch {
 			// No spec changes needed, and no status mismatch, so it's Compliant.
-			r.setEvaluatedObject(obj.policy, obj.existingObj, true, "")
+			r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, true, "")
 
 			return false, "", "", updateNeeded, updatedObj, false
 		}
 
 		// No spec changes needed, but the status mismatches, so it's NonCompliant.
-		r.setEvaluatedObject(obj.policy, obj.existingObj, false, "")
+		r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, "")
 
 		return true, "", diff, updateNeeded, updatedObj, false
 	}
@@ -3324,7 +3326,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 
 			// If the user specifies an unknown or invalid field, it comes back as a bad request.
 			if k8serrors.IsBadRequest(err) {
-				r.setEvaluatedObject(obj.policy, obj.existingObj, false, message)
+				r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, message)
 			}
 
 			return true, message, "", updateNeeded, nil, false
@@ -3351,7 +3353,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 					`you may set spec["object-templates"][].recreateOption to recreate the object`
 			}
 
-			r.setEvaluatedObject(obj.policy, obj.existingObj, false, message)
+			r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, message)
 
 			return true, message, diff, false, nil, false
 		}
@@ -3366,13 +3368,13 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 			log.Info("A mismatch was detected but a dry run update didn't make any changes.")
 
 			if !statusMismatch {
-				r.setEvaluatedObject(obj.policy, obj.existingObj, true, "")
+				r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, true, "")
 
 				return false, "", "", false, updatedObj, true
 			}
 
 			// No spec changes needed, but the status is incorrect, so it's NonCompliant.
-			r.setEvaluatedObject(obj.policy, obj.existingObj, false, "")
+			r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, "")
 
 			return true, "", diff, updateNeeded, updatedObj, false
 		}
@@ -3382,7 +3384,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 
 	// The object would have been updated, so if it's inform, return as noncompliant.
 	if isInform {
-		r.setEvaluatedObject(obj.policy, obj.existingObj, false, "")
+		r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, "")
 
 		return true, "", diff, false, nil, false
 	}
@@ -3462,7 +3464,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	}
 
 	if !statusMismatch {
-		r.setEvaluatedObject(obj.policy, updatedObj, true, message)
+		r.setEvaluatedObject(obj.policy, updatedObj, objectT, true, message)
 	}
 
 	return throwViolation, "", diff, updateNeeded, updatedObj, false
@@ -3650,7 +3652,11 @@ func removeFieldsForComparison(obj *unstructured.Unstructured) {
 // setEvaluatedObject updates the cache to indicate that the ConfigurationPolicy has evaluated this
 // object at its current resourceVersion.
 func (r *ConfigurationPolicyReconciler) setEvaluatedObject(
-	policy *policyv1.ConfigurationPolicy, currentObject *unstructured.Unstructured, compliant bool, msg string,
+	policy *policyv1.ConfigurationPolicy,
+	currentObject *unstructured.Unstructured,
+	objectT *policyv1.ObjectTemplate,
+	compliant bool,
+	msg string,
 ) {
 	policyMap := &sync.Map{}
 
@@ -3660,7 +3666,7 @@ func (r *ConfigurationPolicyReconciler) setEvaluatedObject(
 	}
 
 	policyMap.Store(
-		currentObject.GetUID(),
+		getEvalObjKey(currentObject.GetUID(), objectT),
 		cachedEvaluationResult{
 			resourceVersion: currentObject.GetResourceVersion(),
 			compliant:       compliant,
@@ -3669,10 +3675,12 @@ func (r *ConfigurationPolicyReconciler) setEvaluatedObject(
 	)
 }
 
-// alreadyEvaluated will determine if this ConfigurationPolicy has already evaluated this object at its current
-// resourceVersion.
+// alreadyEvaluated will determine if this ConfigurationPolicy's object template
+// has already evaluated this object at its current resourceVersion.
 func (r *ConfigurationPolicyReconciler) alreadyEvaluated(
-	policy *policyv1.ConfigurationPolicy, currentObject *unstructured.Unstructured,
+	policy *policyv1.ConfigurationPolicy,
+	currentObject *unstructured.Unstructured,
+	objectT *policyv1.ObjectTemplate,
 ) (evaluated bool, compliant bool, msg string) {
 	if policy == nil || currentObject == nil {
 		return false, false, ""
@@ -3685,7 +3693,7 @@ func (r *ConfigurationPolicyReconciler) alreadyEvaluated(
 
 	policyMap := loadedPolicyMap.(*sync.Map)
 
-	result, loaded := policyMap.Load(currentObject.GetUID())
+	result, loaded := policyMap.Load(getEvalObjKey(currentObject.GetUID(), objectT))
 	if !loaded {
 		return false, false, ""
 	}
@@ -3696,6 +3704,24 @@ func (r *ConfigurationPolicyReconciler) alreadyEvaluated(
 		resultTyped.resourceVersion == currentObject.GetResourceVersion()
 
 	return alreadyEvaluated, resultTyped.compliant, resultTyped.msg
+}
+
+// getEvalObjKey returns a key for the cached policy map based on the
+// object UID and hash of the object template. This allows multiple object templates
+// to evaluate the same object without overwriting the cache.
+func getEvalObjKey(objUID types.UID, objectT *policyv1.ObjectTemplate) string {
+	if objectT == nil {
+		return string(objUID)
+	}
+
+	templateBytes, err := json.Marshal(objectT)
+	if err != nil {
+		templateBytes = objectT.ObjectDefinition.Raw
+	}
+
+	sum := sha256.Sum256(templateBytes)
+
+	return fmt.Sprintf("%s%s", objUID, hex.EncodeToString(sum[:]))
 }
 
 func getUpdateErrorMsg(err error, kind string, name string) string {

--- a/test/e2e/case5_multi_test.go
+++ b/test/e2e/case5_multi_test.go
@@ -95,4 +95,91 @@ var _ = Describe("Test multiple obj template handling", Ordered, func() {
 			deletePods(pods, namespaces)
 		})
 	})
+
+	Describe("Test multiple object definitions targeting same object", Ordered, func() {
+		const (
+			podConfigmapPolicyName string = "policy-create-pod-configmap"
+			sameObjPolicyName      string = "policy-pod-multiple-same-obj-name"
+			sameObjDefPolicyName   string = "policy-configmap-multiple-same-obj-def"
+			podConfigmapYaml       string = "../resources/case5_multi/case5_pod_configmap.yaml"
+			sameObjPolicyYaml      string = "../resources/case5_multi/case5_multi_same_obj_name.yaml"
+			sameObjDefYaml         string = "../resources/case5_multi/case5_multi_same_objdef.yaml"
+		)
+
+		BeforeAll(func() {
+			By("Creating nginx pod and configmap with enforce policy from case5")
+			utils.Kubectl("apply", "-f", podConfigmapYaml, "-n", testNamespace)
+			pod := utils.GetWithTimeout(clientManagedDynamic, gvrPod,
+				podName1, "default", true, defaultTimeoutSeconds)
+			Expect(pod).NotTo(BeNil())
+		})
+
+		type testCase struct {
+			policyName string
+			policyYaml string
+			desc       string
+		}
+
+		DescribeTable("should evaluate object definitions and apply enforcement",
+			func(tc testCase) {
+				By("Creating " + tc.policyName + " with object-templates targeting the same pod")
+				utils.Kubectl("apply", "-f", tc.policyYaml, "-n", testNamespace)
+				plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					tc.policyName, testNamespace, true, defaultTimeoutSeconds)
+				Expect(plc).NotTo(BeNil())
+
+				Eventually(func(g Gomega) {
+					By("Verifying the policy is NonCompliant")
+					managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+						tc.policyName, testNamespace, true, defaultTimeoutSeconds)
+
+					utils.CheckComplianceStatus(g, managedPlc, "NonCompliant")
+
+					By("Verifying both compliancyDetails entries exist")
+					details, _, _ := unstructured.NestedSlice(managedPlc.Object, "status", "compliancyDetails")
+					g.Expect(details).To(HaveLen(2))
+				}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+				By("Changing the policy to enforce mode")
+				utils.EnforceConfigurationPolicy(tc.policyName, testNamespace)
+				plc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+					tc.policyName, testNamespace, true, defaultTimeoutSeconds)
+				Expect(plc).NotTo(BeNil())
+
+				Eventually(func(g Gomega) {
+					By("Verifying the pod is Compliant")
+					managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+						tc.policyName, testNamespace, true, defaultTimeoutSeconds)
+					utils.CheckComplianceStatus(g, managedPlc, "Compliant")
+				}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+				By("Deleting policy " + tc.policyName)
+				deleteConfigPolicies([]string{tc.policyName})
+
+				By("Resetting the pod for the next test case")
+				deletePods([]string{podName1}, []string{"default"})
+				utils.Kubectl("apply", "-f", podConfigmapYaml, "-n", testNamespace)
+				pod := utils.GetWithTimeout(clientManagedDynamic, gvrPod,
+					podName1, "default", true, defaultTimeoutSeconds)
+				Expect(pod).NotTo(BeNil())
+				configmap := utils.GetWithTimeout(clientManagedDynamic, gvrConfigMap,
+					"case5-configmap-1", "default", true, defaultTimeoutSeconds)
+				Expect(configmap).NotTo(BeNil())
+			},
+			Entry("with same object name", testCase{
+				policyName: sameObjPolicyName,
+				policyYaml: sameObjPolicyYaml,
+				desc:       "policy-pod-multiple-same-obj-name",
+			}),
+			Entry("with same object definition and different complianceType", testCase{
+				policyName: sameObjDefPolicyName,
+				policyYaml: sameObjDefYaml,
+				desc:       "policy-configmap-multiple-same-obj-def",
+			}),
+		)
+
+		AfterAll(func() {
+			deleteConfigPolicies([]string{podConfigmapPolicyName, sameObjPolicyName, sameObjDefPolicyName})
+		})
+	})
 })

--- a/test/resources/case5_multi/case5_multi_same_obj_name.yaml
+++ b/test/resources/case5_multi/case5_multi_same_obj_name.yaml
@@ -1,0 +1,29 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-multiple-same-obj-name
+  namespace: managed
+spec:
+  remediationAction: inform
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-nginx-pod-1
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-nginx-pod-1
+        spec:
+          activeDeadlineSeconds: 300

--- a/test/resources/case5_multi/case5_multi_same_objdef.yaml
+++ b/test/resources/case5_multi/case5_multi_same_objdef.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-configmap-multiple-same-obj-def
+  namespace: managed
+spec:
+  remediationAction: inform
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case5-configmap-1
+        data:
+          name: testvalue
+    - complianceType: mustonlyhave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case5-configmap-1
+        data:
+          name: testvalue

--- a/test/resources/case5_multi/case5_pod_configmap.yaml
+++ b/test/resources/case5_multi/case5_pod_configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-create-pod-configmap
+  namespace: managed
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: case5-nginx-pod-1
+        spec:
+          containers:
+            - image: nginx:1.7.9
+              name: nginx
+              ports:
+                - containerPort: 80
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: case5-configmap-1
+        data:
+          name: testvalue
+          env: staging


### PR DESCRIPTION
Prevent `ConfigurationPolicy` from skipping evaluation of subsequent object-templates when multiple object-templates point to the same object ([link](https://github.com/open-cluster-management-io/config-policy-controller/blob/main/controllers/configurationpolicy_controller.go#L2435)) AND the policy does not contain object-templates-raw ([link](https://github.com/open-cluster-management-io/config-policy-controller/blob/main/controllers/configurationpolicy_controller.go#L820)).

There was discussion about surfacing this behaviour as a warning, but ConfigurationPolicy already evaluates multiple object-templates for the same object when the object selector contains go templates. Multiple authors working on the same `ConfigurationPolicy` should not need to consider if their objects overlap with other author's object-templates.

ref: https://redhat.atlassian.net/browse/ACM-15052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed compliance evaluation cache to correctly handle multiple templates targeting the same Kubernetes object. Compliance results are now isolated per template, preventing incorrect cache reuse across different template configurations.

* **Tests**
  * Added end-to-end test suite validating multi-template policy scenarios with comprehensive compliance validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->