### PR TITLE
chore: remove unused env

### DIFF
--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -30,9 +30,5 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: managed
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "config-policy-controller"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -135,10 +135,6 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: managed
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: config-policy-controller
         image: quay.io/open-cluster-management/config-policy-controller:latest


### PR DESCRIPTION
It appears POD_NAME may not be in use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment configuration for the controller to use a single namespace setting.
  * Removed two unused runtime environment variables from the container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->