### PR TITLE
Add TLS Profile Compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ fmt:
 # test section
 ############################################################
 
-TEST_PKGS ?= ./api/v1 ./controllers ./pkg/common ./pkg/dryrun ./test/dryrun/...
+TEST_PKGS ?= . ./api/v1 ./controllers ./pkg/common ./pkg/dryrun ./test/dryrun/...
 
 .PHONY: test
 test: envtest kubebuilder gotestsum

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	open-cluster-management.io/addon-framework v1.3.0
 	open-cluster-management.io/governance-policy-propagator v0.19.0
+	open-cluster-management.io/sdk-go v1.3.0
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/klog/v2"
 	"open-cluster-management.io/addon-framework/pkg/lease"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,6 +100,8 @@ type ctrlOpts struct {
 	enableMetrics            bool
 	enableOperatorPolicy     bool
 	enableOcmPolicyNamespace bool
+	tlsMinVersion            string
+	tlsCipherSuites          string
 
 	standaloneHubTemplateKubeConfigPath string
 	defaultTerminatingNSInclusion       string
@@ -271,6 +275,10 @@ func main() {
 	// No need to resync every 10 hours.
 	disableResync := time.Duration(0)
 
+	terminatingCtx := ctrl.SetupSignalHandler()
+
+	tlsCfg := resolveEffectiveTLSConfig(terminatingCtx, cfg, opts)
+
 	metricsOptions := server.Options{
 		BindAddress: opts.metricsAddr,
 	}
@@ -280,6 +288,7 @@ func main() {
 		metricsOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 		metricsOptions.SecureServing = true
 		metricsOptions.CertDir = "/var/run/metrics-cert"
+		metricsOptions.TLSOpts = []func(*tls.Config){sdktls.ConfigToFunc(tlsCfg)}
 	}
 
 	// Set default manager options
@@ -288,7 +297,8 @@ func main() {
 		Scheme:  scheme,
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port: 9443,
+				Port:    9443,
+				TLSOpts: []func(*tls.Config){sdktls.ConfigToFunc(tlsCfg)},
 			},
 		),
 		HealthProbeBindAddress: opts.probeAddr,
@@ -332,8 +342,6 @@ func main() {
 		log.Error(err, "Unable to start manager")
 		os.Exit(1)
 	}
-
-	terminatingCtx := ctrl.SetupSignalHandler()
 
 	uninstallingCtx, uninstallingCtxCancel := context.WithCancel(terminatingCtx)
 
@@ -960,6 +968,22 @@ func parseOpts(flags *pflag.FlagSet, args []string) *ctrlOpts {
 		[]string{},
 		"A comma-separated list of additional template functions to deny. "+
 			"The default deny list will remain active regardless of this setting.",
+	)
+
+	flags.StringVar(
+		&opts.tlsMinVersion,
+		"tls-min-version",
+		"",
+		"The minimum TLS version to use on the metrics and webhook servers (e.g. VersionTLS12). "+
+			"Overrides the ocm-tls-profile ConfigMap when set.",
+	)
+
+	flags.StringVar(
+		&opts.tlsCipherSuites,
+		"tls-cipher-suites",
+		"",
+		"A comma-separated list of IANA cipher suite names to use on the metrics and webhook servers. "+
+			"Overrides the ocm-tls-profile ConfigMap when set.",
 	)
 
 	_ = flags.Parse(args)

--- a/test/e2e/case47_ratelimit_test.go
+++ b/test/e2e/case47_ratelimit_test.go
@@ -38,6 +38,25 @@ var _ = Describe("Test config policy ratelimiting", Ordered, func() {
 		return metricVal, nil
 	}
 
+	// evaluationsSince returns a poll function reporting how many evaluations have happened since
+	// the baseline was taken. This function always logs details, to help troubleshoot whether a
+	// failure was caused by failing to get the metric, or based on the value of the metric.
+	evaluationsSince := func(baseline float64) func() (float64, error) {
+		return func() (float64, error) {
+			total, err := metricCheck("config_policy_evaluation_total", "name", policyName)
+			if err != nil {
+				GinkgoWriter.Printf("evaluationsSince: failed to fetch config_policy_evaluation_total: %v\n", err)
+
+				return 0, err
+			}
+
+			delta := total - baseline
+			GinkgoWriter.Printf("evaluationsSince: total=%.0f baseline=%.0f delta=%.0f\n", total, baseline, delta)
+
+			return delta, nil
+		}
+	}
+
 	BeforeAll(func() {
 		By("Creating " + policyYaml)
 		utils.Kubectl("apply", "-f", policyYaml, "-n", testNamespace)
@@ -46,18 +65,30 @@ var _ = Describe("Test config policy ratelimiting", Ordered, func() {
 	})
 
 	It("should initially have a small number of evaluations", FlakeAttempts(3), func() {
-		Eventually(
-			metricCheck, 10, 2,
-		).WithArguments("config_policy_evaluation_total", "name", policyName).Should(BeNumerically("<=", 5))
+		// The metric may not have appeared yet immediately after BeforeAll creates the policy, so
+		// wait for it rather than requiring it on the first try.
+		var baseline float64
+		Eventually(func() error {
+			total, err := metricCheck("config_policy_evaluation_total", "name", policyName)
+			if err != nil {
+				return err
+			}
 
-		Consistently(
-			metricCheck, 10, 2,
-		).WithArguments("config_policy_evaluation_total", "name", policyName).Should(BeNumerically("<=", 5))
+			baseline = total
+
+			return nil
+		}, 10, 2).Should(Succeed())
+
+		Eventually(evaluationsSince(baseline), 10, 2).Should(BeNumerically("<=", 5))
+		Consistently(evaluationsSince(baseline), 10, 2).Should(BeNumerically("<=", 5))
 	})
 
 	value := 0
 
 	It("should limit the number of evaluations when a watched object changes frequently", FlakeAttempts(3), func() {
+		baseline, err := metricCheck("config_policy_evaluation_total", "name", policyName)
+		Expect(err).ToNot(HaveOccurred())
+
 		start := time.Now()
 
 		By("Updating the watched configmap frequently for 10 seconds")
@@ -68,9 +99,7 @@ var _ = Describe("Test config policy ratelimiting", Ordered, func() {
 			time.Sleep(150 * time.Millisecond)
 		}
 
-		Consistently(
-			metricCheck, 10, 2,
-		).WithArguments("config_policy_evaluation_total", "name", policyName).Should(BeNumerically("<", 12))
+		Consistently(evaluationsSince(baseline), 10, 2).Should(BeNumerically("<", 12))
 	})
 
 	It("should have updated the object to the final value", FlakeAttempts(3), func() {

--- a/test/e2e/case48_tls_profile_test.go
+++ b/test/e2e/case48_tls_profile_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
+)
+
+const (
+	controllerNamespace = "open-cluster-management-agent-addon"
+	containerName       = "config-policy-controller"
+	podLabelSelector    = "name=config-policy-controller"
+)
+
+// This test only works when the controller is running as a real Deployment-managed pod in the
+// cluster: it verifies that the ocm-tls-profile ConfigMap watcher exits the process on change,
+// which relies on the kubelet restarting the container. Running it against the locally-run
+// instrumented binary used by `make e2e-test-coverage` would just kill that process and take
+// down the rest of the suite, so it is excluded from that target via the "running-in-cluster"
+// label (see e2e-test-running-in-cluster in the Makefile).
+var _ = Describe("TLS profile ConfigMap", Label("running-in-cluster"), Serial, func() {
+	var podName string
+
+	BeforeEach(func(ctx context.Context) {
+		pods, err := clientManaged.CoreV1().Pods(controllerNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: podLabelSelector,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		if len(pods.Items) == 0 {
+			Skip("config-policy-controller is not running as a pod in the cluster")
+		}
+
+		podName = pods.Items[0].Name
+	})
+
+	AfterEach(func(ctx context.Context) {
+		if podName == "" {
+			return
+		}
+
+		initialRestarts := getContainerRestartCount(ctx, podName)
+
+		err := clientManaged.CoreV1().ConfigMaps(controllerNamespace).Delete(
+			ctx, sdktls.ConfigMapName, metav1.DeleteOptions{},
+		)
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+
+		Expect(err).ToNot(HaveOccurred())
+
+		// Deleting the ConfigMap is itself a change the watcher reacts to (the effective TLS
+		// config falls back to a TLS 1.2 floor with Go's default cipher suites), so it also
+		// restarts the container. Wait for that to settle here, otherwise a subsequent
+		// "running-in-cluster" spec could start against a pod that's still restarting from this
+		// cleanup.
+		By("Waiting for the controller container to restart again after removing the ocm-tls-profile ConfigMap")
+		Eventually(func() int {
+			return getContainerRestartCount(ctx, podName)
+		}, defaultTimeoutSeconds, 1).Should(BeNumerically(">", initialRestarts))
+
+		By("Waiting for the pod to become ready again")
+		waitForPodReady(ctx, podName)
+	})
+
+	It("restarts the controller container when the ocm-tls-profile ConfigMap changes", func(ctx context.Context) {
+		initialRestarts := getContainerRestartCount(ctx, podName)
+
+		By("Creating the ocm-tls-profile ConfigMap")
+		_, err := clientManaged.CoreV1().ConfigMaps(controllerNamespace).Create(
+			ctx, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sdktls.ConfigMapName,
+					Namespace: controllerNamespace,
+				},
+				Data: map[string]string{
+					sdktls.ConfigMapKeyMinVersion: "VersionTLS13",
+				},
+			}, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Verifying the controller container restarts to pick up the new TLS settings")
+		Eventually(func() int {
+			return getContainerRestartCount(ctx, podName)
+		}, defaultTimeoutSeconds, 1).Should(BeNumerically(">", initialRestarts))
+
+		By("Waiting for the pod to become ready again")
+		waitForPodReady(ctx, podName)
+	})
+})
+
+func getContainerRestartCount(ctx context.Context, podName string) int {
+	pod, err := clientManaged.CoreV1().Pods(controllerNamespace).Get(
+		ctx, podName, metav1.GetOptions{},
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName {
+			return int(cs.RestartCount)
+		}
+	}
+
+	return -1
+}
+
+func waitForPodReady(ctx context.Context, podName string) {
+	Eventually(func() (bool, error) {
+		pod, err := clientManaged.CoreV1().Pods(controllerNamespace).Get(
+			ctx, podName, metav1.GetOptions{},
+		)
+		if err != nil {
+			return false, err
+		}
+
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady {
+				return cond.Status == corev1.ConditionTrue, nil
+			}
+		}
+
+		return false, nil
+	}, defaultTimeoutSeconds, 1).Should(BeTrue())
+}

--- a/tlsconfig.go
+++ b/tlsconfig.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
+
+	"open-cluster-management.io/config-policy-controller/pkg/common"
+)
+
+// resolveEffectiveTLSConfig wires resolveTLSConfig into the running process: it discovers the
+// controller's own namespace (to watch the ocm-tls-profile ConfigMap), restarts the process on
+// ConfigMap changes, and logs the config that will be applied. If no flags or ConfigMap settings
+// apply, it falls back to Go's default cipher suites with an explicit TLS 1.2 floor.
+func resolveEffectiveTLSConfig(ctx context.Context, restCfg *rest.Config, opts *ctrlOpts) *sdktls.TLSConfig {
+	operatorNamespace, err := common.GetOperatorNamespace()
+	if err != nil {
+		if errors.Is(err, common.ErrNoNamespace) || errors.Is(err, common.ErrRunLocal) {
+			log.Info("Not running in a cluster; skipping the ocm-tls-profile ConfigMap watch")
+		} else {
+			log.Error(err, "Failed to get operator namespace; skipping the ocm-tls-profile ConfigMap watch")
+		}
+
+		operatorNamespace = ""
+	}
+
+	var kubeClient kubernetes.Interface
+	if operatorNamespace != "" {
+		kubeClient = kubernetes.NewForConfigOrDie(restCfg)
+	}
+
+	tlsCfg, err := resolveTLSConfig(ctx, opts.tlsMinVersion, opts.tlsCipherSuites, kubeClient, operatorNamespace,
+		func() {
+			log.Info("TLS configuration changed; exiting so the pod restarts with the new settings")
+			os.Exit(0)
+		},
+	)
+	if err != nil {
+		log.Error(err, "Failed to resolve TLS configuration; falling back to defaults")
+
+		tlsCfg = nil
+	}
+
+	effective := tlsCfg
+	if effective == nil {
+		effective = sdktls.GetDefaultTLSConfig()
+	}
+
+	log.Info("Effective TLS configuration",
+		"minVersion", sdktls.VersionToString(effective.MinVersion),
+		"cipherSuites", sdktls.CipherSuitesToString(effective.CipherSuites),
+	)
+
+	return effective
+}
+
+// resolveTLSConfig determines the TLS configuration to apply to the metrics and webhook servers,
+// in order of precedence:
+//  1. Explicit --tls-min-version/--tls-cipher-suites flags.
+//  2. The ocm-tls-profile ConfigMap in the controller's own namespace, if kubeClient and
+//     namespace are available and RBAC permits list/watch on it. This also starts a background
+//     watcher that invokes onConfigMapChange when the ConfigMap's data changes. If the ConfigMap
+//     doesn't exist yet, sdktls.StartTLSConfigMapWatcher still returns a non-nil TLSConfig (Go's
+//     TLS 1.2 defaults) rather than nil, since it needs something concrete to seed the watcher's
+//     change detection. If RBAC denies list/watch, returns an error instead of starting the
+//     watcher so the caller falls back to defaults - see canWatchTLSProfileConfigMap.
+//  3. If kubeClient or namespace is unavailable (e.g. not running in a cluster), returns
+//     (nil, nil) so the caller falls back to a TLS 1.2 floor with Go's default cipher suites.
+func resolveTLSConfig(
+	ctx context.Context, minVersion, cipherSuites string, kubeClient kubernetes.Interface, namespace string,
+	onConfigMapChange func(),
+) (*sdktls.TLSConfig, error) {
+	flagCfg, err := sdktls.ConfigFromFlags(minVersion, cipherSuites)
+	if err != nil {
+		return nil, err
+	}
+
+	if flagCfg != nil {
+		return flagCfg, nil
+	}
+
+	if kubeClient == nil || namespace == "" {
+		return nil, nil
+	}
+
+	allowed, err := canWatchTLSProfileConfigMap(ctx, kubeClient, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if !allowed {
+		return nil, fmt.Errorf(
+			"missing permission to list/watch the %s ConfigMap in namespace %s", sdktls.ConfigMapName, namespace,
+		)
+	}
+
+	return sdktls.StartTLSConfigMapWatcher(ctx, kubeClient, namespace, onConfigMapChange)
+}
+
+// canWatchTLSProfileConfigMap checks list/watch access to the ocm-tls-profile ConfigMap via
+// SelfSubjectAccessReview, which needs no RBAC of its own, instead of finding out the hard way
+// from sdktls.StartTLSConfigMapWatcher (which hangs rather than erroring on missing RBAC).
+func canWatchTLSProfileConfigMap(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (bool, error) {
+	for _, verb := range []string{"list", "watch"} {
+		review := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace: namespace,
+					Verb:      verb,
+					Resource:  "configmaps",
+					Name:      sdktls.ConfigMapName,
+				},
+			},
+		}
+
+		reviewCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		result, err := kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(
+			reviewCtx, review, metav1.CreateOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to check %s permission on the %s ConfigMap: %w",
+				verb, sdktls.ConfigMapName, err)
+		}
+
+		if !result.Status.Allowed {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/tlsconfig_test.go
+++ b/tlsconfig_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	sdktls "open-cluster-management.io/sdk-go/pkg/tls"
+)
+
+// allowSelfSubjectAccessReviews makes a fake clientset report every SelfSubjectAccessReview as
+// allowed. Without this, the fake client's default "create" reaction just stores and echoes back
+// the submitted object, leaving Status.Allowed at its false zero value - indistinguishable from a
+// real permission denial.
+func allowSelfSubjectAccessReviews(client *testclient.Clientset) {
+	client.PrependReactor("create", "selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			//nolint:forcetypeassert
+			review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			review.Status.Allowed = true
+
+			return true, review, nil
+		},
+	)
+}
+
+func TestResolveTLSConfigFlagsTakePrecedence(t *testing.T) {
+	wantVersion, err := sdktls.ParseTLSVersion("VersionTLS13")
+	require.NoError(t, err)
+
+	// A nil kubeClient would panic if resolveTLSConfig tried to use it, proving the
+	// ConfigMap path is skipped when the flags are set.
+	cfg, err := resolveTLSConfig(t.Context(), "VersionTLS13", "", nil, "", func() {})
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, wantVersion, cfg.MinVersion)
+}
+
+func TestResolveTLSConfigInvalidFlagsReturnsError(t *testing.T) {
+	_, err := resolveTLSConfig(t.Context(), "not-a-version", "", nil, "", func() {})
+
+	assert.Error(t, err)
+}
+
+func TestResolveTLSConfigNoFlagsNoClusterFallsBackToNil(t *testing.T) {
+	cfg, err := resolveTLSConfig(t.Context(), "", "", nil, "", func() {})
+
+	require.NoError(t, err)
+	assert.Nil(t, cfg, "expected nil config so caller falls back to a TLS 1.2 floor with Go's default cipher suites")
+}
+
+func TestResolveTLSConfigReadsConfigMapWhenNoFlags(t *testing.T) {
+	client := testclient.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sdktls.ConfigMapName,
+			Namespace: "addon-ns",
+		},
+		Data: map[string]string{
+			sdktls.ConfigMapKeyMinVersion: "VersionTLS13",
+		},
+	})
+	allowSelfSubjectAccessReviews(client)
+
+	cfg, err := resolveTLSConfig(t.Context(), "", "", client, "addon-ns", func() {})
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	wantVersion, err := sdktls.ParseTLSVersion("VersionTLS13")
+	require.NoError(t, err)
+	assert.Equal(t, wantVersion, cfg.MinVersion)
+}
+
+func TestResolveTLSConfigDefaultsWhenConfigMapAbsent(t *testing.T) {
+	client := testclient.NewSimpleClientset()
+	allowSelfSubjectAccessReviews(client)
+
+	cfg, err := resolveTLSConfig(t.Context(), "", "", client, "addon-ns", func() {})
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.EqualValues(t, sdktls.GetDefaultTLSConfig().MinVersion, cfg.MinVersion)
+}
+
+func TestResolveTLSConfigMissingConfigMapPermissionReturnsError(t *testing.T) {
+	// No allowSelfSubjectAccessReviews call: the fake client's default reaction leaves
+	// Status.Allowed at its false zero value, simulating denied RBAC.
+	client := testclient.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sdktls.ConfigMapName,
+			Namespace: "addon-ns",
+		},
+	})
+
+	_, err := resolveTLSConfig(t.Context(), "", "", client, "addon-ns", func() {})
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
The addon-framework will deploy an ocm-tls-profile ConfigMap to the namespace, providing guidance on what settings to use. New `--tls-*` flags can be used to override that behavior. When neither are present, Go's default cipher suites will be used, with a minimum of TLS 1.2.

A new background watcher restarts the container when the new ConfigMap changes, to ensure the new settings take effect.

Refs:
 - https://issues.redhat.com/browse/ACM-30176

This PR also improves the ratelimit test, to try and resolve its flakiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS settings for metrics and webhook servers.
  * Supports TLS profiles through the `ocm-tls-profile` ConfigMap, with explicit settings taking precedence.
  * Applies secure defaults when TLS configuration is unavailable.

* **Tests**
  * Added coverage for TLS configuration, fallback behavior, and in-cluster profile updates.
  * Improved rate-limit test validation by checking changes from an initial baseline.
  * Expanded the default test scope to include the repository root package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->