### PR TITLE
test: replace quay-operator tests

### DIFF
--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -496,7 +496,6 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Testing an operator policy with invalid partial defaults", func() {
 		const (
 			opPolYAML = "../resources/case38_operator_install/operator-policy-defaults-invalid-source.yaml"
-			subName   = "project-quay"
 		)
 		var (
 			opPolName        string
@@ -851,7 +850,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Testing Subscription behavior for musthave mode while enforcing", Ordered, func() {
 		const (
 			opPolYAML        = "../resources/case38_operator_install/operator-policy-with-group.yaml"
-			subName          = "project-quay"
+			subName          = "example-operator"
 			extraOpGroupYAML = "../resources/case38_operator_install/extra-operator-group.yaml"
 			extraOpGroupName = "extra-operator-group"
 		)
@@ -1016,7 +1015,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Testing Subscription behavior for musthave mode while informing", Ordered, func() {
 		const (
 			opPolYAML = "../resources/case38_operator_install/operator-policy-no-group.yaml"
-			subName   = "project-quay"
+			subName   = "example-operator"
 			subYAML   = "../resources/case38_operator_install/subscription.yaml"
 		)
 		var (
@@ -1172,8 +1171,8 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Test status reporting for CatalogSource", Serial, Ordered, func() {
 		const (
 			opPolYAML  = "../resources/case38_operator_install/operator-policy-with-group.yaml"
-			subName    = "project-quay"
-			catSrcName = "operatorhubio-catalog"
+			subName    = "example-operator"
+			catSrcName = "grc-mock-source"
 		)
 		var (
 			opPolTestNS      string
@@ -1191,12 +1190,13 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				By("Fixing the catalog source")
 				KubectlTarget("patch", "catalogsource", catSrcName, "-n", "olm", "--type=json", "-p",
-					`[{"op": "replace", "path": "/spec/image", "value": "quay.io/operatorhubio/catalog:latest"}]`)
+					`[{"op": "replace", "path": "/spec/image",`+
+						`"value": "quay.io/stolostron-grc/grc-mock-operators-catalog:latest"}]`)
 
 				By("Waiting for a packagemanifest to reappear")
 				Eventually(func() error {
 					_, err := targetK8sDynamic.Resource(gvrPackageManifest).Namespace("default").Get(
-						ctx, "project-quay", metav1.GetOptions{})
+						ctx, subName, metav1.GetOptions{})
 
 					return err
 				}, olmWaitTimeout*2, 3).Should(Succeed())
@@ -1293,11 +1293,11 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 		It("Should report unhealthy status when CatalogSource fails", func() {
 			By("Patching the policy to point to an existing CatalogSource")
 			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
-				`[{"op": "replace", "path": "/spec/subscription/source", "value": "operatorhubio-catalog"}]`)
+				`[{"op": "replace", "path": "/spec/subscription/source", "value": "grc-mock-source"}]`)
 
 			By("Patching the CatalogSource to reference a broken image link")
 			KubectlTarget("patch", "catalogsource", catSrcName, "-n", "olm", "--type=json", "-p",
-				`[{"op": "replace", "path": "/spec/image", "value": "quay.io/operatorhubio/fakecatalog:latest"}]`)
+				`[{"op": "replace", "path": "/spec/image", "value": "quay.io/stolostron-grc/fakecatalog:latest"}]`)
 
 			By("Checking the conditions and relatedObj in the policy")
 			check(
@@ -1726,7 +1726,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Testing OperatorPolicy validation messages", Ordered, func() {
 		const (
 			opPolYAML = "../resources/case38_operator_install/operator-policy-validity-test.yaml"
-			subName   = "project-quay"
+			subName   = "example-operator"
 		)
 		var (
 			opPolTestNS      string
@@ -3346,7 +3346,6 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Test mustnothave message when the namespace does not exist", func() {
 		const (
 			opPolYAML = "../resources/case38_operator_install/operator-policy-no-group.yaml"
-			subName   = "project-quay"
 		)
 		var (
 			opPolName        string
@@ -3453,7 +3452,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Testing operator policies that specify the same subscription", Serial, Ordered, FlakeAttempts(2), func() {
 		const (
 			musthaveYAML    = "../resources/case38_operator_install/operator-policy-no-group.yaml"
-			mustnothaveYAML = "../resources/case38_operator_install/operator-policy-mustnothave-any-version-quay.yaml"
+			mustnothaveYAML = "../resources/case38_operator_install/operator-policy-mustnothave-any-version-grc.yaml"
 		)
 		var (
 			musthaveName     string
@@ -3633,7 +3632,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			opPolYAML     = "../resources/case38_operator_install/operator-policy-with-templates.yaml"
 			configmapYAML = "../resources/case38_operator_install/template-configmap.yaml"
 			opGroupName   = "scoped-operator-group"
-			subName       = "project-quay"
+			subName       = "example-operator"
 		)
 		var (
 			opPolTestNS      string
@@ -3724,7 +3723,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 
 		It("Should update the subscription after the configmap is updated", func() {
 			KubectlTarget("patch", "configmap", "op-config", "-n", opPolTestNS, "--type=json", "-p",
-				`[{"op": "replace", "path": "/data/channel", "value": "stable-3.10"}]`)
+				`[{"op": "replace", "path": "/data/channel", "value": "stable"}]`)
 
 			check(
 				opPolName,
@@ -4341,6 +4340,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 	Describe("Test changes to subscription config and operator group selector", Ordered, func() {
 		const (
 			policyYAML = "../resources/case38_operator_install/operator-policy-with-group-and-config.yaml"
+			subName    = "example-operator"
 		)
 
 		var (
@@ -4384,7 +4384,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			By("Verifying the initial state of the config in the subscription")
 			Eventually(func(g Gomega) {
 				sub, err := targetK8sDynamic.Resource(gvrSubscription).Namespace(opPolTestNS).
-					Get(ctx, "example-operator", metav1.GetOptions{})
+					Get(ctx, subName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(sub).NotTo(BeNil())
 
@@ -4424,7 +4424,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			By("Verifying the new state of the config in the subscription")
 			Eventually(func(g Gomega) {
 				sub, err := targetK8sDynamic.Resource(gvrSubscription).Namespace(opPolTestNS).
-					Get(ctx, "example-operator", metav1.GetOptions{})
+					Get(ctx, subName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(sub).NotTo(BeNil())
 
@@ -4465,7 +4465,7 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			By("Verifying the final state of the config in the subscription")
 			Eventually(func(g Gomega) {
 				sub, err := targetK8sDynamic.Resource(gvrSubscription).Namespace(opPolTestNS).
-					Get(ctx, "example-operator", metav1.GetOptions{})
+					Get(ctx, subName, metav1.GetOptions{})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(sub).NotTo(BeNil())
 

--- a/test/resources/case38_operator_install/operator-policy-defaults-invalid-source.yaml
+++ b/test/resources/case38_operator_install/operator-policy-defaults-invalid-source.yaml
@@ -15,7 +15,7 @@ spec:
   severity: medium
   complianceType: musthave
   subscription:
-    name: project-quay
+    name: example-operator
     namespace: operator-policy-testns
     source: wrong
   upgradeApproval: None

--- a/test/resources/case38_operator_install/operator-policy-mustnothave-any-version-grc.yaml
+++ b/test/resources/case38_operator_install/operator-policy-mustnothave-any-version-grc.yaml
@@ -15,10 +15,10 @@ spec:
   severity: medium
   complianceType: mustnothave
   subscription:
-    channel: stable-3.10
-    name: project-quay
+    channel: stable
+    name: example-operator
     namespace: operator-policy-testns
-    source: operatorhubio-catalog
+    source: grc-mock-source
     sourceNamespace: olm
   upgradeApproval: Automatic
   removalBehavior:

--- a/test/resources/case38_operator_install/operator-policy-no-group.yaml
+++ b/test/resources/case38_operator_install/operator-policy-no-group.yaml
@@ -15,10 +15,10 @@ spec:
   severity: medium
   complianceType: musthave
   subscription:
-    channel: stable-3.10
-    name: project-quay
+    channel: stable
+    name: example-operator
     namespace: operator-policy-testns
-    source: operatorhubio-catalog
+    source: grc-mock-source
     sourceNamespace: olm
-    startingCSV: quay-operator.v3.10.0
+    startingCSV: example-operator.v0.0.3
   upgradeApproval: Automatic

--- a/test/resources/case38_operator_install/operator-policy-validity-test.yaml
+++ b/test/resources/case38_operator_install/operator-policy-validity-test.yaml
@@ -22,11 +22,11 @@ spec:
       - operator-policy-testns
   subscription:
     actually: incorrect
-    channel: stable-3.10
-    name: project-quay
+    channel: stable
+    name: example-operator
     namespace: nonexist-testns
     installPlanApproval: Automatic
-    source: operatorhubio-catalog
+    source: grc-mock-source
     sourceNamespace: olm
-    startingCSV: quay-operator.v3.10.0
+    startingCSV: example-operator.v0.0.3
   upgradeApproval: None

--- a/test/resources/case38_operator_install/operator-policy-with-group.yaml
+++ b/test/resources/case38_operator_install/operator-policy-with-group.yaml
@@ -20,10 +20,10 @@ spec:
     targetNamespaces:
       - operator-policy-testns
   subscription:
-    channel: stable-3.10
-    name: project-quay
+    channel: stable
+    name: example-operator
     namespace: operator-policy-testns
-    source: operatorhubio-catalog
+    source: grc-mock-source
     sourceNamespace: olm
-    startingCSV: quay-operator.v3.10.0
+    startingCSV: example-operator.v0.0.3
   upgradeApproval: Automatic

--- a/test/resources/case38_operator_install/operator-policy-with-templates.yaml
+++ b/test/resources/case38_operator_install/operator-policy-with-templates.yaml
@@ -20,9 +20,9 @@ spec:
     targetNamespaces: '{{ (fromConfigMap "operator-policy-testns" "op-config" "namespaces") | toLiteral }}'
   subscription:
     channel: '{{ (lookup "v1" "ConfigMap" "operator-policy-testns" "op-config").data.channel }}'
-    name: project-quay
+    name: example-operator
     namespace: operator-policy-testns
-    source: operatorhubio-catalog
+    source: grc-mock-source
     sourceNamespace: olm
-    startingCSV: quay-operator.v3.10.0
+    startingCSV: example-operator.v0.0.3
   upgradeApproval: Automatic

--- a/test/resources/case38_operator_install/subscription.yaml
+++ b/test/resources/case38_operator_install/subscription.yaml
@@ -1,11 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: project-quay
+  name: example-operator
 spec:
-  channel: stable-3.10
-  name: project-quay
+  channel: stable
+  name: example-operator
   installPlanApproval: Automatic
-  source: operatorhubio-catalog
+  source: grc-mock-source
   sourceNamespace: olm
-  startingCSV: quay-operator.v3.10.0
+  startingCSV: example-operator.v0.0.3


### PR DESCRIPTION
The operator created in some OperatorPolicy tests was removed from OperatorHub. Replace with grc example operator.

It turns out the cluster-scoped test that deployed `quay-operator` was already running as `Serial`. I used `example-operator` for the replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and scenarios to use updated operator package and catalog source references across multiple test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->