### PR TITLE
Preserve createdByPolicy through recreates

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -2335,6 +2335,24 @@ type objectTmplEvalResultWithEvent struct {
 	event  objectTmplEvalEvent
 }
 
+// uidWasCreatedByPolicy reports whether the configuration policy's status lists the given object UID
+// with createdByPolicy set. The UID should be the cluster object's metadata.uid from before an
+// operation that replaces the object (for example enforce-mode recreate). Callers use this to
+// preserve createdByPolicy across a UID change when pruneObjectBehavior is DeleteIfCreated.
+func uidWasCreatedByPolicy(plc *policyv1.ConfigurationPolicy, objectUID string) bool {
+	for _, related := range plc.Status.RelatedObjects {
+		if related.Properties == nil || related.Properties.UID != objectUID {
+			continue
+		}
+
+		if related.Properties.CreatedByPolicy != nil {
+			return *related.Properties.CreatedByPolicy
+		}
+	}
+
+	return false
+}
+
 // handleSingleObj takes in an object template (for a named object) and its data and determines whether
 // the object on the cluster is compliant or not
 func (r *ConfigurationPolicyReconciler) handleSingleObj(
@@ -2427,7 +2445,7 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 	if exists && obj.shouldExist {
 		objLog.V(2).Info("The object already exists. Verifying the object fields match what is desired.")
 
-		var throwSpecViolation, triedUpdate, matchesAfterDryRun bool
+		var violation, triedUpdate, matchesAfterDryRun bool
 		var msg, diff string
 		var updatedObj *unstructured.Unstructured
 
@@ -2447,16 +2465,24 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 				}
 			}
 
-			throwSpecViolation = !compliant
+			violation = !compliant
 			msg = cachedMsg
 		} else {
-			throwSpecViolation, msg, diff, triedUpdate, updatedObj, matchesAfterDryRun = r.checkAndUpdateResource(
+			var recreated bool
+
+			violation, msg, diff, triedUpdate, updatedObj, matchesAfterDryRun, recreated = r.checkAndUpdateResource(
 				ctx, obj, objectT, remediation,
 			)
 
 			if updatedObj != nil && string(updatedObj.GetUID()) != uid {
+				oldUID := uid
 				uid = string(updatedObj.GetUID())
-				created = true
+
+				if recreated {
+					created = uidWasCreatedByPolicy(obj.policy, oldUID) // preserve the previous setting
+				} else {
+					created = true
+				}
 			}
 		}
 
@@ -2465,7 +2491,7 @@ func (r *ConfigurationPolicyReconciler) handleSingleObj(
 			result.events = append(result.events, objectTmplEvalEvent{false, reasonWantFoundNoMatch, ""})
 		}
 
-		if throwSpecViolation {
+		if violation {
 			var resultReason, resultMsg string
 
 			if msg != "" {
@@ -3198,10 +3224,18 @@ type cachedEvaluationResult struct {
 	msg             string
 }
 
-// checkAndUpdateResource checks each individual key of a resource and passes it to handleKeys to see if it
-// matches the template and update it if the remediationAction is enforce. UpdateNeeded indicates whether the
-// function tried to update the child object and updateSucceeded indicates whether the update was applied
-// successfully.
+// checkAndUpdateResource compares the live object to the template using handleKeys, runs a server-side
+// dry-run update when a spec change may be needed, and in enforce mode applies an update or a
+// delete-and-create when recreate is allowed. It returns:
+//   - throwViolation: true when the object should be reported as non-compliant (including API errors).
+//   - message: a human-readable error or status detail when throwViolation is true.
+//   - diff: a rendered diff when recordDiff allows it and a mismatch was analyzed.
+//   - updateNeeded: true when handleKeys reported that a spec update may be required (also true on some error paths).
+//   - updatedObj: the object returned from a successful live Update or Create, otherwise nil.
+//   - matchesAfterDryRun: true when a mismatch was detected but the dry-run update produced no spec change
+//     and the object is otherwise compliant (no status mismatch).
+//   - recreated: true only when enforce mode successfully replaced the object via delete then create
+//     (not a plain Update); callers use this with related-object UID changes for prune behavior.
 func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	ctx context.Context, obj singleObject, objectT *policyv1.ObjectTemplate, remediation policyv1.RemediationAction,
 ) (
@@ -3211,6 +3245,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	updateNeeded bool,
 	updatedObj *unstructured.Unstructured,
 	matchesAfterDryRun bool,
+	recreated bool,
 ) {
 	log := ctrl.LoggerFrom(ctx, "objName", obj.name, "objNamespace", obj.namespace, "resource", obj.scopedGVR.Resource)
 
@@ -3234,7 +3269,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	if obj.existingObj == nil {
 		log.Info("Skipping update: Previous object retrieval from the API server failed")
 
-		return false, "", "", false, nil, false
+		return false, "", "", false, nil, false, false
 	}
 
 	var res dynamic.ResourceInterface
@@ -3257,7 +3292,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 		objectT.MetadataComplianceType,
 	)
 	if errMsg != "" {
-		return true, errMsg, "", true, nil, false
+		return true, errMsg, "", true, nil, false, false
 	}
 
 	recordDiff := objectT.RecordDiffWithDefault()
@@ -3279,13 +3314,13 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 			// No spec changes needed, and no status mismatch, so it's Compliant.
 			r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, true, "")
 
-			return false, "", "", updateNeeded, updatedObj, false
+			return false, "", "", updateNeeded, updatedObj, false, false
 		}
 
 		// No spec changes needed, but the status mismatches, so it's NonCompliant.
 		r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, "")
 
-		return true, "", diff, updateNeeded, updatedObj, false
+		return true, "", diff, updateNeeded, updatedObj, false, false
 	}
 
 	if updateNeeded {
@@ -3329,7 +3364,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 				r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, message)
 			}
 
-			return true, message, "", updateNeeded, nil, false
+			return true, message, "", updateNeeded, nil, false, false
 		}
 
 		// If an update is invalid (i.e. modifying Pod spec fields), then return noncompliant since that
@@ -3355,7 +3390,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 
 			r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, message)
 
-			return true, message, diff, false, nil, false
+			return true, message, diff, false, nil, false, false
 		}
 
 		mergedObjCopy := obj.existingObj.DeepCopy()
@@ -3370,13 +3405,13 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 			if !statusMismatch {
 				r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, true, "")
 
-				return false, "", "", false, updatedObj, true
+				return false, "", "", false, updatedObj, true, false
 			}
 
 			// No spec changes needed, but the status is incorrect, so it's NonCompliant.
 			r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, "")
 
-			return true, "", diff, updateNeeded, updatedObj, false
+			return true, "", diff, updateNeeded, updatedObj, false, false
 		}
 
 		diff = handleDiff(log, recordDiff, existingObjectCopy, dryRunUpdatedObj, r.FullDiffs)
@@ -3386,7 +3421,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 	if isInform {
 		r.setEvaluatedObject(obj.policy, obj.existingObj, objectT, false, "")
 
-		return true, "", diff, false, nil, false
+		return true, "", diff, false, nil, false, false
 	}
 
 	// If it's not inform (i.e. enforce), update the object
@@ -3406,7 +3441,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 		if err != nil && !k8serrors.IsNotFound(err) {
 			message = fmt.Sprintf(`%s failed to delete when recreating with the error %v`, getMsgPrefix(&obj), err)
 
-			return true, message, "", updateNeeded, nil, false
+			return true, message, "", updateNeeded, nil, false, false
 		}
 
 		attempts := 0
@@ -3424,7 +3459,7 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 				message = getMsgPrefix(&obj) + " timed out waiting for the object to delete during recreate, " +
 					"will retry on the next policy evaluation"
 
-				return true, message, "", updateNeeded, nil, false
+				return true, message, "", updateNeeded, nil, false, false
 			}
 
 			time.Sleep(time.Second)
@@ -3449,25 +3484,19 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 			}
 		}
 
-		action := "update"
-
-		if needsRecreate || objectT.RecreateOption == policyv1.Always {
-			action = "recreate"
-		}
-
 		message := getUpdateErrorMsg(err, obj.existingObj.GetKind(), obj.name)
 		if message == "" {
 			message = fmt.Sprintf("%s failed to %s with the error `%v`", getMsgPrefix(&obj), action, err)
 		}
 
-		return true, message, diff, updateNeeded, nil, false
+		return true, message, diff, updateNeeded, nil, false, false
 	}
 
 	if !statusMismatch {
 		r.setEvaluatedObject(obj.policy, updatedObj, objectT, true, message)
 	}
 
-	return throwViolation, "", diff, updateNeeded, updatedObj, false
+	return throwViolation, "", diff, updateNeeded, updatedObj, false, action == "recreate"
 }
 
 func getMsgPrefix(obj *singleObject) string {

--- a/test/e2e/case40_recreate_option_test.go
+++ b/test/e2e/case40_recreate_option_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Recreate options", Ordered, func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		uid := deployment.GetUID()
+		originalUID := deployment.GetUID()
 
 		utils.Kubectl(
 			"-n", testNamespace, "patch", "configurationpolicy", "case40", "--type=json", "-p",
@@ -117,7 +117,6 @@ var _ = Describe("Recreate options", Ordered, func() {
 
 		By("Verifying the ConfigurationPolicy is Compliant")
 		var managedPlc *unstructured.Unstructured
-		var propsUID string
 		Eventually(func(g Gomega) {
 			managedPlc = utils.GetWithTimeout(
 				clientManagedDynamic,
@@ -139,11 +138,11 @@ var _ = Describe("Recreate options", Ordered, func() {
 			diff, _, _ := unstructured.NestedString(relatedObject, "properties", "diff")
 			g.Expect(diff).To(BeEmpty())
 
-			propsUID, _, _ = unstructured.NestedString(relatedObject, "properties", "uid")
+			propsUID, _, _ := unstructured.NestedString(relatedObject, "properties", "uid")
 			g.Expect(propsUID).ToNot(BeEmpty())
 
 			createdByPolicy, _, _ := unstructured.NestedBool(relatedObject, "properties", "createdByPolicy")
-			g.Expect(createdByPolicy).To(BeTrue())
+			g.Expect(createdByPolicy).To(BeFalse())
 
 			deployment, err = clientManagedDynamic.Resource(gvrDeployment).Namespace("default").Get(
 				ctx, "case40", metav1.GetOptions{},
@@ -153,15 +152,123 @@ var _ = Describe("Recreate options", Ordered, func() {
 
 		By("Verifying the Deployment was recreated")
 		Eventually(func(g Gomega) {
-			g.Expect(deployment.GetUID()).ToNot(
-				Equal(uid), "Expected a new UID on the Deployment after it got recreated")
-			g.Expect(propsUID).To(
-				BeEquivalentTo(deployment.GetUID()), "Expect the object properties UID to match the new Deployment",
+			deployment, err := clientManagedDynamic.Resource(gvrDeployment).Namespace("default").Get(
+				ctx, "case40", metav1.GetOptions{},
 			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(deployment.GetUID()).ToNot(
+				Equal(originalUID), "Expected a new UID on the Deployment after it got recreated")
 
 			selector, _, _ := unstructured.NestedString(deployment.Object, "spec", "selector", "matchLabels", "app")
 			g.Expect(selector).To(Equal("case40-2"))
 		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		deleteConfigPolicies([]string{"case40"})
+	})
+
+	It("should preserve createdByPolicy=true after recreate", func(ctx SpecContext) {
+		By("Removing any leftover case40 policy or Deployment from prior tests")
+		deleteConfigPolicies([]string{"case40"})
+		utils.KubectlDelete("-n", "default", "deployment", "case40")
+
+		By("Creating only the ConfigurationPolicy so it creates the Deployment")
+		utils.Kubectl("-n", testNamespace, "create", "-f", policyNoRecreateYAML)
+
+		var managedPlc *unstructured.Unstructured
+		var uidBeforeMismatch string
+
+		By("Waiting until the policy is Compliant and records createdByPolicy=true")
+		Eventually(func(g Gomega) {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				"case40",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			utils.CheckComplianceStatus(g, managedPlc, "Compliant")
+
+			deployment, err := clientManagedDynamic.Resource(gvrDeployment).Namespace("default").Get(
+				ctx, "case40", metav1.GetOptions{},
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			uidBeforeMismatch = string(deployment.GetUID())
+
+			relatedObjects, _, err := unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(relatedObjects).To(HaveLen(1))
+
+			relatedObject := relatedObjects[0].(map[string]interface{})
+			createdByPolicy, _, _ := unstructured.NestedBool(relatedObject, "properties", "createdByPolicy")
+			g.Expect(createdByPolicy).To(BeTrue(), "expected the Deployment to have createdByPolicy=true")
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		By("Patching the policy desired labels to an immutable mismatch (still without recreate)")
+		selectorPath := "/spec/object-templates/0/objectDefinition/spec/selector/matchLabels/app"
+		labelPath := "/spec/object-templates/0/objectDefinition/spec/template/metadata/labels/app"
+
+		utils.Kubectl(
+			"-n", testNamespace, "patch", "configurationpolicy", "case40", "--type=json", "-p",
+			`[{"op":"replace","path":"`+selectorPath+`","value":"case40-3"},`+
+				`{"op":"replace","path":"`+labelPath+`","value":"case40-3"}]`,
+		)
+
+		By("Waiting for the policy to become NonCompliant")
+		Eventually(func(g Gomega) {
+			managedPlc = utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				"case40", testNamespace, true, defaultTimeoutSeconds)
+
+			utils.CheckComplianceStatus(g, managedPlc, "NonCompliant")
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		By("Setting recreateOption=IfRequired so the controller recreates the Deployment")
+		utils.Kubectl(
+			"-n", testNamespace, "patch", "configurationpolicy", "case40", "--type=json", "-p",
+			`[{"op":"replace","path":"/spec/object-templates/0/recreateOption","value":"IfRequired"}]`,
+		)
+
+		var propsUID string
+
+		By("Waiting until Compliant again and createdByPolicy is still true after recreate")
+		Eventually(func(g Gomega) {
+			managedPlc = utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrConfigPolicy,
+				"case40",
+				testNamespace,
+				true,
+				defaultTimeoutSeconds,
+			)
+
+			utils.CheckComplianceStatus(g, managedPlc, "Compliant")
+
+			deployment, err := clientManagedDynamic.Resource(gvrDeployment).Namespace("default").Get(
+				ctx, "case40", metav1.GetOptions{},
+			)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(string(deployment.GetUID())).ToNot(
+				Equal(uidBeforeMismatch), "expected a new UID after recreate")
+
+			relatedObjects, _, err := unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(relatedObjects).To(HaveLen(1))
+
+			relatedObject := relatedObjects[0].(map[string]interface{})
+
+			createdByPolicy, _, _ := unstructured.NestedBool(relatedObject, "properties", "createdByPolicy")
+			g.Expect(createdByPolicy).To(BeTrue(), "expected createdByPolicy to stay true")
+
+			propsUID, _, _ = unstructured.NestedString(relatedObject, "properties", "uid")
+			g.Expect(propsUID).To(BeEquivalentTo(deployment.GetUID()))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		deployment := utils.GetWithTimeout(clientManagedDynamic, gvrDeployment,
+			"case40", "default", true, defaultTimeoutSeconds)
+
+		selector, _, _ := unstructured.NestedString(deployment.Object, "spec", "selector", "matchLabels", "app")
+		Expect(selector).To(Equal("case40-3"))
 
 		deleteConfigPolicies([]string{"case40"})
 	})


### PR DESCRIPTION
Previously, when a configurationpolicy would recreate an object in order to enforce the policy, the controller would always mark that object in the status as having been created by the policy. While this is technically true, it meant that a resource created *before* the policy might be deleted if `pruneObjectBehavior: DeleteIfCreated` was set, and that was often surprising to users.

Now, when an object is recreated by a policy, the previous setting for that object in the status is preserved.

Refs:
 - https://issues.redhat.com/browse/ACM-26300

Assisted-by: Cursor, claude-4.6-opus-high

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ConfigurationPolicy handling of object recreation scenarios to properly preserve object ownership information when objects are recreated during policy enforcement and reconciliation.

* **Tests**
  * Extended test suite for ConfigurationPolicy recreation functionality with comprehensive coverage for ownership state tracking behavior when policies trigger object recreation, including verification of ownership state preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/config-policy-controller/pull/471)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->