### PR TITLE
fix: ignore startingCSV only in subscription

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,11 @@ e2e-stop-instrumented:
 
 .PHONY: e2e-debug
 e2e-debug:
+	@echo running pods:
+	-kubectl get pods -A
+	@echo "::group::describe pods"
+	-kubectl describe pods -A
+	@echo "::endgroup::"
 	@echo local controller log:
 	-cat build/_output/controller.log
 	@echo remote controller log:

--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -903,6 +903,25 @@ func canonicalizeVersions(policy *policyv1beta1.OperatorPolicy) {
 	policy.Spec.Versions = nonEmptyVersions
 }
 
+// policyStartingCSV extracts the startingCSV from the policy's subscription spec,
+// returning an empty string if it's not set or the spec can't be parsed.
+func policyStartingCSV(policy *policyv1beta1.OperatorPolicy) string {
+	raw := policy.Spec.Subscription.Raw
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var sub struct {
+		StartingCSV string `json:"startingCSV"` //nolint: tagliatelle
+	}
+
+	if err := json.Unmarshal(raw, &sub); err != nil {
+		return ""
+	}
+
+	return sub.StartingCSV
+}
+
 // buildSubscription bootstraps the subscription spec defined in the operator policy
 // with the apiversion and kind in preparation for resource creation.
 // If an error is returned, it will include details on why the policy spec if invalid and
@@ -2268,8 +2287,8 @@ func getApprovedCSVs(
 			}
 		}
 
-		if sub.Spec != nil && sub.Spec.StartingCSV != "" {
-			allowedCSVs = append(allowedCSVs, policyv1.NonEmptyString(sub.Spec.StartingCSV))
+		if startingCSV := policyStartingCSV(policy); startingCSV != "" {
+			allowedCSVs = append(allowedCSVs, policyv1.NonEmptyString(startingCSV))
 		}
 
 		for _, allowedCSV := range allowedCSVs {
@@ -2489,8 +2508,8 @@ func (r *OperatorPolicyReconciler) handleCSV(
 			}
 		}
 
-		if sub.Spec.StartingCSV != "" {
-			allowedVersions = append(allowedVersions, policyv1.NonEmptyString(sub.Spec.StartingCSV))
+		if startingCSV := policyStartingCSV(policy); startingCSV != "" {
+			allowedVersions = append(allowedVersions, policyv1.NonEmptyString(startingCSV))
 		}
 
 		allowed := false

--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -572,6 +572,84 @@ func TestGetApprovedCSVs(t *testing.T) {
 	}
 }
 
+// TestGetApprovedCSVs_AdoptedStartingCSVNotInVersions verifies that when an OperatorPolicy adopts
+// an existing Subscription whose startingCSV is not in the policy's versions list, that startingCSV
+// should NOT be treated as an approved version. This is a regression test for a bug where the
+// controller unconditionally appended sub.Spec.StartingCSV to the allowed versions, even when the
+// policy itself did not specify that startingCSV.
+func TestGetApprovedCSVs_AdoptedStartingCSVNotInVersions(t *testing.T) {
+	// This InstallPlan is in `phase: RequiresApproval`, and contains the v4.16.3-rhodf version.
+	odfIPRaw, err := os.ReadFile("../test/resources/unit/odf-installplan.yaml")
+	if err != nil {
+		t.Fatalf("Encountered an error when reading the odf-installplan.yaml: %v", err)
+	}
+
+	odfIP := &operatorv1alpha1.InstallPlan{}
+
+	err = yaml.Unmarshal(odfIPRaw, odfIP)
+	if err != nil {
+		t.Fatalf("Encountered an error when unmarshaling the odf-installplan.yaml: %v", err)
+	}
+
+	// The policy allows some-other-operator.v1.0.0 and does NOT specify a startingCSV.
+	policy := &policyv1beta1.OperatorPolicy{
+		Spec: policyv1beta1.OperatorPolicySpec{
+			UpgradeApproval:   "Automatic",
+			RemediationAction: "enforce",
+			Versions:          []string{"some-other-operator.v1.0.0"},
+		},
+	}
+
+	// The adopted Subscription has a startingCSV that is NOT in the policy's versions list.
+	// The Subscription's CurrentCSV matches the startingCSV (not the policy's allowed version).
+	subscription := &operatorv1alpha1.Subscription{
+		Spec: &operatorv1alpha1.SubscriptionSpec{
+			StartingCSV: "odf-operator.v4.16.3-rhodf",
+		},
+		Status: operatorv1alpha1.SubscriptionStatus{
+			CurrentCSV: "odf-operator.v4.16.3-rhodf",
+		},
+	}
+
+	// The Subscription's startingCSV (v4.16.3) is not in the policy versions list, and the
+	// policy did not specify a startingCSV, so getApprovedCSVs should return nil, because the
+	// current version in the Subscription should not be allowed by the policy.
+	csvs := getApprovedCSVs(t.Context(), policy, subscription, odfIP)
+	if len(csvs) != 0 {
+		t.Fatalf(
+			"Expected no CSVs to be approved when the adopted Subscription's startingCSV "+
+				"is not in the policy versions, but got: %s",
+			strings.Join(csvs.UnsortedList(), ", "),
+		)
+	}
+
+	// Now simulate the policy specifying the startingCSV in its subscription spec.
+	// When the policy itself sets startingCSV, that version should be treated as allowed
+	// even if it's not in the versions list.
+	policy.Spec.Subscription = runtime.RawExtension{
+		Raw: []byte(`{
+			"source": "operatorhubio-catalog",
+			"sourceNamespace": "olm",
+			"name": "odf-operator",
+			"channel": "stable-4.16",
+			"startingCSV": "odf-operator.v4.16.3-rhodf"
+		}`),
+	}
+
+	csvs = getApprovedCSVs(t.Context(), policy, subscription, odfIP)
+
+	expectedCSVs := sets.Set[string]{}
+	expectedCSVs.Insert(odfIP.Spec.ClusterServiceVersionNames...)
+
+	if !csvs.Equal(expectedCSVs) {
+		t.Fatalf(
+			"Expected all CSVs to be approved when the policy specifies the startingCSV, "+
+				"but missing: %s",
+			strings.Join(expectedCSVs.Difference(csvs).UnsortedList(), ", "),
+		)
+	}
+}
+
 func TestGetApprovedCSVsWithPackageNameLookup(t *testing.T) {
 	mtcOadpIPRaw, err := os.ReadFile("../test/resources/unit/mtc-oadp-installplan.yaml")
 	if err != nil {


### PR DESCRIPTION
Previously, the `startingCSV` in a Subscription that was adopted by an OperatorPolicy could be incorrectly considered an allowed version, even if that version was not specified in the `versions` or `startingCSV` of the OperatorPolicy. Now, when determining which versions should be considered compliant for the operator, only the versions actually in the policy are used.

Refs:
 - https://issues.redhat.com/browse/ACM-32977

Assisted-by: Cursor, claude-4.6-opus-high

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operator policy approval logic to correctly consider starting CSV values provided in raw subscription data when evaluating approved CSVs.

* **Tests**
  * Added a regression test to verify approval behavior when adopting subscriptions whose starting CSV is not listed in the policy's versions.

* **Chores**
  * Enhanced e2e-debug output to list and describe all pods before collecting controller logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->