### PR TITLE
Cleaning up removed CustomResources

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -589,6 +589,12 @@ func (r *ConfigurationPolicyReconciler) cleanUpChildObjects(
 
 		scopedGVR, err := r.DynamicWatcher.GVKToGVR(gvk)
 		if err != nil && !errors.Is(err, depclient.ErrResourceUnwatchable) {
+			if childObjectUnavailable(err) {
+				log.V(1).Info("Child object API unavailable, treating the object as removed")
+
+				continue
+			}
+
 			log.Error(err, "Could not get resource mapping for child object")
 
 			deletionFailures = append(deletionFailures, gvk.String()+fmt.Sprintf(` "%s" in namespace %s`,
@@ -629,6 +635,12 @@ func (r *ConfigurationPolicyReconciler) cleanUpChildObjects(
 		}
 
 		if err != nil {
+			if childObjectUnavailable(err) {
+				log.V(1).Info("Child object API unavailable, treating the object as removed")
+
+				continue
+			}
+
 			log.Error(err, "Failed to get child object")
 
 			deletionFailures = append(deletionFailures, gvk.String()+fmt.Sprintf(` "%s" in namespace %s`,
@@ -694,6 +706,12 @@ func (r *ConfigurationPolicyReconciler) cleanUpChildObjects(
 					r.TargetK8sDynamicClient,
 				)
 				if err != nil {
+					if childObjectUnavailable(err) {
+						log.V(1).Info("Child object API unavailable, treating deletion as complete")
+
+						continue
+					}
+
 					// Note: a NotFound error is handled specially in `getObject`, so this is something different
 					log.Error(err, "Error: failed to get object after deleting it")
 

--- a/controllers/configurationpolicy_utils.go
+++ b/controllers/configurationpolicy_utils.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -15,6 +16,8 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 	templates "github.com/stolostron/go-template-utils/v7/pkg/templates"
 	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	apiRes "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -910,4 +913,12 @@ func resolveGoTemplates(
 	resolvedTemplate, err = tmplResolver.ResolveTemplate(rawObj, templateContext, resolveOptions)
 
 	return resolvedTemplate, skipObject, err
+}
+
+// childObjectUnavailable reports whether a child object can no longer be accessed because its API
+// mapping or resource type was removed from the cluster.
+func childObjectUnavailable(err error) bool {
+	return errors.Is(err, depclient.ErrNoVersionedResource) ||
+		k8serrors.IsNotFound(err) ||
+		meta.IsNoMatchError(err)
 }

--- a/controllers/configurationpolicy_utils_test.go
+++ b/controllers/configurationpolicy_utils_test.go
@@ -1,15 +1,20 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stolostron/go-template-utils/v7/pkg/templates"
+	depclient "github.com/stolostron/kubernetes-dependency-watches/client"
 	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -616,6 +621,49 @@ func TestGetTemplateResolver_DenylistFunctions(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.expectedDenylist, resolveOptions.DenylistFunctions)
+		})
+	}
+}
+
+func TestChildObjectUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "no versioned resource",
+			err:  depclient.ErrNoVersionedResource,
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  k8serrors.NewNotFound(schema.GroupResource{Resource: "widgets"}, "case20-widget"),
+			want: true,
+		},
+		{
+			name: "no match",
+			err: &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{
+				Group: "example.com", Resource: "widgets",
+			}},
+			want: true,
+		},
+		{
+			name: "other error",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := childObjectUnavailable(tt.err); got != tt.want {
+				t.Fatalf("childObjectUnavailable() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/test/e2e/case20_delete_objects_test.go
+++ b/test/e2e/case20_delete_objects_test.go
@@ -12,36 +12,32 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"open-cluster-management.io/config-policy-controller/test/utils"
 )
 
-const (
-	case20PodName                   string = "nginx-pod-e2e20"
-	case20PodWithFinalizer          string = "nginx-pod-cannot-delete"
-	case20ConfigPolicyNameCreate    string = "policy-pod-create-c20"
-	case20ConfigPolicyNameEdit      string = "policy-pod-edit-c20"
-	case20ConfigPolicyNameExisting  string = "policy-pod-already-created-c20"
-	case20ConfigPolicyNameInform    string = "policy-pod-inform-c20"
-	case20ConfigPolicyNameFinalizer string = "policy-pod-create-withfinalizer-c20"
-	case20ConfigPolicyNameChange    string = "policy-pod-change-remediation-c20"
-	case20ConfigPolicyNameMHPDA     string = "policy-pod-mhpda-c20"
-	case20PodMHPDAName              string = "nginx-pod-e2e20-mhpda"
-	case20PodYaml                   string = "../resources/case20_delete_objects/case20_pod.yaml"
-	case20PolicyYamlCreate          string = "../resources/case20_delete_objects/case20_create_pod.yaml"
-	case20PolicyYamlEdit            string = "../resources/case20_delete_objects/case20_edit_pod.yaml"
-	case20PolicyYamlExisting        string = "../resources/case20_delete_objects/case20_enforce_noncreated_pod.yaml"
-	case20PolicyYamlInform          string = "../resources/case20_delete_objects/case20_inform_pod.yaml"
-	case20PolicyYamlFinalizer       string = "../resources/case20_delete_objects/case20_createpod_finalizer.yaml"
-	case20PolicyYamlChangeInform    string = "../resources/case20_delete_objects/case20_change_inform.yaml"
-	case20PolicyYamlChangeEnforce   string = "../resources/case20_delete_objects/case20_change_enforce.yaml"
-	case20PolicyYamlMHPDA           string = "../resources/case20_delete_objects/case20_musthave_pod_deleteall.yaml"
-
-	// For the CRD deletion test
-	case20ConfigPolicyCRDPath string = "../../deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml"
-)
-
 var _ = Describe("Test Object deletion", Ordered, func() {
+	const (
+		case20PodName                   string = "nginx-pod-e2e20"
+		case20PodWithFinalizer          string = "nginx-pod-cannot-delete"
+		case20ConfigPolicyNameCreate    string = "policy-pod-create-c20"
+		case20ConfigPolicyNameEdit      string = "policy-pod-edit-c20"
+		case20ConfigPolicyNameExisting  string = "policy-pod-already-created-c20"
+		case20ConfigPolicyNameInform    string = "policy-pod-inform-c20"
+		case20ConfigPolicyNameFinalizer string = "policy-pod-create-withfinalizer-c20"
+		case20ConfigPolicyNameChange    string = "policy-pod-change-remediation-c20"
+		case20Path                      string = "../resources/case20_delete_objects/"
+		case20PodYaml                   string = case20Path + "case20_pod.yaml"
+		case20PolicyYamlCreate          string = case20Path + "case20_create_pod.yaml"
+		case20PolicyYamlEdit            string = case20Path + "case20_edit_pod.yaml"
+		case20PolicyYamlExisting        string = case20Path + "case20_enforce_noncreated_pod.yaml"
+		case20PolicyYamlInform          string = case20Path + "case20_inform_pod.yaml"
+		case20PolicyYamlFinalizer       string = case20Path + "case20_createpod_finalizer.yaml"
+		case20PolicyYamlChangeInform    string = case20Path + "case20_change_inform.yaml"
+		case20PolicyYamlChangeEnforce   string = case20Path + "case20_change_enforce.yaml"
+	)
+
 	Describe("Test status fields being set for object deletion", Ordered, func() {
 		It("should update status fields properly for created objects", func() {
 			By("Creating " + case20ConfigPolicyNameCreate + " on managed")
@@ -550,6 +546,14 @@ var _ = Describe("Test Object deletion", Ordered, func() {
 })
 
 var _ = Describe("Test objects are not deleted when the CRD is removed", Serial, Ordered, func() {
+	const (
+		case20ConfigPolicyCRDPath string = "../../deploy/crds/" +
+			"policy.open-cluster-management.io_configurationpolicies.yaml"
+		case20PodMHPDAName          string = "nginx-pod-e2e20-mhpda"
+		case20ConfigPolicyNameMHPDA string = "policy-pod-mhpda-c20"
+		case20PolicyYamlMHPDA       string = "../resources/case20_delete_objects/case20_musthave_pod_deleteall.yaml"
+	)
+
 	AfterAll(func() {
 		deleteConfigPolicies([]string{case20ConfigPolicyNameMHPDA})
 		utils.Kubectl("apply", "-f", case20ConfigPolicyCRDPath)
@@ -614,6 +618,84 @@ var _ = Describe("Test objects are not deleted when the CRD is removed", Serial,
 
 			return string(pod.GetUID())
 		}, defaultTimeoutSeconds, 1).Should(Equal(oldPodUID))
+	})
+})
+
+var _ = Describe("Test policy deletion when child CRD is removed", Serial, Ordered, func() {
+	const (
+		case20ConfigPolicyNameMissingCRD string = "case20-cleanup-missing-crd"
+		case20WidgetName                 string = "case20-widget"
+		case20Path                       string = "../resources/case20_delete_objects/"
+		case20WidgetCRDYAML              string = case20Path + "case20_widget_crd.yaml"
+		case20WidgetYAML                 string = case20Path + "case20_widget.yaml"
+		case20PolicyYamlMissingCRD       string = case20Path + "case20_cleanup_missing_child_crd.yaml"
+		case20PruneObjectFinalizer       string = "policy.open-cluster-management.io/delete-related-objects"
+	)
+
+	gvrWidget := schema.GroupVersionResource{
+		Group:    "e2e.test.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "widgets",
+	}
+
+	AfterAll(func() {
+		deleteConfigPolicies([]string{case20ConfigPolicyNameMissingCRD}, true)
+		utils.Kubectl("apply", "-f", case20WidgetCRDYAML)
+		utils.KubectlDelete("-f", case20WidgetCRDYAML)
+	})
+
+	It("creates a policy that manages a custom resource", func() {
+		By("Installing the Widget CRD and instance")
+		utils.Kubectl("apply", "-f", case20WidgetCRDYAML)
+		utils.Kubectl("apply", "-f", case20WidgetYAML)
+
+		By("Creating the ConfigurationPolicy")
+		utils.Kubectl("apply", "-f", case20PolicyYamlMissingCRD, "-n", testNamespace)
+
+		Eventually(func(g Gomega) {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case20ConfigPolicyNameMissingCRD, testNamespace, true, defaultTimeoutSeconds)
+
+			utils.CheckComplianceStatus(g, managedPlc, "Compliant")
+			g.Expect(managedPlc.GetFinalizers()).To(ContainElement(case20PruneObjectFinalizer))
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			widget := utils.GetWithTimeout(clientManagedDynamic, gvrWidget, case20WidgetName,
+				"default", true, defaultTimeoutSeconds)
+			g.Expect(widget).NotTo(BeNil())
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+	})
+
+	It("completes policy deletion without getting stuck on missing child mappings", func() {
+		// Since GVKToGVR results are cached in-memory, just deleting the CRD won't necessarily
+		// recreate the potential issue. Instead, patch the status to reference a kind that was
+		// never defined so cleanup must perform a cold discovery lookup for that GVK.
+		Eventually(func(g Gomega) {
+			managedPlc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case20ConfigPolicyNameMissingCRD, testNamespace, true, defaultTimeoutSeconds)
+
+			relatedObjects, found, err := unstructured.NestedSlice(managedPlc.Object, "status", "relatedObjects")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(found).To(BeTrue())
+			g.Expect(relatedObjects).NotTo(BeEmpty())
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		By("Patching status.relatedObjects to reference a nonexistent API kind")
+		utils.Kubectl("patch", "configurationpolicy", case20ConfigPolicyNameMissingCRD, "-n", testNamespace,
+			"--type=json", "--subresource=status", "-p", `[
+				{"op": "replace", "path": "/status/relatedObjects/0/object/kind", "value": "UndefinedWidget"}
+			]`)
+
+		By("Deleting the ConfigurationPolicy")
+		deleteConfigPolicies([]string{case20ConfigPolicyNameMissingCRD})
+
+		By("Verifying the policy is fully removed (finalizer released)")
+		Eventually(func(g Gomega) {
+			policy := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy,
+				case20ConfigPolicyNameMissingCRD, testNamespace, false, defaultTimeoutSeconds)
+			g.Expect(policy).To(BeNil())
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
 	})
 })
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -275,19 +275,64 @@ func LoadConfig(url, kubeconfig, context string) (*rest.Config, error) {
 	return nil, errors.New("could not create a valid kubeconfig")
 }
 
-func deleteConfigPolicies(policyNames []string) {
+// deleteConfigPolicies deletes the named configuration policies and waits for them to be
+// removed. Pass true as the optional force argument to strip finalizers when deletion is stuck.
+func deleteConfigPolicies(policyNames []string, force ...bool) {
 	GinkgoHelper()
+
+	forceDelete := len(force) > 0 && force[0]
 
 	for _, policyName := range policyNames {
 		err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Delete(
 			context.TODO(), policyName, metav1.DeleteOptions{},
 		)
-		if !k8serrors.IsNotFound(err) {
+		if forceDelete {
+			if err != nil && !k8serrors.IsNotFound(err) {
+				continue
+			}
+		} else if !k8serrors.IsNotFound(err) {
 			Expect(err).ToNot(HaveOccurred())
 		}
 	}
 
 	for _, policyName := range policyNames {
+		if forceDelete {
+			Eventually(func() error {
+				policy, err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Get(
+					context.TODO(), policyName, metav1.GetOptions{},
+				)
+				if k8serrors.IsNotFound(err) {
+					return nil
+				}
+
+				if err != nil {
+					return err
+				}
+
+				if len(policy.GetFinalizers()) > 0 {
+					utils.Kubectl("patch", "configurationpolicy", policyName, "-n", testNamespace,
+						"--type=merge", `-p={"metadata":{"finalizers":[]}}`)
+
+					return errors.New("waiting for finalizers to be removed")
+				}
+
+				if policy.GetDeletionTimestamp() == nil {
+					err := clientManagedDynamic.Resource(gvrConfigPolicy).Namespace(testNamespace).Delete(
+						context.TODO(), policyName, metav1.DeleteOptions{},
+					)
+					if err != nil && !k8serrors.IsNotFound(err) {
+						return err
+					}
+
+					return errors.New("waiting for configuration policy deletion to start")
+				}
+
+				return errors.New("waiting for configuration policy to be deleted")
+			}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+			continue
+		}
+
 		_ = utils.GetWithTimeout(
 			clientManagedDynamic, gvrConfigPolicy, policyName, testNamespace, false, defaultTimeoutSeconds,
 		)

--- a/test/resources/case20_delete_objects/case20_cleanup_missing_child_crd.yaml
+++ b/test/resources/case20_delete_objects/case20_cleanup_missing_child_crd.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case20-cleanup-missing-crd
+spec:
+  remediationAction: enforce
+  pruneObjectBehavior: DeleteAll
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: e2e.test.open-cluster-management.io/v1
+        kind: Widget
+        metadata:
+          name: case20-widget
+          namespace: default
+        spec:
+          color: blue

--- a/test/resources/case20_delete_objects/case20_widget.yaml
+++ b/test/resources/case20_delete_objects/case20_widget.yaml
@@ -1,0 +1,7 @@
+apiVersion: e2e.test.open-cluster-management.io/v1
+kind: Widget
+metadata:
+  name: case20-widget
+  namespace: default
+spec:
+  color: blue

--- a/test/resources/case20_delete_objects/case20_widget_crd.yaml
+++ b/test/resources/case20_delete_objects/case20_widget_crd.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.e2e.test.open-cluster-management.io
+spec:
+  group: e2e.test.open-cluster-management.io
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            properties:
+              color:
+                type: string
+    served: true
+    storage: true


### PR DESCRIPTION
Previously, if a custom resource endpoint was no longer available on a
cluster, but a policy still referenced an object of that type, the
policy would become stuck. The failed lookups would prevent the
finalizer from being removed.

Now, when the API response indicates there is no match for a resource
version, the controller will consider the child object as properly
removed.

Refs:
 - https://issues.redhat.com/browse/ACM-31401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior when a managed object or its API is no longer available, reducing unnecessary delete-failure reports.
  * Policy deletion now handles missing child resource types more reliably and can complete even when related objects point to removed kinds.

* **Tests**
  * Added coverage for unavailable child-object error cases.
  * Expanded end-to-end coverage for policy deletion scenarios involving missing child resource definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->