### PR TITLE
chore: upgrade to Go 1.26

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Open Cluster Management project
 
 # Stage 1: Use image builder to build the target binaries
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 ENV COMPONENT=config-policy-controller
 ENV REPO_PATH=/go/src/github.com/open-cluster-management/${COMPONENT}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/config-policy-controller
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.26 to support improved build performance and keep runtime behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->