### PR TITLE
Detect AllNamespaces operator in another namespace

### DIFF
--- a/controllers/operatorpolicy_controller.go
+++ b/controllers/operatorpolicy_controller.go
@@ -405,6 +405,41 @@ func (r *OperatorPolicyReconciler) handleResources(ctx context.Context, policy *
 		return earlyComplianceEvents, condChanged, err
 	}
 
+	// If an AllNamespaces operator is already installed elsewhere, OLM copies its CSV into this
+	// namespace. Short-circuit to avoid creating a duplicate Sub that would become orphaned.
+	// See https://github.com/operator-framework/operator-lifecycle-manager/issues/3866
+	if desiredSub != nil && desiredOG != nil &&
+		policy.Spec.ComplianceType.IsMustHave() &&
+		len(desiredOG.Spec.TargetNamespaces) == 0 {
+		copiedCSV, err := r.findCopiedCSV(ctx, policy, desiredSub)
+		if err != nil {
+			return earlyComplianceEvents, condChanged, err
+		}
+
+		if copiedCSV != nil {
+			condChanged = r.handleExistingInstallation(policy, copiedCSV) || condChanged
+
+			// Compliance config checks apply to the CSV regardless of whether the installation
+			// is local or existing, but need the packageManifest and desiredSub context.
+			if err := r.updateDeprecationStatus(ctx, policy, desiredSub, copiedCSV, packageManifest); err != nil {
+				return earlyComplianceEvents, condChanged, err
+			}
+
+			changed, err = r.updateMinorChannelUpgradeStatus(policy, desiredSub, packageManifest)
+			condChanged = condChanged || changed
+
+			if err != nil {
+				return earlyComplianceEvents, condChanged, err
+			}
+
+			if err := r.cleanupStaleInstallation(ctx, policy, desiredSub); err != nil {
+				return earlyComplianceEvents, condChanged, err
+			}
+
+			return earlyComplianceEvents, condChanged, nil
+		}
+	}
+
 	desiredSubName := ""
 	if desiredSub != nil {
 		desiredSubName = desiredSub.Name
@@ -920,6 +955,26 @@ func policyStartingCSV(policy *policyv1beta1.OperatorPolicy) string {
 	}
 
 	return sub.StartingCSV
+}
+
+// isCSVVersionAllowed assumes the Versions list has been canonicalized already,
+// usually done by buildResources (via resolveVersionsTemplates and canonicalizeVersions).
+func isCSVVersionAllowed(policy *policyv1beta1.OperatorPolicy, csvName string) bool {
+	if len(policy.Spec.Versions) == 0 {
+		return true
+	}
+
+	for _, version := range policy.Spec.Versions {
+		if version == csvName {
+			return true
+		}
+	}
+
+	if startingCSV := policyStartingCSV(policy); startingCSV != "" && startingCSV == csvName {
+		return true
+	}
+
+	return false
 }
 
 // buildSubscription bootstraps the subscription spec defined in the operator policy
@@ -2442,6 +2497,76 @@ func (r *OperatorPolicyReconciler) mustnothaveInstallPlan(
 	return changed
 }
 
+// handleExistingInstallation handles the case where an AllNamespaces operator is already installed
+// in a different namespace and OLM has copied the CSV into the target namespace.
+// It sets all conditions appropriately and returns whether the status changed.
+func (r *OperatorPolicyReconciler) handleExistingInstallation(
+	policy *policyv1beta1.OperatorPolicy,
+	csv *operatorv1alpha1.ClusterServiceVersion,
+) bool {
+	changed := false
+
+	csv.SetGroupVersionKind(clusterServiceVersionGVK)
+
+	if !isCSVVersionAllowed(policy, csv.Name) {
+		return updateStatus(policy, disallowedCSVCond(csv), disallowedCSVObj(csv))
+	}
+
+	sourceNS := csv.GetLabels()[operatorv1alpha1.CopiedLabelKey]
+
+	for _, kind := range []string{
+		"OperatorGroup", "Subscription", "InstallPlan",
+		"CustomResourceDefinition", "Deployment", "CatalogSource",
+	} {
+		changed = updateStatus(policy, existingInstallCond(kind, sourceNS)) || changed
+	}
+
+	changed = updateStatus(policy, allowedCSVCond(csv), existingCSVObj(csv)) || changed
+
+	return changed
+}
+
+// cleanupStaleInstallation removes a stale Subscription created by a previous enforce reconcile
+// before the existing AllNamespaces installation was detected.
+// This can happen when the controller reconciles in enforce mode before OLM copies the CSV,
+// or on upgrade from a version without the detection.
+// InstallPlans are garbage-collected via ownerReference.
+// OG cleanup is deferred until ownership tracking is available (#489).
+func (r *OperatorPolicyReconciler) cleanupStaleInstallation(
+	ctx context.Context,
+	policy *policyv1beta1.OperatorPolicy,
+	sub *operatorv1alpha1.Subscription,
+) error {
+	opLog := ctrl.LoggerFrom(ctx)
+
+	if policy.Spec.RemediationAction.IsInform() {
+		return nil
+	}
+
+	foundSub := &operatorv1alpha1.Subscription{}
+
+	if err := r.TargetClient.Get(ctx, client.ObjectKey{
+		Namespace: sub.Namespace, Name: sub.Name,
+	}, foundSub); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("error getting stale Subscription: %w", err)
+	}
+
+	expectedAnnotation := policy.Namespace + "." + policy.Name
+	if foundSub.GetAnnotations()[ManagedByAnnotation] == expectedAnnotation {
+		opLog.Info("Deleting stale Subscription from previous reconcile",
+			"subName", foundSub.GetName(), "subNamespace", foundSub.GetNamespace())
+
+		if err := r.TargetClient.Delete(ctx, foundSub); err != nil {
+			return fmt.Errorf("error deleting stale Subscription: %w", err)
+		}
+	}
+
+	// FUTURE: revisit OG cleanup when #489 (OG ownership tracking) is implemented.
+	// Until then, we can't distinguish stale OGs from pre-existing ones.
+
+	return nil
+}
+
 func (r *OperatorPolicyReconciler) handleCSV(
 	ctx context.Context,
 	policy *policyv1beta1.OperatorPolicy,
@@ -2498,33 +2623,8 @@ func (r *OperatorPolicyReconciler) handleCSV(
 		return foundCSV, nil, updateStatus(policy, missingWantedCond("ClusterServiceVersion"), relatedCSVs...), nil
 	}
 
-	// Check if the CSV is an approved version
-	if len(policy.Spec.Versions) != 0 {
-		allowedVersions := make([]policyv1.NonEmptyString, 0, len(policy.Spec.Versions)+1)
-
-		for _, version := range policy.Spec.Versions {
-			if version != "" {
-				allowedVersions = append(allowedVersions, policyv1.NonEmptyString(version))
-			}
-		}
-
-		if startingCSV := policyStartingCSV(policy); startingCSV != "" {
-			allowedVersions = append(allowedVersions, policyv1.NonEmptyString(startingCSV))
-		}
-
-		allowed := false
-
-		for _, allowedVersion := range allowedVersions {
-			if string(allowedVersion) == foundCSV.Name {
-				allowed = true
-
-				break
-			}
-		}
-
-		if !allowed {
-			return foundCSV, nil, updateStatus(policy, disallowedCSVCond(foundCSV), disallowedCSVObj(foundCSV)), nil
-		}
+	if !isCSVVersionAllowed(policy, foundCSV.Name) {
+		return foundCSV, nil, updateStatus(policy, disallowedCSVCond(foundCSV), disallowedCSVObj(foundCSV)), nil
 	}
 
 	return foundCSV, nil, updateStatus(policy, allowedCSVCond(foundCSV), relatedCSVs...), nil
@@ -3178,6 +3278,84 @@ func getNextMinorChannel(channels []interface{}, selectedChannelName string) ([]
 	slices.Sort(nextChannelNames)
 
 	return nextChannelNames, true
+}
+
+// findCopiedCSV looks for a CSV in the subscription's namespace that was copied there by OLM
+// from an AllNamespaces installation in a different namespace.
+// It returns the copied CSV if one matches the subscription's package name, or nil if none is found.
+// A name-specific watch is registered on the matched CSV to ensure deletion events are caught.
+func (r *OperatorPolicyReconciler) findCopiedCSV(
+	ctx context.Context,
+	policy *policyv1beta1.OperatorPolicy,
+	sub *operatorv1alpha1.Subscription,
+) (*operatorv1alpha1.ClusterServiceVersion, error) {
+	// Use TargetClient for the list to avoid registering a broad watch on all copied CSVs.
+	csvList := &operatorv1alpha1.ClusterServiceVersionList{}
+
+	if err := r.TargetClient.List(ctx, csvList,
+		client.InNamespace(sub.Namespace),
+		client.HasLabels{operatorv1alpha1.CopiedLabelKey},
+	); err != nil {
+		return nil, fmt.Errorf("error listing copied CSVs: %w", err)
+	}
+
+	watcher := opPolIdentifier(policy.Namespace, policy.Name)
+
+	opLog := ctrl.LoggerFrom(ctx)
+
+	for _, csv := range csvList.Items {
+		pkgName := csvPackageName(&csv)
+		if pkgName == "" {
+			opLog.V(2).Info("Copied CSV has no package name in properties annotation, skipping",
+				"csvName", csv.GetName(), "csvNamespace", csv.GetNamespace())
+
+			continue
+		}
+
+		if pkgName != sub.Spec.Package {
+			continue
+		}
+
+		// Register a name-specific watch to reliably catch deletion events.
+		if _, err := r.DynamicWatcher.Get(
+			watcher, clusterServiceVersionGVK, sub.Namespace, csv.GetName(),
+		); err != nil {
+			return nil, fmt.Errorf("error watching the copied CSV: %w", err)
+		}
+
+		return &csv, nil
+	}
+
+	return nil, nil
+}
+
+// csvPackageName extracts the package name from a CSV's properties annotation.
+func csvPackageName(csv *operatorv1alpha1.ClusterServiceVersion) string {
+	propsJSON := csv.GetAnnotations()["operatorframework.io/properties"]
+	if propsJSON == "" {
+		return ""
+	}
+
+	var wrapper struct {
+		Properties []struct {
+			Type  string                 `json:"type"`
+			Value map[string]interface{} `json:"value"`
+		} `json:"properties"`
+	}
+
+	if err := json.Unmarshal([]byte(propsJSON), &wrapper); err != nil {
+		return ""
+	}
+
+	for _, prop := range wrapper.Properties {
+		if prop.Type == "olm.package" {
+			if pkgName, ok := prop.Value["packageName"].(string); ok {
+				return pkgName
+			}
+		}
+	}
+
+	return ""
 }
 
 // subLabelSelector returns a selector that matches a label that OLM adds to resources

--- a/controllers/operatorpolicy_controller_test.go
+++ b/controllers/operatorpolicy_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
+	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policyv1beta1 "open-cluster-management.io/config-policy-controller/api/v1beta1"
 )
 
@@ -1124,5 +1125,183 @@ func TestGetSelectedChannelName(t *testing.T) {
 				assert.Equal(t, tc.expectedChannel, channelName)
 			}
 		})
+	}
+}
+
+func TestIsCSVVersionAllowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		versions []string
+		csvName  string
+		expected bool
+	}{
+		{
+			name:     "empty versions allows all",
+			csvName:  "my-operator.v0.0.1",
+			expected: true,
+		},
+		{
+			name:     "matching version",
+			versions: []string{"my-operator.v0.0.1"},
+			csvName:  "my-operator.v0.0.1",
+			expected: true,
+		},
+		{
+			name:     "non-matching version",
+			versions: []string{"my-operator.v0.0.2"},
+			csvName:  "my-operator.v0.0.1",
+			expected: false,
+		},
+		{
+			name:     "one of multiple versions matches",
+			versions: []string{"my-operator.v0.0.2", "my-operator.v0.0.1"},
+			csvName:  "my-operator.v0.0.1",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy := &policyv1beta1.OperatorPolicy{
+				Spec: policyv1beta1.OperatorPolicySpec{
+					Versions: tc.versions,
+				},
+			}
+
+			assert.Equal(t, tc.expected, isCSVVersionAllowed(policy, tc.csvName))
+		})
+	}
+}
+
+func copiedCSV(name, namespace, sourceNS string, phase operatorv1alpha1.ClusterServiceVersionPhase,
+) *operatorv1alpha1.ClusterServiceVersion {
+	return &operatorv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				operatorv1alpha1.CopiedLabelKey: sourceNS,
+			},
+		},
+		Status: operatorv1alpha1.ClusterServiceVersionStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func TestHandleExistingInstallation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		versions        []string
+		csvPhase        operatorv1alpha1.ClusterServiceVersionPhase
+		expectedCSVCond metav1.ConditionStatus
+	}{
+		{
+			name:            "compliant with no version restriction",
+			csvPhase:        operatorv1alpha1.CSVPhaseSucceeded,
+			expectedCSVCond: metav1.ConditionTrue,
+		},
+		{
+			name:            "version allowed",
+			versions:        []string{"my-operator.v0.0.1"},
+			csvPhase:        operatorv1alpha1.CSVPhaseSucceeded,
+			expectedCSVCond: metav1.ConditionTrue,
+		},
+		{
+			name:            "CSV not succeeded",
+			csvPhase:        operatorv1alpha1.CSVPhaseInstalling,
+			expectedCSVCond: metav1.ConditionFalse,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &OperatorPolicyReconciler{}
+			policy := &policyv1beta1.OperatorPolicy{
+				Spec: policyv1beta1.OperatorPolicySpec{
+					ComplianceType: "musthave",
+					Versions:       tc.versions,
+				},
+			}
+
+			csv := copiedCSV("my-operator.v0.0.1", "target-ns", "source-ns", tc.csvPhase)
+
+			changed := r.handleExistingInstallation(policy, csv)
+			assert.True(t, changed)
+
+			_, csvCond := policy.Status.GetCondition(csvConditionType)
+			assert.Equal(t, tc.expectedCSVCond, csvCond.Status)
+
+			for _, condType := range []string{
+				opGroupConditionType, subConditionType, installPlanConditionType,
+				crdConditionType, deploymentConditionType,
+			} {
+				_, cond := policy.Status.GetCondition(condType)
+				assert.Equal(t, metav1.ConditionTrue, cond.Status, "condition %s", condType)
+				assert.Equal(t, "ExistingInstallation", cond.Reason, "condition %s", condType)
+				assert.Contains(t, cond.Message, "source-ns", "condition %s", condType)
+			}
+
+			// CatalogSourcesUnhealthy has reversed polarity
+			_, catCond := policy.Status.GetCondition(catalogSrcConditionType)
+			assert.Equal(t, metav1.ConditionFalse, catCond.Status)
+			assert.Equal(t, "ExistingInstallation", catCond.Reason)
+			assert.Contains(t, catCond.Message, "source-ns")
+		})
+	}
+}
+
+func TestHandleExistingInstallation_VersionNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	r := &OperatorPolicyReconciler{}
+	policy := &policyv1beta1.OperatorPolicy{
+		Spec: policyv1beta1.OperatorPolicySpec{
+			ComplianceType: "musthave",
+			Versions:       []string{"my-operator.v0.0.2"},
+		},
+	}
+
+	csv := copiedCSV("my-operator.v0.0.1", "target-ns", "source-ns", operatorv1alpha1.CSVPhaseSucceeded)
+
+	changed := r.handleExistingInstallation(policy, csv)
+	assert.True(t, changed)
+
+	_, csvCond := policy.Status.GetCondition(csvConditionType)
+	assert.Equal(t, metav1.ConditionFalse, csvCond.Status)
+	assert.Equal(t, "UnapprovedVersion", csvCond.Reason)
+
+	idx, _ := policy.Status.GetCondition(opGroupConditionType)
+	assert.Equal(t, -1, idx, "OperatorGroup condition should not be set")
+}
+
+func TestHandleExistingInstallation_RelatedObjects(t *testing.T) {
+	t.Parallel()
+
+	r := &OperatorPolicyReconciler{}
+	policy := &policyv1beta1.OperatorPolicy{
+		Spec: policyv1beta1.OperatorPolicySpec{
+			ComplianceType: "musthave",
+		},
+	}
+
+	csv := copiedCSV("my-operator.v0.0.1", "target-ns", "source-ns", operatorv1alpha1.CSVPhaseSucceeded)
+
+	r.handleExistingInstallation(policy, csv)
+
+	csvObjs := policy.Status.RelatedObjsOfKind("ClusterServiceVersion")
+	assert.Len(t, csvObjs, 1)
+
+	for _, obj := range csvObjs {
+		assert.Equal(t, "my-operator.v0.0.1", obj.Object.Metadata.Name)
+		assert.Equal(t, string(policyv1.Compliant), obj.Compliant)
 	}
 }

--- a/controllers/operatorpolicy_status.go
+++ b/controllers/operatorpolicy_status.go
@@ -702,6 +702,25 @@ func subResFailedCond(subFailedCond operatorv1alpha1.SubscriptionCondition) meta
 	return cond
 }
 
+// existingInstallCond returns a Compliant condition indicating the operator is already
+// installed via AllNamespaces mode in a different namespace.
+func existingInstallCond(kind, sourceNamespace string) metav1.Condition {
+	status := metav1.ConditionTrue
+	// CatalogSourcesUnhealthy has reversed polarity: False means healthy
+	if condType(kind) == catalogSrcConditionType {
+		status = metav1.ConditionFalse
+	}
+
+	return metav1.Condition{
+		Type:   condType(kind),
+		Status: status,
+		Reason: "ExistingInstallation",
+		Message: fmt.Sprintf(
+			"the operator is installed in namespace %s and is available via AllNamespaces mode", sourceNamespace,
+		),
+	}
+}
+
 // notApplicableCond returns a Compliant condition, with a Reason like '____NotApplicable',
 // and a Message like 'MustNotHave policies ignore kind ____'
 func notApplicableCond(kind string) metav1.Condition {

--- a/test/e2e/case38_install_operator_test.go
+++ b/test/e2e/case38_install_operator_test.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	policyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policyv1beta1 "open-cluster-management.io/config-policy-controller/api/v1beta1"
@@ -362,10 +363,17 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 		return patchOwnerRefName
 	}
 
-	setupPolicy := func(ctx context.Context, opPolYAML, opPolName, parentPolicyName string) {
+	setupPolicy := func(ctx context.Context, opPolYAML, opPolName, parentPolicyName string, subNamespace ...string) {
 		GinkgoHelper()
 		patchedParentYAML := patchSingleField(ctx, parentPolicyYAML, testNamespace, "/metadata/name", parentPolicyName)
 		patchedOpPolYAML := parallelizeOpPol(ctx, opPolYAML, opPolName)
+
+		if len(subNamespace) > 0 {
+			patched := patchSingleField(
+				ctx, patchedOpPolYAML, testNamespace, "/spec/subscription/namespace", subNamespace[0])
+			os.Remove(patchedOpPolYAML)
+			patchedOpPolYAML = patched
+		}
 
 		createObjWithParent(patchedParentYAML, parentPolicyName,
 			patchedOpPolYAML, testNamespace, gvrPolicy, gvrOperatorPolicy)
@@ -377,6 +385,31 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 			os.Remove(patchedOpPolYAML)
 			os.Remove(patchedParentYAML)
 		})
+	}
+
+	waitForCSVField := func(ctx context.Context, csvName, namespace, expected string, fields ...string) {
+		GinkgoHelper()
+
+		Eventually(func(ctx context.Context) string {
+			csv, err := targetK8sDynamic.Resource(gvrClusterServiceVersion).Namespace(namespace).
+				Get(ctx, csvName, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+
+			val, _, _ := unstructured.NestedString(csv.Object, fields...)
+
+			return val
+		}, olmWaitTimeout, 5, ctx).Should(Equal(expected))
+	}
+
+	expectNoResources := func(g Gomega, ctx context.Context, namespace string, gvr schema.GroupVersionResource) {
+		GinkgoHelper()
+
+		list, err := targetK8sDynamic.Resource(gvr).Namespace(namespace).
+			List(ctx, metav1.ListOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(list.Items).To(BeEmpty(), "expected no %s in %s", gvr.Resource, namespace)
 	}
 
 	Describe("Testing an all default operator policy", Serial, Ordered, func() {
@@ -4546,6 +4579,213 @@ var _ = Describe("Testing OperatorPolicy", Label("supports-hosted"), func() {
 				},
 				"",
 			)
+		})
+	})
+
+	Describe("Testing OperatorPolicy with existing AllNamespaces installation", Serial, Ordered, func() {
+		const (
+			opPolYAML   = "../resources/case38_operator_install/operator-policy-no-group.yaml"
+			subYAML     = "../resources/case38_operator_install/subscription.yaml"
+			opGroupYAML = "../resources/case38_operator_install/extra-operator-group.yaml"
+			csvName     = "example-operator.v0.0.3"
+			preInstNS   = "existing-allns-install"
+		)
+		var (
+			opPolTestNS      string
+			opPolName        string
+			parentPolicyName string
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			opPolTestNS = getOpPolTestNS()
+			opPolName = "oppol-existing-allns" + getTestSuffix()
+			parentPolicyName = getParentPolicyName()
+
+			By("Creating the pre-existing AllNamespaces installation in " + preInstNS)
+			KubectlTarget("create", "ns", preInstNS)
+			DeferCleanup(func() {
+				KubectlTarget("delete", "ns", preInstNS, "--ignore-not-found", "--wait")
+			})
+
+			KubectlTarget("apply", "-f", opGroupYAML, "-n", preInstNS)
+			KubectlTarget("apply", "-f", subYAML, "-n", preInstNS)
+
+			By("Waiting for the CSV to be installed in " + preInstNS)
+			waitForCSVField(ctx, csvName, preInstNS, "Succeeded", "status", "phase")
+
+			By("Waiting for the copied CSV to appear in the target namespace")
+			preFunc()
+			waitForCSVField(ctx, csvName, opPolTestNS, preInstNS, "metadata", "labels", "olm.copiedFrom")
+
+			By("Creating the OperatorPolicy targeting " + opPolTestNS)
+			setupPolicy(ctx, opPolYAML, opPolName, parentPolicyName)
+		})
+
+		It("Should report Compliant when the operator is available via AllNamespaces", func(ctx SpecContext) {
+			utils.EnforceOperatorPolicy(opPolName, testNamespace)
+			checkCompliance(ctx, opPolName, testNamespace, eventuallyTimeout, policyv1.Compliant)
+		})
+
+		It("Should have the ExistingInstallation condition on Subscription", func() {
+			check(
+				opPolName,
+				false,
+				[]policyv1.RelatedObject{{
+					Object: policyv1.ObjectResource{
+						Kind:       "ClusterServiceVersion",
+						APIVersion: "operators.coreos.com/v1alpha1",
+						Metadata: policyv1.ObjectMetadata{
+							Name:      csvName,
+							Namespace: opPolTestNS,
+						},
+					},
+					Compliant: "Compliant",
+					Reason:    "Copied",
+				}},
+				metav1.Condition{
+					Type:    "SubscriptionCompliant",
+					Status:  metav1.ConditionTrue,
+					Reason:  "ExistingInstallation",
+					Message: "the operator is installed in namespace " + preInstNS,
+				},
+				"",
+			)
+		})
+
+		It("Should not create a Subscription or OperatorGroup in the target namespace", func(ctx context.Context) {
+			Consistently(func(g Gomega, ctx context.Context) {
+				expectNoResources(g, ctx, opPolTestNS, gvrSubscription)
+				expectNoResources(g, ctx, opPolTestNS, gvrOperatorGroup)
+			}, consistentlyDuration, 1).WithContext(ctx).Should(Succeed())
+		})
+
+		It("Should stay Compliant when deprecationsPresent is NonCompliant", func(ctx SpecContext) {
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p",
+				`[{"op": "replace", "path": "/spec/complianceConfig/deprecationsPresent", "value": "NonCompliant"}]`)
+			checkCompliance(ctx, opPolName, testNamespace, eventuallyTimeout, policyv1.Compliant)
+		})
+
+		It("Should stay Compliant when minorChannelUpgradeAvailable is NonCompliant", func(ctx SpecContext) {
+			patch := `[{"op": "replace", "path": "/spec/complianceConfig/minorChannelUpgradeAvailable",` +
+				` "value": "NonCompliant"}]`
+			utils.Kubectl("patch", "operatorpolicy", opPolName, "-n", testNamespace, "--type=json", "-p", patch)
+			checkCompliance(ctx, opPolName, testNamespace, eventuallyTimeout, policyv1.Compliant)
+		})
+	})
+
+	Describe("Testing two competing AllNamespaces OperatorPolicies", Serial, Ordered, func() {
+		const (
+			opPolYAML   = "../resources/case38_operator_install/operator-policy-no-group.yaml"
+			opGroupYAML = "../resources/case38_operator_install/extra-operator-group.yaml"
+			csvName     = "example-operator.v0.0.3"
+			primaryNS   = "competing-primary"
+			secondaryNS = "competing-secondary"
+			tertiaryNS  = "competing-preexisting-og"
+		)
+		var (
+			opPolName        string
+			secondaryPolName string
+			tertiaryPolName  string
+			parentPolicyName string
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			opPolName = "oppol-no-group" + getTestSuffix()
+			secondaryPolName = "oppol-secondary" + getTestSuffix()
+			tertiaryPolName = "oppol-tertiary" + getTestSuffix()
+			parentPolicyName = getParentPolicyName()
+
+			By("Creating namespaces for all installations")
+			KubectlTarget("create", "ns", primaryNS)
+			KubectlTarget("create", "ns", secondaryNS)
+			KubectlTarget("create", "ns", tertiaryNS)
+
+			DeferCleanup(func() {
+				KubectlTarget("delete", "ns", primaryNS, "--ignore-not-found", "--wait")
+				KubectlTarget("delete", "ns", secondaryNS, "--ignore-not-found", "--wait")
+				KubectlTarget("delete", "ns", tertiaryNS, "--ignore-not-found", "--wait")
+			})
+
+			By("Installing operator via OperatorPolicy in " + primaryNS)
+			setupPolicy(ctx, opPolYAML, opPolName, parentPolicyName, primaryNS)
+			utils.EnforceOperatorPolicy(opPolName, testNamespace)
+
+			By("Waiting for the operator to install in " + primaryNS)
+			waitForCSVField(ctx, csvName, primaryNS, "Succeeded", "status", "phase")
+
+			By("Waiting for copied CSV in " + secondaryNS)
+			waitForCSVField(ctx, csvName, secondaryNS, primaryNS, "metadata", "labels", "olm.copiedFrom")
+
+			By("Creating second OperatorPolicy targeting " + secondaryNS)
+			setupPolicy(ctx, opPolYAML, secondaryPolName, parentPolicyName, secondaryNS)
+			utils.EnforceOperatorPolicy(secondaryPolName, testNamespace)
+		})
+
+		It("Primary policy should be Compliant with a real installation", func(ctx SpecContext) {
+			checkCompliance(ctx, opPolName, testNamespace, eventuallyTimeout, policyv1.Compliant)
+		})
+
+		It("Secondary policy should be Compliant via ExistingInstallation", func(ctx SpecContext) {
+			checkCompliance(ctx, secondaryPolName, testNamespace, eventuallyTimeout, policyv1.Compliant)
+
+			check(
+				secondaryPolName,
+				false,
+				[]policyv1.RelatedObject{{
+					Object: policyv1.ObjectResource{
+						Kind:       "ClusterServiceVersion",
+						APIVersion: "operators.coreos.com/v1alpha1",
+						Metadata: policyv1.ObjectMetadata{
+							Name:      csvName,
+							Namespace: secondaryNS,
+						},
+					},
+					Compliant: "Compliant",
+					Reason:    "Copied",
+				}},
+				metav1.Condition{
+					Type:    "SubscriptionCompliant",
+					Status:  metav1.ConditionTrue,
+					Reason:  "ExistingInstallation",
+					Message: "the operator is installed in namespace " + primaryNS,
+				},
+				"",
+			)
+		})
+
+		It("Secondary namespace should have no stale OLM resources", func(ctx context.Context) {
+			Eventually(func(g Gomega, ctx context.Context) {
+				expectNoResources(g, ctx, secondaryNS, gvrSubscription)
+				expectNoResources(g, ctx, secondaryNS, gvrOperatorGroup)
+				expectNoResources(g, ctx, secondaryNS, gvrInstallPlan)
+			}, eventuallyTimeout, 5).WithContext(ctx).Should(Succeed())
+		})
+
+		It("Should preserve pre-existing OperatorGroup in tertiary namespace", func(ctx context.Context) {
+			By("Creating a pre-existing OperatorGroup in " + tertiaryNS)
+			KubectlTarget("apply", "-f", opGroupYAML, "-n", tertiaryNS)
+
+			By("Waiting for copied CSV in " + tertiaryNS)
+			waitForCSVField(ctx, csvName, tertiaryNS, primaryNS, "metadata", "labels", "olm.copiedFrom")
+
+			By("Creating third OperatorPolicy targeting " + tertiaryNS)
+			setupPolicy(ctx, opPolYAML, tertiaryPolName, parentPolicyName, tertiaryNS)
+			utils.EnforceOperatorPolicy(tertiaryPolName, testNamespace)
+
+			checkCompliance(ctx, tertiaryPolName, testNamespace, eventuallyTimeout, policyv1.Compliant)
+
+			// The stale Sub should be cleaned up.
+			Eventually(func(g Gomega, ctx context.Context) {
+				expectNoResources(g, ctx, tertiaryNS, gvrSubscription)
+			}, eventuallyTimeout, 5).WithContext(ctx).Should(Succeed())
+
+			// The pre-existing OG should survive.
+			Consistently(func(g Gomega, ctx context.Context) {
+				og, err := targetK8sDynamic.Resource(gvrOperatorGroup).Namespace(tertiaryNS).
+					Get(ctx, "extra-operator-group", metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(og).NotTo(BeNil())
+			}, consistentlyDuration, 1).WithContext(ctx).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
OperatorPolicy reported NonCompliant for operators already available in the target namespace via an AllNamespaces installation elsewhere. In enforce mode it created a duplicate Subscription that would never produce a real installation and become permanently orphaned if the original was removed (OLM bug operator-framework/operator-lifecycle-manager#3866).

Detect the existing installation via OLM's copied CSV in the target namespace and report Compliant without creating any resources. When the original is removed, OLM deletes the copied CSV, the detection stops, and normal flow takes over.

Clean up a stale Subscription if enforce mode created one before the detection could fire. OperatorGroup cleanup is deferred until ownership tracking is available (#489).

Closes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Operator policies now detect existing AllNamespaces installations created in other namespaces and treat them as compliant.
  - When an existing copied CSV is found, policies update conditions and avoid creating duplicate local Subscription/OperatorGroup/InstallPlan/CSV resources.

- **Bug Fixes**
  - Version-allowance behavior is consistent and properly marks unapproved versions as not allowed.
  - Catalog source unhealthy polarity is handled correctly in status conditions.
  - Stale subscriptions are cleaned up while preserving pre-existing operator resources.

- **Tests**
  - Added unit and end-to-end coverage for existing and competing AllNamespaces scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->