### PR TITLE
test: retry ratelimit test

### DIFF
--- a/test/e2e/case47_ratelimit_test.go
+++ b/test/e2e/case47_ratelimit_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Test config policy ratelimiting", Ordered, func() {
 		utils.Kubectl("apply", "-f", configMapYaml) // The YAML specifies namespace "default"
 	})
 
-	It("should initially have a small number of evaluations", func() {
+	It("should initially have a small number of evaluations", FlakeAttempts(3), func() {
 		Eventually(
 			metricCheck, 10, 2,
 		).WithArguments("config_policy_evaluation_total", "name", policyName).Should(BeNumerically("<=", 5))
@@ -57,7 +57,7 @@ var _ = Describe("Test config policy ratelimiting", Ordered, func() {
 
 	value := 0
 
-	It("should limit the number of evaluations when a watched object changes frequently", func() {
+	It("should limit the number of evaluations when a watched object changes frequently", FlakeAttempts(3), func() {
 		start := time.Now()
 
 		By("Updating the watched configmap frequently for 10 seconds")
@@ -73,7 +73,7 @@ var _ = Describe("Test config policy ratelimiting", Ordered, func() {
 		).WithArguments("config_policy_evaluation_total", "name", policyName).Should(BeNumerically("<", 12))
 	})
 
-	It("should have updated the object to the final value", func() {
+	It("should have updated the object to the final value", FlakeAttempts(3), func() {
 		By("Verifying the configmap has bar=" + strconv.Itoa(value))
 		Eventually(func(g Gomega) {
 			cm := utils.GetWithTimeout(clientManagedDynamic, gvrConfigMap,


### PR DESCRIPTION
None of the other tests poll utils.GetMetrics as often as case 47, suggesting Github's servers under high load causes transient network issues when curling the metrics pod. I cannot reproduce the flake on my local machine.

ref: https://redhat.atlassian.net/browse/ACM-26139

Other ideas I tried and did not work:
- editing the polling frequency did not affect flakes
- implementing a retry within GetMetrics made the Eventually and Consistently tests difficult to interpret
- using Ginkgo's default number of parallel procs with `-p` instead of 20 did not affect flakes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of several end-to-end rate limit test cases by allowing automatic retries for intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->